### PR TITLE
docs: handover spec + 11-phase build plan for irc-lens

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -50,18 +50,22 @@ These are checked by `afi cli verify` and must not be weakened when shape-adapti
 2. **stdout/stderr split** — results to stdout, errors and diagnostics to stderr, even in `--json` mode. The streams are never mixed.
 3. **Errors have shape `{code, message, remediation}`** — text-mode errors render as `error: <msg>\nhint: <remediation>`. The `hint:` prefix is required by the rubric.
 4. **`_ArgumentParser` override** — argparse errors must route through `emit_error` so unknown verbs/flags exit with `error:` + `hint:` and no traceback.
-5. **Globals `learn` and `explain` exist at the top level** — not nested under a noun. New command groups are registered as siblings via `register(sub)` in `cli/__init__.py` at the marked location.
+5. **Globals `learn`, `explain`, `overview` exist at the top level** — not nested under a noun. New command groups are registered as siblings via `register(sub)` in `cli/__init__.py` at the marked location. Every noun group with action-verbs must also expose its own `overview` verb.
 6. **`learn` output rubric** — stdout ≥ 200 chars, mentions purpose, commands, exit codes, `--json`, and `explain`. `learn --json` is parseable with stderr clean.
+7. **`overview` is descriptive, not verifying** — `overview <bogus-path>` exits **0** with a warning section. Hard-failing on a missing target is `afi cli verify`'s job, not `overview`'s.
 
 ### `afi cli verify` rubric bundles
 
-The five bundles checked by the verifier (run from the host project root once code exists):
+The six bundles checked by the verifier (run from the host project root once code exists):
 
 1. **Structure** — `pyproject.toml` with `[project.scripts]`, `tests/` dir, `<tool> --help` exits 0.
 2. **Learnability** — `<tool> learn` exits 0, stdout ≥ 200 chars, mentions purpose / commands / exit codes / `--json` / `explain`.
 3. **JSON** — `<tool> learn --json` parseable; stderr clean on success; `<tool> explain --json` works.
 4. **Errors** — bogus verb exits non-zero with a `hint:` line and no Python traceback.
 5. **Explain** — `explain`, `explain <tool>`, and bogus-path-failure with hint all work.
+6. **Overview** — global `<tool> overview` exits 0; `<tool> overview --json` returns `{subject, path, sections}`; every noun group with action-verbs also exposes an `overview` verb (e.g. `<tool> cli overview`); `<tool> overview <bogus-path>` exits **0** with a warning section (overview is descriptive, not verifying).
+
+The `python-cli` reference template predates the `overview` bundle. The bootstrap phase explicitly adds an `overview` global + a minimal `cli` noun with `cli overview`. New noun groups added later must follow the same rule.
 
 After integration completes and the rubric passes, the reference can be removed (`rm -rf .afi/reference/`) or refreshed with `afi cli cite`.
 

--- a/docs/superpowers/plans/2026-04-27-irc-lens-build-plan.md
+++ b/docs/superpowers/plans/2026-04-27-irc-lens-build-plan.md
@@ -1,9 +1,22 @@
 # `irc-lens` Build Plan
 
-**Status:** Ready to execute
+**Status:** Ready to execute (Phase 1 landed in PR #3)
 **Date:** 2026-04-27
 **Spec:** [`docs/superpowers/specs/2026-04-27-irc-lens-handover-design.md`](../specs/2026-04-27-irc-lens-handover-design.md)
-**Audience:** The agent building this repo. Read the spec first, then this plan, then start at Phase 1.
+**Audience:** The agent building this repo. Read the spec first, then this plan, then start at the first not-yet-landed phase.
+
+## Resolved decisions
+
+These were "agent's call" or "two options" in the original draft; they
+have since been decided. The relevant phases below have been updated.
+
+| Decision | Choice | Rationale |
+| --- | --- | --- |
+| HTMX delivery | **Vendored** under `src/irc_lens/static/vendor/` | Localhost + Playwright + offline-friendly agent loops; no outbound network at boot. |
+| AgentIRC test fixture | **Option (a)** — culture pinned as a dev dep, import its `tests/conftest.py` server fixture | Zero IRC-server code in this repo; SHA-pinned for reproducibility. Fall back to (b) only if upstream's fixture surface stops fitting. |
+| PyPI release model | **PR → TestPyPI / push-to-main → PyPI** via PyPI Trusted Publishers, mirroring `../culture/.github/workflows/publish.yml` | The `pypi` and `testpypi` GitHub environments are already provisioned with Trusted Publishers; tag-based releases are not needed for v0.1.0. |
+| `afi cli verify` rubric | **Six bundles** (added `overview` after the original draft) — Phase 1 ships an `overview` global + `cli overview` noun-verb so the verifier passes 22/22 from day one | The reference template (`python-cli`) predates the `overview` bundle. |
+| PR cadence | **One PR per phase** | Per-phase verification gates were designed for this. |
 
 ---
 
@@ -32,7 +45,7 @@ Before Phase 1:
 
 ## Phase 1 — Repo bootstrap
 
-**Goal:** A working `pip install -e .` and `irc-lens learn` that exits 0 with rubric-passing output.
+**Goal:** A working `pip install -e .` and `irc-lens learn` that exits 0 with rubric-passing output (22/22 across all six `afi cli verify` bundles).
 
 1. Run `afi cli cite python-cli` from the repo root. This populates `.afi/reference/python-cli/`. **Read `MANIFEST.json` and `AGENT.md` before writing any CLI code.**
 2. Substitute tokens (`{{project_name}}` → `irc-lens`, `{{slug}}`/`{{module}}` → `irc_lens`) and copy `stable-contract` files verbatim into `src/irc_lens/`:
@@ -41,23 +54,35 @@ Before Phase 1:
    - `cli/_commands/explain.py`
    - `explain/` (catalog resolver)
 3. Shape-adapt `cli/__init__.py` (parser + `_dispatch`, including `_ArgumentParser` override and try/except wrapping `AfiError`), `cli/_commands/learn.py` (TEXT body + JSON payload mentioning purpose, commands, exit codes, `--json`, `explain`), `explain/catalog.py`, package `__init__.py` / `__main__.py`, and `tests/test_cli.py` per `MANIFEST.json`.
-4. Write `pyproject.toml`:
+4. Add the new `overview` bundle (the `python-cli` reference predates it):
+   - `cli/_commands/overview.py` — global `overview` verb. Subject defaults to `"all"`. JSON shape `{subject, path, sections: [{heading, body_md, findings}]}`. Unknown `<path>` arg exits **0** with a warning section, not non-zero — overview is descriptive, not a verifier.
+   - Register a minimal `cli` noun in `cli/__init__.py` with at least an `overview` verb (`cli overview`), to satisfy "every noun with action-verbs exposes `overview`."
+   - Add `("overview",)` and `("cli",)` entries to `explain/catalog.py`.
+5. Write `pyproject.toml`:
    - `[project]` with name `irc-lens`, version `0.1.0`, Python 3.11+
    - `[project.scripts]` registers `irc-lens = "irc_lens.cli:main"`
+   - Build backend: `hatchling` (`[tool.hatch.build.targets.wheel] packages = ["src/irc_lens"]`)
    - Runtime deps: `aiohttp`, `jinja2`, `pyyaml`
    - Dev deps: `pytest`, `pytest-asyncio`, `pytest-aiohttp`, `playwright`, `pytest-playwright`
-5. Write a minimal CI skeleton at `.github/workflows/ci.yml`: `uv sync`, `pytest`, `afi cli verify`. Skip the Playwright job for now (added in Phase 9).
-6. Write `CITATION.md` with a placeholder block for culture's source SHA (filled in Phase 2).
+   - `[tool.pytest.ini_options]` with `asyncio_mode = "auto"` and a `playwright` marker for the opt-in browser job (used in Phase 9c).
+6. Write a minimal CI skeleton at `.github/workflows/ci.yml`: `uv venv`, `uv pip install -e ".[dev]"`, `uv run pytest`. Skip `afi cli verify` in CI for now (afi is not on PyPI; the verifier runs locally before each commit). Skip the Playwright job (added in Phase 9c). The PyPI publish workflow is a separate file added in Phase 11.
+7. Write `CITATION.md` with a placeholder Sources table (filled in Phase 2).
+8. Track `uv.lock` (matches culture's convention).
 
 **Verification:**
 
 ```bash
 uv venv && uv pip install -e ".[dev]"
-irc-lens --help                # exits 0, lists global verbs (learn, explain)
+irc-lens --help                # exits 0, lists globals (learn, explain, overview) + `cli` noun
 irc-lens learn                  # exits 0, stdout ≥ 200 chars, mentions all 5 rubric items
 irc-lens learn --json | jq .    # parseable JSON, stderr clean
+irc-lens overview               # exits 0, prints rollup
+irc-lens overview --json | jq . # {subject, path, sections} shape
+irc-lens overview bogus-path    # exits 0 with a warning section (NOT non-zero)
+irc-lens cli overview           # exits 0
 irc-lens nope                   # exits non-zero, stderr has 'error:' and 'hint:', no Python traceback
-afi cli verify                  # all five rubric bundles pass
+uv run pytest                   # all green
+afi cli verify                  # 22/22 passed across six bundles
 ```
 
 **Commit:** "phase 1: bootstrap repo with afi cli cite python-cli pattern"
@@ -123,7 +148,7 @@ uv run pytest tests/test_session_unit.py -v
    - `GET /events` → SSE stub that emits one `chat` event saying "irc-lens online" then closes. Wired properly in Phase 5.
    - `GET /static/{path}` → static file handler for `lens.css`, `lens.js`.
 3. Create `src/irc_lens/web/render.py` with the Jinja2 environment and a `render_fragment(template, **ctx)` helper.
-4. Create `templates/index.html.j2` with the three-pane layout (sidebar, chat, info) and the SSE listener `<script>` tag (HTMX vendored or CDN — document the choice in `docs/architecture.md`).
+4. Create `templates/index.html.j2` with the three-pane layout (sidebar, chat, info) and the SSE listener `<script>` tag. HTMX is vendored (per Resolved decisions): drop a pinned `htmx.min.js` + `sse.js` extension under `src/irc_lens/static/vendor/` and reference them by relative path from the template. Document the pinned version in `docs/architecture.md`.
 5. Add `_chat_line.j2`, `_sidebar.j2`, `_info.j2` as empty placeholders rendered with current state.
 
 **Verification:**
@@ -287,13 +312,22 @@ The new repo's `docs/` must contain at least:
 
 ## Phase 11 — Release workflow
 
-**Goal:** Tagging `v0.1.0` produces a wheel on PyPI.
+**Goal:** Every PR pushes a `.devN` build to TestPyPI; merging to `main` publishes a real version to PyPI. No long-lived tokens.
 
-1. Add `.github/workflows/release.yml`: triggers on `tags: v*`. Builds with `uv build`, publishes with `pypa/gh-action-pypi-publish` using a PyPI Trusted Publisher (no long-lived token in the repo).
-2. Tag `v0.1.0` and push. Confirm the release lands on PyPI.
-3. Update `README.md` install line to `pip install irc-lens`.
+The `pypi` and `testpypi` GitHub environments are already provisioned with PyPI Trusted Publishers pointing at this repo. Mirror `../culture/.github/workflows/publish.yml`:
 
-**Commit:** "phase 11: release workflow + first release"
+1. Add `.github/workflows/publish.yml` with three jobs:
+   - **`test`** — runs on every `push` and `pull_request` to `main`. `uv sync && uv run pytest -n auto -v`.
+   - **`test-publish`** — `if: github.event_name == 'pull_request'`. `needs: test`. `environment: testpypi`. `permissions: contents: read, id-token: write`. Mints a `${BASE_VERSION}.dev${{ github.run_number }}` version (sed into `pyproject.toml`), then `uv build && uv publish --publish-url https://test.pypi.org/legacy/ --trusted-publishing always --check-url https://test.pypi.org/simple/`. Prints the install command via `::notice::`.
+   - **`publish`** — `if: github.event_name == 'push'`. `needs: test`. `environment: pypi`. `permissions: contents: read, id-token: write`. `uv build && uv publish --trusted-publishing always --check-url https://pypi.org/simple/`.
+2. Pin all action SHAs (mirror culture: `actions/checkout@34e114876b…` v4 and `astral-sh/setup-uv@38f3f10…` v4).
+3. Open a small PR; confirm `test-publish` puts `0.1.0.devN` on TestPyPI in the `testpypi` environment.
+4. Merge to `main`; confirm `publish` puts `0.1.0` on PyPI in the `pypi` environment.
+5. Update `README.md` install line to `pip install irc-lens`.
+
+Tag-based releases are intentionally not used for v0.1.0 — the GitHub environments + Trusted Publishers already give us safe, gated publishing without manual tagging.
+
+**Commit:** "phase 11: trusted-publisher PyPI workflow + first release"
 
 ---
 

--- a/docs/superpowers/plans/2026-04-27-irc-lens-build-plan.md
+++ b/docs/superpowers/plans/2026-04-27-irc-lens-build-plan.md
@@ -1,0 +1,314 @@
+# `irc-lens` Build Plan
+
+**Status:** Ready to execute
+**Date:** 2026-04-27
+**Spec:** [`docs/superpowers/specs/2026-04-27-irc-lens-handover-design.md`](../specs/2026-04-27-irc-lens-handover-design.md)
+**Audience:** The agent building this repo. Read the spec first, then this plan, then start at Phase 1.
+
+---
+
+## How to use this plan
+
+The spec defines **WHAT** to build and **WHY**. This plan defines **HOW** and **ORDER**. Each phase is small, independently committable, and ends with a verification block. Do not skip phases or merge them — the verification gates exist so a regression is caught one phase later, not eleven.
+
+If something in this plan disagrees with the spec, the spec wins; flag the discrepancy in your commit message.
+
+If something in this plan disagrees with `CLAUDE.md` or with the AFI rubric (`afi cli verify`), `CLAUDE.md` and the rubric win — they encode contracts the spec was written against, not optional advice.
+
+---
+
+## Prerequisites
+
+Before Phase 1:
+
+- `culture` is checked out at `../culture/` relative to this repo. The citation-source files live there. Pin to the commit SHA you cite from; record it in `CITATION.md` (Phase 2).
+- `citation-cli` (`afi`) is on `PATH`. Verify with `afi --help`. If missing, install per `../citation-cli/README.md` before continuing — Phase 1 depends on it.
+- `uv` ≥ 0.5 installed.
+- Python 3.11+.
+- A reachable AgentIRC server for end-to-end testing in Phase 9. The simplest option: `cd ../culture && culture server start --name local && culture server status local` to get a host/port. Tear it down at the end with `culture server stop local`.
+- `chromium` installed for Playwright (`uv run playwright install chromium` after deps land in Phase 1).
+
+---
+
+## Phase 1 — Repo bootstrap
+
+**Goal:** A working `pip install -e .` and `irc-lens learn` that exits 0 with rubric-passing output.
+
+1. Run `afi cli cite python-cli` from the repo root. This populates `.afi/reference/python-cli/`. **Read `MANIFEST.json` and `AGENT.md` before writing any CLI code.**
+2. Substitute tokens (`{{project_name}}` → `irc-lens`, `{{slug}}`/`{{module}}` → `irc_lens`) and copy `stable-contract` files verbatim into `src/irc_lens/`:
+   - `cli/_errors.py` (`AfiError`, exit codes)
+   - `cli/_output.py` (stdout/stderr split, `--json` helpers)
+   - `cli/_commands/explain.py`
+   - `explain/` (catalog resolver)
+3. Shape-adapt `cli/__init__.py` (parser + `_dispatch`, including `_ArgumentParser` override and try/except wrapping `AfiError`), `cli/_commands/learn.py` (TEXT body + JSON payload mentioning purpose, commands, exit codes, `--json`, `explain`), `explain/catalog.py`, package `__init__.py` / `__main__.py`, and `tests/test_cli.py` per `MANIFEST.json`.
+4. Write `pyproject.toml`:
+   - `[project]` with name `irc-lens`, version `0.1.0`, Python 3.11+
+   - `[project.scripts]` registers `irc-lens = "irc_lens.cli:main"`
+   - Runtime deps: `aiohttp`, `jinja2`, `pyyaml`
+   - Dev deps: `pytest`, `pytest-asyncio`, `pytest-aiohttp`, `playwright`, `pytest-playwright`
+5. Write a minimal CI skeleton at `.github/workflows/ci.yml`: `uv sync`, `pytest`, `afi cli verify`. Skip the Playwright job for now (added in Phase 9).
+6. Write `CITATION.md` with a placeholder block for culture's source SHA (filled in Phase 2).
+
+**Verification:**
+
+```bash
+uv venv && uv pip install -e ".[dev]"
+irc-lens --help                # exits 0, lists global verbs (learn, explain)
+irc-lens learn                  # exits 0, stdout ≥ 200 chars, mentions all 5 rubric items
+irc-lens learn --json | jq .    # parseable JSON, stderr clean
+irc-lens nope                   # exits non-zero, stderr has 'error:' and 'hint:', no Python traceback
+afi cli verify                  # all five rubric bundles pass
+```
+
+**Commit:** "phase 1: bootstrap repo with afi cli cite python-cli pattern"
+
+---
+
+## Phase 2 — Citation lift from culture
+
+**Goal:** The IRC transport, message buffer, and command parser from culture are present, tagged with their source SHA, and importable in `irc-lens`.
+
+1. Capture the source SHA: `git -C ../culture rev-parse HEAD`. Record it in `CITATION.md` under a "Sources" section.
+2. Copy and adapt per the spec's citation table:
+   - `../culture/packages/agent-harness/irc_transport.py` → `src/irc_lens/irc/transport.py`. Strip `CAP REQ :message-tags` (the lens doesn't render IRCv3 tags — see `culture/console/client.py:50-55` for precedent). Keep the persistent-connection + read-loop shape.
+   - `../culture/packages/agent-harness/message_buffer.py` → `src/irc_lens/irc/buffer.py`. Use as-is unless an import-time conflict surfaces.
+   - `../culture/culture/console/commands.py` → `src/irc_lens/commands.py`. Lift wholesale.
+3. Add `src/irc_lens/irc/__init__.py` re-exporting the public symbols.
+4. Adjust imports inside the cited files to use the new module paths. Do **not** introduce abstractions; the goal is byte-faithful citation plus minimum-viable rewiring.
+
+**Verification:**
+
+```bash
+uv run python -c "from irc_lens.irc.transport import IRCTransport; print(IRCTransport)"
+uv run python -c "from irc_lens.irc.buffer import MessageBuffer; print(MessageBuffer)"
+uv run python -c "from irc_lens.commands import parse_command, CommandType; print(parse_command('/join #ops'))"
+afi cli verify                  # still passing
+```
+
+**Commit:** "phase 2: cite irc_transport, message_buffer, commands from culture@<sha>" (one commit, or one per file — the agent's call).
+
+---
+
+## Phase 3 — Session class
+
+**Goal:** A `Session` object that owns the IRC connection and can answer all the queries the spec's slash commands need.
+
+1. Create `src/irc_lens/session.py` with a `Session` class that:
+   - Constructs an `IRCTransport` and `MessageBuffer`.
+   - Exposes `connect()`, `disconnect()`, `send_privmsg(target, text)`, `join(ch)`, `part(ch)`, `send_raw(line)`.
+   - Implements `list_channels()`, `who(target)`, `history(channel, limit)` using the **future-based collect-buffer pattern** from `../culture/culture/console/client.py:206-288`. Reuse the pattern shape; do **not** import the file.
+   - Maintains view state: `current_channel: str`, `joined_channels: set[str]`, `view: Literal["chat","help","overview","status"]`, `roster: list[EntityItem]`.
+   - Defines `LensConnectionLost(ConnectionError)` and raises it when `send_raw` fails.
+2. Define `SessionEvent` dataclass and `SessionEventBus` with bounded `asyncio.Queue` (default 256, drop-oldest with overflow `error` event) — but only the bus interface; SSE wiring lands in Phase 5.
+3. Add `tests/test_session_unit.py` for state transitions that don't require a live server (e.g., `current_channel` updates, `joined_channels` after `join`/`part` no-op when not connected).
+
+**Verification:**
+
+```bash
+uv run pytest tests/test_session_unit.py -v
+```
+
+**Commit:** "phase 3: Session class with future-based query methods"
+
+---
+
+## Phase 4 — aiohttp app skeleton
+
+**Goal:** A static index page renders, returns 200, has all required `data-testid` attributes.
+
+1. Create `src/irc_lens/web/app.py` with an aiohttp `Application` factory that takes a `Session` and registers routes.
+2. Create `src/irc_lens/web/routes.py`:
+   - `GET /` → render `templates/index.html.j2` with the current Session state. Stable `data-testid` attributes on every element listed in the spec's DOM contract section.
+   - `POST /input` → stub returning `204 No Content`. Wired in Phase 5.
+   - `GET /events` → SSE stub that emits one `chat` event saying "irc-lens online" then closes. Wired properly in Phase 5.
+   - `GET /static/{path}` → static file handler for `lens.css`, `lens.js`.
+3. Create `src/irc_lens/web/render.py` with the Jinja2 environment and a `render_fragment(template, **ctx)` helper.
+4. Create `templates/index.html.j2` with the three-pane layout (sidebar, chat, info) and the SSE listener `<script>` tag (HTMX vendored or CDN — document the choice in `docs/architecture.md`).
+5. Add `_chat_line.j2`, `_sidebar.j2`, `_info.j2` as empty placeholders rendered with current state.
+
+**Verification:**
+
+```bash
+# Manual: in one shell
+irc-lens serve --host 127.0.0.1 --port 6667 --nick test --web-port 8765 &
+# In another shell
+curl -fsS http://127.0.0.1:8765/                  # returns HTML with all required data-testid attrs
+curl -fsS -I http://127.0.0.1:8765/static/lens.css # 200 OK
+curl -fsS -N http://127.0.0.1:8765/events         # one SSE event, then EOF
+kill %1
+```
+
+(If no AgentIRC server is running, `serve` will fail-fast at `Session.connect`; that is expected and tested in Phase 9. For Phase 4 verification, point at any reachable IRC server or stub the connect call.)
+
+**Commit:** "phase 4: aiohttp app skeleton with index + SSE stub + static"
+
+---
+
+## Phase 5 — Wire the SSE event bus
+
+**Goal:** Real-time updates work. Receiving an IRC PRIVMSG triggers a `chat` SSE event in an open browser stream.
+
+1. In `src/irc_lens/web/events.py`, finalize `SessionEvent` (`name: Literal["chat","roster","info","view","error"]`, `data: str`) and SSE serialization (`event: <name>\ndata: <data>\n\n`).
+2. `SessionEventBus.subscribe()` returns an `AsyncIterator[SessionEvent]` backed by a per-subscriber queue. On overflow, drop oldest and emit a one-shot `error` event with payload `{"message": "events dropped"}`.
+3. Rewrite `GET /events` to subscribe and stream until client disconnect (`ConnectionResetError`). On disconnect, unsubscribe and unwind cleanly.
+4. In `Session.dispatch(msg)`, when `msg.command == "PRIVMSG"` and the channel matches `current_channel`, render `_chat_line.j2` and publish a `chat` event.
+5. In `routes.py`, `POST /input` parses the body via `parse_command()`, dispatches via `Session.execute()`, returns `204`. On `LensConnectionLost`, return `503`.
+6. `Session.execute()` for `JOIN`/`PART` updates `joined_channels`, then publishes a `roster` event with re-rendered `_sidebar.j2`.
+
+**Verification:**
+
+```bash
+# Terminal 1
+irc-lens serve --host <real> --port <real> --nick lens-test --web-port 8765
+# Terminal 2 — open SSE stream
+curl -fsS -N http://127.0.0.1:8765/events &
+# Terminal 3 — submit /join
+curl -fsS -X POST -d '{"text":"/join #general"}' -H "Content-Type: application/json" \
+     http://127.0.0.1:8765/input
+# Terminal 2 should receive a `roster` event within 100ms
+```
+
+**Commit:** "phase 5: wire SSE event bus + POST /input through Session"
+
+---
+
+## Phase 6 — Render fragments
+
+**Goal:** Each SSE event type produces a real, populated fragment that HTMX swaps correctly.
+
+For each event type in the spec's table (`chat`, `roster`, `info`, `view`, `error`), in this order:
+
+1. Flesh out the corresponding template (`_chat_line.j2`, `_sidebar.j2`, `_info.j2`; `view` and `error` are JSON-payload, not templates).
+2. Wire the trigger point in `Session` and confirm the fragment renders correctly via `tests/test_render.py` (added properly in Phase 9 unit-tests; for now, ad hoc).
+3. Confirm `data-testid` attributes from the DOM contract are present.
+
+One commit per event type is fine; combine `view` + `error` into one commit since they're JSON-only.
+
+**Verification:** open the page in a real browser, type `/join #general`, observe the sidebar update without page reload. Type a message — observe it append to `#chat-log`.
+
+**Commit:** four commits, one per fragment template (plus the `view`+`error` JSON commit).
+
+---
+
+## Phase 7 — Browser glue (`lens.js` + `lens.css`)
+
+**Goal:** ≤ 50 lines of JS that wire SSE to HTMX and toggle view classes on `view` events.
+
+1. `lens.js`:
+   - On page load, open `EventSource('/events')`.
+   - Listen for `chat` events → `htmx.process(...)` after appending the fragment to `#chat-log`.
+   - Listen for `roster`, `info` events → `outerHTML`-swap the targeted element.
+   - Listen for `view` events → toggle `data-view` on `<body>`; CSS handles visibility.
+   - Listen for `error` events → render a transient toast in `#toast-region`.
+2. `lens.css`: bare-minimum three-pane grid layout. No theming. Reuse colors from culture's TUI where reasonable for visual continuity.
+3. Form submission: HTMX `hx-post="/input"` on the `<form id="chat-form">`. On 204, clear the input box. On 503, surface a toast via the `error` listener (the server can also emit an `error` SSE event, choose one path and document).
+
+**Verification:** load `/`, type `/help`, see help fragment in `#info`. Type chat text, see it appear in `#chat-log`. Resize the window — three panes reflow.
+
+**Commit:** "phase 7: browser SSE/HTMX glue"
+
+---
+
+## Phase 8 — `--seed` flag
+
+**Goal:** `irc-lens serve --seed tests/fixtures/basic.yaml` starts with deterministic UI state.
+
+1. Add YAML loading in `cli.py`. Schema matches the spec's `--seed` example exactly.
+2. After `Session.connect()` succeeds, if `--seed` is set, load the YAML and overlay it onto Session state (`joined_channels`, `current_channel`, `roster`, `_message_buffer`).
+3. Validate the YAML schema; on shape errors, raise `AfiError` with a remediation hint (rubric requires `hint:` line on errors).
+4. Document the schema in `docs/cli.md` and `docs/playwright.md`.
+
+**Verification:**
+
+```bash
+irc-lens serve --host <real> --port <real> --nick lens-test --seed tests/fixtures/basic.yaml --web-port 8765 &
+curl -fsS http://127.0.0.1:8765/ | grep "data-testid=\"chat-line\"" | wc -l   # ≥ 2 from the seed
+kill %1
+```
+
+**Commit:** "phase 8: --seed YAML fixture"
+
+---
+
+## Phase 9 — Tests
+
+Three layers, three commits:
+
+### 9a — Unit tests
+
+- `tests/test_commands.py` — every `CommandType` round-trips through `parse_command`. Coverage target: 100% on `commands.py`.
+- `tests/test_render.py` — every fragment template renders correctly given fixture session state. Coverage target: every branch in each template.
+- `tests/test_session_unit.py` — extend Phase 3 tests to cover all view-state transitions.
+
+**Commit:** "phase 9a: unit tests for commands, render, session state"
+
+### 9b — HTTP e2e
+
+- `tests/conftest.py` — fixture that spawns a real AgentIRC server on a random port. Two paths per the spec:
+  - **Recommended:** import the fixture from `culture` as a dev dep pinned to a SHA. Pros: zero IRC code in this repo's tests. Cons: requires `culture` source available at test time.
+  - **Fallback:** copy a thin AgentIRC test server into `tests/_agentirc_server.py`. More work; cleaner boundary. Document the choice in `tests/README.md`.
+- `tests/test_e2e_http.py` — drives `irc-lens` via `aiohttp.ClientSession`. Asserts:
+  - `GET /` returns 200 with all required `data-testid` attrs
+  - `POST /input` with `/join #x` triggers a `roster` SSE event within 1s
+  - `POST /input` with chat text causes the message to appear in the channel via the test server
+  - `LensConnectionLost` produces a 503 from `POST /input`
+
+**Commit:** "phase 9b: HTTP e2e tests"
+
+### 9c — Playwright e2e
+
+- Configure `pytest -m playwright` opt-in marker.
+- `tests/test_e2e_playwright.py` — uses `--seed` fixture for determinism. Asserts:
+  - The seeded chat lines render with correct `data-testid="chat-line"` count
+  - Typing into `data-testid="chat-input"` and submitting triggers a new `chat-line`
+  - Clicking a `data-testid="sidebar-channel"` updates the active channel and triggers an `info` swap
+- Add a separate CI job for Playwright (skipped on the default job).
+
+**Commit:** "phase 9c: Playwright e2e tests (opt-in)"
+
+---
+
+## Phase 10 — Documentation deliverables
+
+The new repo's `docs/` must contain at least:
+
+- `docs/cli.md` — every flag, exit code, example invocations, the `--seed` schema with annotations.
+- `docs/slash-commands.md` — full inherited command list with usage, example I/O.
+- `docs/sse-events.md` — every SSE event type, payload shape, fragment template name, HTMX target.
+- `docs/playwright.md` — how to drive `irc-lens` with Playwright MCP. Include a worked transcript: launch `irc-lens serve --seed ... &`, navigate to URL, locate elements by `data-testid`, drive the chat flow.
+- `docs/architecture.md` — runtime architecture diagram from the spec, module layout, decision log (especially "why SSE not WS").
+- `README.md` — quickstart (one paragraph), install (one line), link to `docs/`. Keep the file < 50 lines; depth lives in `docs/`.
+
+**Verification:** every link in every doc resolves. `docs/cli.md` enumerates every flag in `cli.py`. `docs/sse-events.md` enumerates every event published by `Session`.
+
+**Commit:** "phase 10: docs deliverables"
+
+---
+
+## Phase 11 — Release workflow
+
+**Goal:** Tagging `v0.1.0` produces a wheel on PyPI.
+
+1. Add `.github/workflows/release.yml`: triggers on `tags: v*`. Builds with `uv build`, publishes with `pypa/gh-action-pypi-publish` using a PyPI Trusted Publisher (no long-lived token in the repo).
+2. Tag `v0.1.0` and push. Confirm the release lands on PyPI.
+3. Update `README.md` install line to `pip install irc-lens`.
+
+**Commit:** "phase 11: release workflow + first release"
+
+---
+
+## Done criteria
+
+The build is complete when the spec's verification section passes verbatim:
+
+1. `pip install irc-lens` succeeds (Phase 11).
+2. `irc-lens serve --host localhost --port 6667 --nick test` starts and prints the localhost URL (Phase 4 + Phase 5).
+3. The three-pane layout renders with no joined channels (Phase 4).
+4. `/join #general` makes the channel appear in the sidebar via SSE `roster` event (Phase 5).
+5. Typing `hello` posts a PRIVMSG and the message appears in the chat log (Phase 5).
+6. A second IRC client posting in the same channel appears in the chat log within SSE delivery latency (Phase 5).
+7. `pytest` passes (Phase 9a/9b); Playwright tests opt-in via `-m playwright` (Phase 9c).
+8. Playwright MCP can navigate to the URL, locate elements by `data-testid`, drive the same flow (Phase 9c).
+9. `afi cli verify` passes throughout — every phase ends with this still green (Phases 1–11).
+
+Open a PR per phase if the user prefers small reviews, or batch into 3–4 PRs (`bootstrap`, `core`, `tests`, `docs+release`) if they prefer fewer. Default to small PRs unless told otherwise.

--- a/docs/superpowers/specs/2026-04-27-irc-lens-handover-design.md
+++ b/docs/superpowers/specs/2026-04-27-irc-lens-handover-design.md
@@ -29,7 +29,7 @@ The expected outcome: a `pip install irc-lens && irc-lens --host x --port y --ni
 - **Dependency manager:** `uv` (match culture)
 - **Web framework:** `aiohttp`
 - **Templating:** Jinja2
-- **Frontend:** vanilla JS + HTMX (loaded from CDN or vendored — agent's call, document the choice)
+- **Frontend:** vanilla JS + HTMX. **Vendored** under `src/irc_lens/static/vendor/` (pinned `htmx.min.js` + `sse.js`), not loaded from a CDN — irc-lens runs on localhost, drives Playwright in offline-friendly agent loops, and must boot deterministically without outbound network. The pinned version is documented in `docs/architecture.md`.
 
 ---
 
@@ -286,12 +286,9 @@ Three layers:
 
 **3. Playwright e2e (`tests/test_e2e_playwright.py`, opt-in via `pytest -m playwright`):** launches chromium, navigates to the local URL, types into `data-testid="chat-input"`, asserts visible `data-testid="chat-line"` elements. Uses `--seed` fixtures for setup. Slower; runs in CI on a separate job.
 
-**AgentIRC server fixture.** The agent has two options for getting an AgentIRC server in tests:
+**AgentIRC server fixture.** Use option (a): pin `culture` as a dev dependency to a commit SHA and import its `tests/conftest.py` server fixture. This keeps zero IRC-server code in `irc-lens` and lets us track upstream protocol changes by bumping the SHA. Document the pinned SHA in `tests/README.md` and `CITATION.md`.
 
-- (a) Add `culture` as a dev dependency (pinned to a commit SHA), import its `tests/conftest.py` server fixture. Simplest, but couples test-time deps to culture's source.
-- (b) Build a thin AgentIRC test server in the new repo. More work; cleaner boundary.
-
-**Recommendation:** start with (a). If/when culture's test fixture stops fitting, extract a minimal test server into `tests/_agentirc_server.py`. Document the choice in `tests/README.md`.
+If culture's fixture later stops fitting (e.g., the import surface changes, or culture itself splits), fall back to option (b): extract a minimal AgentIRC test server into `tests/_agentirc_server.py` and update `tests/README.md`. Do not attempt both at once.
 
 ---
 
@@ -310,22 +307,27 @@ The repo's CLAUDE.md should mirror culture's structure: project overview, packag
 
 ---
 
-## Build sequence (suggested for the building agent)
+## Build sequence
 
-1. Bootstrap repo: `pyproject.toml`, `uv` venv, CI skeleton, `README.md`, `CLAUDE.md`, `CITATION.md`.
-2. Cite `irc_transport.py`, `message_buffer.py`, `commands.py` per the citation table. Verify they import.
-3. Build `Session` class — wire transport + buffer + commands, implement query methods (LIST/WHO/HISTORY) by mirroring `culture/console/client.py`.
-4. Build aiohttp app + routes + Jinja templates. Render index page, hard-coded SSE event for sanity check.
-5. Wire `Session` events → SSE stream. End-to-end smoke: open browser, see a real chat line.
-6. Add `data-testid` attributes per the DOM contract.
-7. Add `--seed` flag and YAML loading.
-8. Write unit tests (commands, render).
-9. Write HTTP e2e tests (real AgentIRC fixture).
-10. Write Playwright e2e tests (opt-in marker).
-11. Write `docs/` deliverables.
-12. PyPI publish workflow + first release.
+The operational sequence is the 11-phase build plan: [`docs/superpowers/plans/2026-04-27-irc-lens-build-plan.md`](../plans/2026-04-27-irc-lens-build-plan.md). Each phase ends with a verification block; one PR per phase.
 
-Each step is independently committable. Do not skip the documentation step at the end — agents that follow this spec will rely on those docs.
+Quick map (spec section → plan phase):
+
+| Spec topic | Plan phase |
+| --- | --- |
+| Repo bootstrap (incl. `overview` global + `cli overview`) | Phase 1 |
+| Citation lift from culture | Phase 2 |
+| `Session` class | Phase 3 |
+| aiohttp app skeleton + index render | Phase 4 |
+| SSE event bus wired through `Session` | Phase 5 |
+| Render fragments per event type | Phase 6 |
+| Browser glue (`lens.js`, `lens.css`) | Phase 7 |
+| `--seed` YAML fixture | Phase 8 |
+| Tests (unit, HTTP e2e, Playwright opt-in) | Phase 9 |
+| `docs/` deliverables | Phase 10 |
+| Release workflow (PR → TestPyPI / push → PyPI) | Phase 11 |
+
+Do not skip the documentation phase — agents reading this spec later will rely on those docs.
 
 ---
 
@@ -353,10 +355,11 @@ If a v2 needs any of these, that's a follow-up spec.
 The handover is complete when, on a clean machine:
 
 1. `pip install irc-lens` succeeds.
-2. With a culture AgentIRC server running, `irc-lens --host localhost --port 6667 --nick test` starts and prints the localhost URL.
+2. With a culture AgentIRC server running, `irc-lens serve --host localhost --port 6667 --nick test` starts and prints the localhost URL.
 3. Opening the URL shows the three-pane layout with the user joined to no channels.
 4. Typing `/join #general` in the chat input causes the channel to appear in the sidebar (via SSE `roster` event).
 5. Typing `hello` posts a PRIVMSG and the message appears in the chat log.
 6. A second user posting from another IRC client appears in the chat log within the SSE delivery latency.
 7. `pytest` passes (with Playwright tests opt-in via `-m playwright`).
 8. Playwright MCP can navigate to the URL, locate elements by `data-testid`, and drive the same flow.
+9. `afi cli verify` reports 22/22 across all six rubric bundles (Structure, Learnability, JSON, Errors, Explain, Overview).

--- a/docs/superpowers/specs/2026-04-27-irc-lens-handover-design.md
+++ b/docs/superpowers/specs/2026-04-27-irc-lens-handover-design.md
@@ -14,7 +14,7 @@ This spec defines `irc-lens`, a separate sibling repo that re-implements the con
 
 `irc-lens` speaks AgentIRC over a plain TCP socket. It depends on culture only insofar as it cites code from `packages/agent-harness/`. It does not import culture at runtime, does not read `~/.culture/server.yaml`, and is not coupled to culture's nick/manifest conventions.
 
-The expected outcome: a `pip install irc-lens && irc-lens --host x --port y --nick z` flow that launches a localhost web app the user (or an agent driving Playwright) can use to admin any AgentIRC server.
+The expected outcome: a `pip install irc-lens && irc-lens serve --host x --port y --nick z` flow that launches a localhost web app the user (or an agent driving Playwright) can use to admin any AgentIRC server.
 
 ---
 
@@ -179,7 +179,7 @@ AgentIRC PRIVMSG
       fragment = render("_chat_line.j2", msg=msg)
       self.event_bus.publish("chat", fragment)
   → SSE stream sends `event: chat\ndata: <fragment>\n\n`
-  → HTMX (htmx-sse extension) appends to #chat-log
+  → Browser SSE→DOM glue (`lens.js` EventSource handler) appends the fragment to #chat-log via HTMX
 ```
 
 **User input:**
@@ -268,9 +268,9 @@ In seed mode, the IRC connection is still established (the agent must verify the
 
 **Browser disconnect.** SSE generator detects `ConnectionResetError` on write, exits cleanly. Session and IRC connection survive. Refresh re-attaches and renders current state.
 
-**Startup failures.** AgentIRC unreachable → stderr message including host/port + hint, exit 1, aiohttp never starts. Web port already in use → stderr message + hint, exit 1.
+**Startup failures.** AgentIRC unreachable → stderr message including host/port + hint, exit 1, aiohttp never starts. Web port already in use → stderr message + hint, exit 2 (env error per the exit-code policy in [CLI shape](#cli-shape)).
 
-**Shutdown.** Ctrl-C → SIGINT handler → close all SSE streams (final `bye` event), send IRC `QUIT`, close TCP, exit 0.
+**Shutdown.** Ctrl-C → SIGINT handler → close all SSE streams cleanly, send IRC `QUIT`, close TCP, exit 0. (No `bye` SSE event — the spec's five event types are the entire reactive surface.)
 
 **Logging.** Default: human-readable stderr. With `--log-json`, one JSON object per line on stderr. No log file in v1.
 

--- a/docs/superpowers/specs/2026-04-27-irc-lens-handover-design.md
+++ b/docs/superpowers/specs/2026-04-27-irc-lens-handover-design.md
@@ -1,0 +1,362 @@
+# `irc-lens` — Reactive Web Console for AgentIRC
+
+**Status:** Design / handover spec
+**Date:** 2026-04-27
+**Audience:** The agent that will build `irc-lens` in a new sibling repo. Read this end-to-end before opening a worktree.
+
+---
+
+## Context
+
+Culture's interactive admin console (`culture mesh console`) is a Textual TUI today. It works well for humans at terminals, but it can't be driven by a browser-automation agent (Playwright MCP), which makes iteration on the UI slow — every change requires a human in the loop to verify.
+
+This spec defines `irc-lens`, a separate sibling repo that re-implements the console as an aiohttp-served reactive web app. The web frontend is server-rendered (HTMX + SSE), so DOM is deterministic and Playwright-testable. The TUI in culture stays as-is; `irc-lens` is **not** a replacement that lives behind a `--html` flag — it ships as its own CLI, on its own release cadence, in its own repo.
+
+`irc-lens` speaks AgentIRC over a plain TCP socket. It depends on culture only insofar as it cites code from `packages/agent-harness/`. It does not import culture at runtime, does not read `~/.culture/server.yaml`, and is not coupled to culture's nick/manifest conventions.
+
+The expected outcome: a `pip install irc-lens && irc-lens --host x --port y --nick z` flow that launches a localhost web app the user (or an agent driving Playwright) can use to admin any AgentIRC server.
+
+---
+
+## Repo identity
+
+- **Name:** `irc-lens`
+- **GitHub:** `agentculture/irc-lens` (new repo, sibling to `agentculture/culture`)
+- **PyPI:** `irc-lens`
+- **CLI entry point:** `irc-lens`
+- **License:** match culture's
+- **Python:** 3.11+ (match culture)
+- **Dependency manager:** `uv` (match culture)
+- **Web framework:** `aiohttp`
+- **Templating:** Jinja2
+- **Frontend:** vanilla JS + HTMX (loaded from CDN or vendored — agent's call, document the choice)
+
+---
+
+## CLI shape
+
+The repo bootstraps from the `afi cli cite python-cli` pattern (see `irc-lens/CLAUDE.md`). The user-facing entry point is therefore the AFI rubric (`learn`, `explain`, plus per-tool verbs) extended with a `serve` verb that launches the web console.
+
+```
+irc-lens learn [--json]          # AFI-required: tool overview
+irc-lens explain [path] [--json] # AFI-required: catalog explainer
+irc-lens serve --host <agentirc-host> --port <agentirc-port> --nick <nick>
+               [--web-port 8765]
+               [--bind 127.0.0.1]
+               [--icon <emoji>]
+               [--open]            # auto-launch default browser
+               [--seed <path>]     # YAML fixture for tests/dev (see Testing)
+               [--log-json]        # emit stderr logs as JSON lines
+```
+
+Behavior:
+
+- `serve` requires `--host`, `--port`, `--nick`. No defaults; refuse to start without them.
+- `--bind 0.0.0.0` prints a loud stderr warning before listening (no auth in v1).
+- Foreground only. No daemonization, no PID file. Ctrl-C is the supported shutdown.
+- All failures raise `AfiError` (cited from the python-cli pattern). Exit codes: `0` success / clean shutdown; `1` user error (bad args, AgentIRC unreachable); `2` env error (web port in use); `3+` reserved.
+- stdout/stderr split is preserved per AFI rubric — even in `--log-json`, results go to stdout, diagnostics to stderr.
+- argparse errors route through the rubric's `_ArgumentParser` override so unknown verbs/flags print `error:` + `hint:` and exit non-zero with no Python traceback.
+
+---
+
+## Citation from culture
+
+`irc-lens` follows culture's **cite-don't-import** rule. At repo bootstrap, copy these files from `agentculture/culture@<sha>` and adapt them. Record the source commit SHA in a `CITATION.md` at repo root so future updates can be diffed against the upstream.
+
+The primary citation source is `packages/agent-harness/` (transport-level reusable code). `commands.py` is the one exception — it lives in `culture/console/` because the slash-command parser is console-specific, never needed by an agent. The lift is still the same pattern: copy, adapt, track the source SHA.
+
+| Cite from | Copy to | Adapt |
+|---|---|---|
+| `packages/agent-harness/irc_transport.py` | `src/irc_lens/irc/transport.py` | Strip CAP REQ for `message-tags` (the console doesn't use them — see `culture/console/client.py` for precedent). Keep the persistent-connection + read-loop shape. |
+| `packages/agent-harness/message_buffer.py` | `src/irc_lens/irc/buffer.py` | Use as-is unless the agent finds a reason not to. |
+| `culture/console/commands.py` | `src/irc_lens/commands.py` | Lift wholesale. The `CommandType` enum and `parse_command()` are the slash-command surface. |
+
+Do **not** cite: `daemon.py`, `socket_server.py`, `ipc.py`, `webhook.py`, `telemetry.py`, `config.py` — those are agent-runtime concerns. `irc-lens` has no agent loop.
+
+The IRC query patterns in `culture/console/client.py` (`list_channels`, `who`, `history` — futures + collect buffers for multi-line replies) are the reference shape for `Session`'s query methods. Reuse the pattern; do not import the file.
+
+---
+
+## Runtime architecture
+
+```
+┌──────────────────────────────────────────────────────────┐
+│  irc-lens process                                        │
+│                                                          │
+│  ┌────────────────┐    ┌─────────────────────────────┐   │
+│  │ aiohttp server │◄──►│ Session                      │  │
+│  │  GET  /        │    │  - IRCTransport (cited)      │  │
+│  │  POST /input   │    │  - MessageBuffer (cited)     │  │
+│  │  GET  /events  │    │  - command parser            │  │
+│  │       (SSE)    │    │  - view state                │  │
+│  │  /static/*     │    │  - SessionEventBus           │  │
+│  └────────────────┘    └─────────────────────────────┘   │
+│         ▲                          │                     │
+└─────────┼──────────────────────────┼─────────────────────┘
+          │ HTTP + SSE                │ TCP (AgentIRC)
+          ▼                           ▼
+   browser tab                AgentIRC server
+```
+
+**One process owns one IRC connection and serves one browser tab.** Multi-tab and multi-user are explicit non-goals for v1. The SSE stream is per-connection but the underlying state is shared, so a refresh re-attaches without losing history.
+
+**SSE for server → browser, plain POST for browser → server.** No WebSocket. HTMX-native, curl-debuggable, Playwright-friendly.
+
+**Server-rendered fragments, not JSON.** Every reactive update is a Jinja2-rendered HTML fragment delivered via SSE; HTMX swaps it into the DOM. Browser-side JS is the SSE → HTMX glue and nothing else (target: ≤ 50 lines).
+
+---
+
+## Module layout
+
+```
+irc-lens/
+├── pyproject.toml
+├── README.md
+├── CITATION.md             # tracks source commit SHAs from culture
+├── docs/
+│   ├── cli.md              # all flags, exit codes, examples
+│   ├── slash-commands.md   # full inherited command list
+│   ├── sse-events.md       # event types + payloads
+│   └── playwright.md       # how to drive irc-lens with Playwright MCP
+├── src/irc_lens/
+│   ├── __init__.py
+│   ├── cli.py              # argparse, wiring, asyncio.run
+│   ├── session.py          # Session class
+│   ├── commands.py         # cited from culture/console/commands.py
+│   ├── irc/
+│   │   ├── transport.py    # cited
+│   │   └── buffer.py       # cited
+│   ├── web/
+│   │   ├── app.py          # aiohttp Application factory
+│   │   ├── routes.py       # GET /, POST /input, GET /events, GET /partials/*
+│   │   ├── render.py       # Jinja2 environment + render helpers
+│   │   └── events.py       # SessionEvent dataclass + SSE serialization
+│   ├── static/
+│   │   ├── lens.css
+│   │   └── lens.js
+│   └── templates/
+│       ├── index.html.j2
+│       ├── _chat_line.j2
+│       ├── _sidebar.j2
+│       └── _info.j2
+└── tests/
+    ├── conftest.py         # AgentIRC server fixture
+    ├── test_commands.py
+    ├── test_render.py
+    ├── test_e2e_http.py
+    └── test_e2e_playwright.py  # opt-in via marker
+```
+
+---
+
+## SSE event types
+
+Five named event types form the entire reactive surface. Each event is `event: <name>\ndata: <html>\n\n`. The data is a pre-rendered HTML fragment unless noted.
+
+| Event | Trigger | Payload | HTMX target |
+|---|---|---|---|
+| `chat` | New PRIVMSG arrived in the current channel | `_chat_line.j2` fragment | append to `#chat-log` |
+| `roster` | Channel joined/parted, WHO refreshed, sidebar entity update | `_sidebar.j2` fragment | swap `#sidebar` |
+| `info` | View changed (chat ↔ overview ↔ status), agent selected, channel info refreshed | `_info.j2` fragment | swap `#info` |
+| `view` | Server-driven view switch (e.g. `/help`) | JSON `{view: "chat"\|"help"\|"overview"\|"status"}` | JS toggles visibility classes |
+| `error` | Transient surfaceable error | `{message: str}` | JS toast |
+
+**Resilience:** the EventBus uses a bounded per-subscriber `asyncio.Queue` (default 256). On overflow, drop oldest and emit a single `error` event indicating dropped events.
+
+---
+
+## Data flows
+
+**Incoming chat:**
+
+```
+AgentIRC PRIVMSG
+  → IRCTransport._read_loop
+  → MessageBuffer.append(ChatMessage)
+  → Session.dispatch(msg)
+    if msg.channel == self.current_channel:
+      fragment = render("_chat_line.j2", msg=msg)
+      self.event_bus.publish("chat", fragment)
+  → SSE stream sends `event: chat\ndata: <fragment>\n\n`
+  → HTMX (htmx-sse extension) appends to #chat-log
+```
+
+**User input:**
+
+```
+form submit → POST /input  body: {text: "/join #ops"}
+  → Session.execute(parse_command(text))
+  → IRCTransport.send_raw("JOIN #ops")
+  → on JOIN ack from server, Session emits `roster` event
+  → HTTP response: 204 No Content
+  → HTMX clears the input, SSE drives the visible update
+```
+
+The POST handler returns 204 specifically so HTMX does not attempt to swap anything from the response — all visible changes flow through SSE.
+
+---
+
+## Slash commands inherited from console
+
+These come for free by lifting `culture/console/commands.py`. The agent must wire each to a Session method. The list (CommandType → handler):
+
+`CHAT`, `JOIN`, `PART`, `CHANNELS`, `WHO`, `READ`, `SEND`, `OVERVIEW`, `STATUS`, `AGENTS`, `ICON`, `TOPIC`, `KICK`, `INVITE`, `SERVER`, `QUIT`, `HELP`. Plus `START`, `STOP`, `RESTART` — these print a message saying agent management requires culture's CLI (mirrors console behavior).
+
+The Session's query methods (`list_channels`, `who`, `history`) follow the future-based collect-buffer pattern from `culture/console/client.py:206-288`. Reuse that pattern.
+
+---
+
+## DOM contract for Playwright
+
+The building agent must add stable `data-testid` attributes on every interactive element. The Playwright e2e tests and Playwright MCP both depend on these selectors being canonical.
+
+**Required testids:**
+
+- `chat-input` — the text input field
+- `chat-submit` — the submit button (if present; an `Enter`-only form is fine, but the button gets a testid)
+- `chat-log` — the scrollable chat area
+- `chat-line` — each rendered message
+- `chat-line-nick` — nick within a chat line
+- `chat-line-text` — text within a chat line
+- `sidebar` — the sidebar container
+- `sidebar-channel` — each channel row (with `data-channel="#name"`)
+- `sidebar-entity` — each roster entry (with `data-nick="..."`)
+- `info` — the right-pane container
+- `view-indicator` — element whose text or `data-view` reflects current view
+- `connection-status` — element that shows connected/disconnected state
+
+If the agent adds new interactive elements, they get `data-testid` attributes too. Document them in `docs/playwright.md`.
+
+---
+
+## `--seed` fixture format
+
+To make Playwright tests deterministic without round-tripping through a real AgentIRC server, `--seed <path>` loads a YAML file at startup and stages canned state in the Session before the SSE stream opens.
+
+```yaml
+# tests/fixtures/basic.yaml
+joined_channels:
+  - "#general"
+  - "#ops"
+preload_messages:
+  - channel: "#general"
+    nick: "alice"
+    text: "hello world"
+    timestamp: 1714000000
+  - channel: "#general"
+    nick: "bob"
+    text: "hi alice"
+    timestamp: 1714000005
+roster:
+  - nick: "alice"
+    type: "human"
+    online: true
+  - nick: "bob"
+    type: "agent"
+    online: true
+current_channel: "#general"
+```
+
+In seed mode, the IRC connection is still established (the agent must verify the server is reachable), but the initial UI state is overlaid from YAML. This lets Playwright tests start from a known DOM without scripting an entire conversation.
+
+---
+
+## Error handling & lifecycle
+
+**IRC connection loss.** Define `LensConnectionLost(ConnectionError)`. Raised by `IRCTransport.send_raw` on broken pipe. `Session.execute` catches it, emits a `chat` system message ("Connection to AgentIRC lost — restart irc-lens to reconnect"), marks Session unhealthy. SSE stays open so the user sees the message; subsequent `POST /input` returns 503. **No auto-reconnect in v1.**
+
+**Browser disconnect.** SSE generator detects `ConnectionResetError` on write, exits cleanly. Session and IRC connection survive. Refresh re-attaches and renders current state.
+
+**Startup failures.** AgentIRC unreachable → stderr message including host/port + hint, exit 1, aiohttp never starts. Web port already in use → stderr message + hint, exit 1.
+
+**Shutdown.** Ctrl-C → SIGINT handler → close all SSE streams (final `bye` event), send IRC `QUIT`, close TCP, exit 0.
+
+**Logging.** Default: human-readable stderr. With `--log-json`, one JSON object per line on stderr. No log file in v1.
+
+---
+
+## Testing strategy
+
+Three layers:
+
+**1. Unit (`tests/test_commands.py`, `tests/test_render.py`):** pure pytest. No I/O. Asserts `parse_command()` shapes and that fragment rendering produces expected DOM given fixture session state. Coverage target: every `CommandType` and every fragment template.
+
+**2. HTTP e2e (`tests/test_e2e_http.py`):** spins up irc-lens against a real AgentIRC server (fixture). Drives via `aiohttp.ClientSession` — POST /input, read SSE stream, assert event names and fragment content. Fast, deterministic, no browser. This is the primary regression net.
+
+**3. Playwright e2e (`tests/test_e2e_playwright.py`, opt-in via `pytest -m playwright`):** launches chromium, navigates to the local URL, types into `data-testid="chat-input"`, asserts visible `data-testid="chat-line"` elements. Uses `--seed` fixtures for setup. Slower; runs in CI on a separate job.
+
+**AgentIRC server fixture.** The agent has two options for getting an AgentIRC server in tests:
+
+- (a) Add `culture` as a dev dependency (pinned to a commit SHA), import its `tests/conftest.py` server fixture. Simplest, but couples test-time deps to culture's source.
+- (b) Build a thin AgentIRC test server in the new repo. More work; cleaner boundary.
+
+**Recommendation:** start with (a). If/when culture's test fixture stops fitting, extract a minimal test server into `tests/_agentirc_server.py`. Document the choice in `tests/README.md`.
+
+---
+
+## Documentation deliverables
+
+The new repo's `docs/` directory must contain at least:
+
+- `docs/cli.md` — every flag, exit code, example invocations
+- `docs/slash-commands.md` — full command list with usage
+- `docs/sse-events.md` — every SSE event type, payload, fragment template name
+- `docs/playwright.md` — how to drive irc-lens with Playwright MCP, with example transcripts
+- `docs/architecture.md` — the runtime architecture diagram from this spec, plus module layout
+- `README.md` — quickstart, install, link to docs
+
+The repo's CLAUDE.md should mirror culture's structure: project overview, package management, citation pattern, doc conventions, git workflow, testing.
+
+---
+
+## Build sequence (suggested for the building agent)
+
+1. Bootstrap repo: `pyproject.toml`, `uv` venv, CI skeleton, `README.md`, `CLAUDE.md`, `CITATION.md`.
+2. Cite `irc_transport.py`, `message_buffer.py`, `commands.py` per the citation table. Verify they import.
+3. Build `Session` class — wire transport + buffer + commands, implement query methods (LIST/WHO/HISTORY) by mirroring `culture/console/client.py`.
+4. Build aiohttp app + routes + Jinja templates. Render index page, hard-coded SSE event for sanity check.
+5. Wire `Session` events → SSE stream. End-to-end smoke: open browser, see a real chat line.
+6. Add `data-testid` attributes per the DOM contract.
+7. Add `--seed` flag and YAML loading.
+8. Write unit tests (commands, render).
+9. Write HTTP e2e tests (real AgentIRC fixture).
+10. Write Playwright e2e tests (opt-in marker).
+11. Write `docs/` deliverables.
+12. PyPI publish workflow + first release.
+
+Each step is independently committable. Do not skip the documentation step at the end — agents that follow this spec will rely on those docs.
+
+---
+
+## Non-goals (v1)
+
+Listing these explicitly so the building agent does not scope-creep:
+
+- Multi-tab / multi-user / shared sessions
+- Authentication, TLS termination
+- Auto-reconnect to AgentIRC
+- Reading culture's `~/.culture/server.yaml`
+- Daemonization, PID files, systemd units
+- IRCv3 message tags
+- Mobile layout
+- Theming beyond a single CSS file
+- WebSocket transport
+- Any LLM agent loop (`irc-lens` is a pure client, not an agent)
+
+If a v2 needs any of these, that's a follow-up spec.
+
+---
+
+## Verification
+
+The handover is complete when, on a clean machine:
+
+1. `pip install irc-lens` succeeds.
+2. With a culture AgentIRC server running, `irc-lens --host localhost --port 6667 --nick test` starts and prints the localhost URL.
+3. Opening the URL shows the three-pane layout with the user joined to no channels.
+4. Typing `/join #general` in the chat input causes the channel to appear in the sidebar (via SSE `roster` event).
+5. Typing `hello` posts a PRIVMSG and the message appears in the chat log.
+6. A second user posting from another IRC client appears in the chat log within the SSE delivery latency.
+7. `pytest` passes (with Playwright tests opt-in via `-m playwright`).
+8. Playwright MCP can navigate to the URL, locate elements by `data-testid`, and drive the same flow.


### PR DESCRIPTION
## Summary

Adds the design spec and 11-phase implementation plan that the build will follow:

- `docs/superpowers/specs/2026-04-27-irc-lens-handover-design.md` — what to build and why (handover from claude-in-culture).
- `docs/superpowers/plans/2026-04-27-irc-lens-build-plan.md` — 11 small, independently committable phases.

These are the source of truth for subsequent build PRs (`phase-1-bootstrap` etc.).

## What changed in the latest push

Phase 1 (PR #3) surfaced a few drift/ambiguity items in the original spec/plan. Resolved here so future phases inherit aligned guidance:

- **`afi cli verify` rubric grew a 6th `overview` bundle** after the spec was drafted. CLAUDE.md, spec, and plan now document the bundle (subject/path/sections JSON shape; descriptive, not verifying; unknown-path exits 0 with warning). Plan Phase 1 now explicitly ships an `overview` global + `cli overview` noun-verb so the verifier passes 22/22 from day one.
- **HTMX delivery**: was "agent's call (CDN or vendored)" — decided: vendored under `src/irc_lens/static/vendor/` for offline-friendly Playwright loops. Plan Phase 4 updated.
- **AgentIRC test fixture**: was "(a) or (b)" — decided: (a) culture pinned as a dev dep, with (b) as a fall-through.
- **PyPI release workflow**: was tag-triggered — replaced with PR→TestPyPI / push→PyPI Trusted Publisher model that mirrors culture's `publish.yml` and uses the `pypi` / `testpypi` GitHub environments already provisioned.
- **Verification step 2** in the spec had `irc-lens --host …` (missing the `serve` verb) — fixed.
- **Build sequence** in the spec had 12 steps that didn't map cleanly to the plan's 11 phases — replaced with a section→phase table pointing at the plan as operational source of truth.
- **Resolved decisions table** added to the top of the plan so future agents see the choices immediately.

## Test plan

- [ ] Render docs in the GitHub UI; check internal links resolve.
- [ ] Reviewer can run `afi cli verify` against PR #3's branch and see 22/22 (validates the rubric description here matches the implementation there).

- Claude