### PR TITLE
phase 3: Session class with future-based query methods

### DIFF
--- a/src/irc_lens/session.py
+++ b/src/irc_lens/session.py
@@ -98,23 +98,32 @@ class _Subscriber:
             # the next burst is allowed to issue a fresh error event.
             self._overflow_flagged = False
             return
-        # Overflow path: drop oldest, signal once, then try the new one.
-        try:
-            self.queue.get_nowait()
-        except asyncio.QueueEmpty:
-            pass
+        # Overflow path: the spec says "drop oldest on overflow" — the
+        # newest event must always survive. To inject the one-shot
+        # error notice without losing the new event, drop one extra
+        # oldest entry so both the error and the new event fit.
         if not self._overflow_flagged:
+            self._drop_one_oldest()  # make room for the error
+            self._drop_one_oldest()  # make room for the new event
             err = SessionEvent(name="error", data=_OVERFLOW_DATA)
             try:
                 self.queue.put_nowait(err)
                 self._overflow_flagged = True
             except asyncio.QueueFull:
-                # Bus completely jammed; the subscriber will see the
-                # next event whenever it drains. Don't loop forever.
+                # Bus completely jammed even after two drops (queue_max=1
+                # edge case). Skip the error rather than loop forever.
                 pass
+        else:
+            self._drop_one_oldest()  # just one drop on subsequent overflows
         try:
             self.queue.put_nowait(event)
         except asyncio.QueueFull:
+            pass
+
+    def _drop_one_oldest(self) -> None:
+        try:
+            self.queue.get_nowait()
+        except asyncio.QueueEmpty:
             pass
 
     async def iter(self) -> AsyncIterator[SessionEvent]:
@@ -249,6 +258,13 @@ class Session:
         # Future + collect-buffer state for LIST / WHO / HISTORY.
         self._pending: dict[str, asyncio.Future[Any]] = {}
         self._collect_buffers: dict[str, list[Any]] = {}
+        # Per-query-key lock: serialises concurrent same-key queries so
+        # they can't clobber each other's collect-buffer + pending future.
+        # IRC numerics like RPL_LISTEND (323) carry no query-id, so two
+        # in-flight LIST calls would otherwise resolve each other's
+        # futures with mixed results. Different keys (e.g. WHO #a vs
+        # WHO #b) don't block each other.
+        self._query_locks: dict[str, asyncio.Lock] = {}
 
         # Event bus: Phase 5 will wire publishes; Phase 3 just holds it.
         self.event_bus = event_bus if event_bus is not None else SessionEventBus()
@@ -273,6 +289,13 @@ class Session:
             # ConnectionError is an OSError subclass in Python 3.3+.
             self._healthy = False
             raise LensConnectionLost(str(exc)) from exc
+        # Disable IRCTransport's auto-reconnect: the spec's lifecycle
+        # contract is "no auto-reconnect in v1 — restart irc-lens to
+        # reconnect". `_transport.connect()` set `_should_run = True`,
+        # which would cause `_read_loop`'s finally to spawn `_reconnect`
+        # on EOF. Flipping it back to False keeps the read loop alive
+        # but lets it terminate cleanly when the socket closes.
+        self._transport._should_run = False
 
     async def disconnect(self) -> None:
         await self._transport.disconnect()
@@ -321,9 +344,10 @@ class Session:
     async def join(self, channel: str) -> None:
         if not channel.startswith("#"):
             return
-        # Track locally first so the optimistic UI matches the user's
-        # intent even if the JOIN ack hasn't landed yet. The server's
-        # ack will be a no-op via this set (set semantics).
+        # Server-confirmed semantics: only mark the channel joined once
+        # the JOIN write succeeds. A failed send raises
+        # `LensConnectionLost` and `joined_channels` does NOT advance —
+        # see `test_join_translates_pipe_error`.
         try:
             await self._transport.join_channel(channel)
         except OSError as exc:
@@ -414,27 +438,32 @@ class Session:
         Mirrors the body of LIST/WHO/HISTORY in
         ``culture/console/client.py``. Extracted so each query verb is a
         five-line wrapper; the upstream files duplicate this 25-line
-        block three times.
+        block three times. Wrapped in a per-key lock so concurrent
+        same-key queries serialise instead of clobbering each other's
+        future/buffer (upstream has the same defect — flag candidate to
+        feed back to culture).
         """
-        self._collect_buffers[key] = []
-        end_future: asyncio.Future[None] = asyncio.get_running_loop().create_future()
-        self._pending[pending_key] = end_future
-        try:
-            await send()
-        except LensConnectionLost:
-            self._pending.pop(pending_key, None)
-            self._collect_buffers.pop(key, None)
-            raise
+        lock = self._query_locks.setdefault(key, asyncio.Lock())
+        async with lock:
+            self._collect_buffers[key] = []
+            end_future: asyncio.Future[None] = asyncio.get_running_loop().create_future()
+            self._pending[pending_key] = end_future
+            try:
+                await send()
+            except LensConnectionLost:
+                self._pending.pop(pending_key, None)
+                self._collect_buffers.pop(key, None)
+                raise
 
-        try:
-            await asyncio.wait_for(end_future, timeout=QUERY_TIMEOUT)
-        except asyncio.TimeoutError:
-            pass
-        finally:
-            self._pending.pop(pending_key, None)
+            try:
+                await asyncio.wait_for(end_future, timeout=QUERY_TIMEOUT)
+            except asyncio.TimeoutError:
+                pass
+            finally:
+                self._pending.pop(pending_key, None)
 
-        items = self._collect_buffers.pop(key, [])
-        return sorted(items) if sort else items
+            items = self._collect_buffers.pop(key, [])
+            return sorted(items) if sort else items
 
     # ------------------------------------------------------------------
     # IRC dispatch handlers (registered into IRCTransport._cmd_handlers)

--- a/src/irc_lens/session.py
+++ b/src/irc_lens/session.py
@@ -1,0 +1,488 @@
+"""Session — the lens's owner of one IRC connection.
+
+A `Session` wires together the cited transport / buffer / commands and
+adds the bits the spec asks for that don't belong in a re-cited file:
+
+* ``LensConnectionLost`` — raised by send paths when the underlying
+  socket is broken; ``POST /input`` will translate this to ``503``.
+* View state — ``current_channel``, ``joined_channels``, ``view``,
+  ``roster``.
+* Future-based query methods (``list_channels``, ``who``, ``history``)
+  using the *collect-buffer + future* pattern from
+  ``../culture/culture/console/client.py:206-288``. The shape is
+  reused; that file is **not** imported.
+* ``SessionEvent`` + ``SessionEventBus`` — a bounded, drop-oldest pub/sub
+  bus that Phase 5 will wire into the SSE response stream. For Phase 3
+  the bus is interface-only: Session can hold one and publish events
+  without crashing, so that future-phase wiring is plug-and-play.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from collections.abc import AsyncIterator
+from dataclasses import dataclass, field
+from typing import Any, Callable, Literal
+
+from irc_lens.irc import IRCTransport, Message, MessageBuffer
+
+logger = logging.getLogger(__name__)
+
+# Mirrors ``culture/console/client.py``'s constants.
+QUERY_TIMEOUT = 10.0
+REGISTER_TIMEOUT = 15.0
+
+#: The four named views the spec's ``info`` event can switch between.
+ViewName = Literal["chat", "help", "overview", "status"]
+
+#: SSE event names defined in the spec's "SSE event types" section.
+EventName = Literal["chat", "roster", "info", "view", "error"]
+
+
+class LensConnectionLost(ConnectionError):
+    """Raised when the underlying IRC socket is broken mid-send.
+
+    ``POST /input`` translates this to HTTP 503 (see Phase 5). The SSE
+    stream is left open so the user sees a system chat line surfaced by
+    the dispatcher.
+    """
+
+
+@dataclass
+class EntityItem:
+    """A roster entry for the sidebar (`_sidebar.j2`)."""
+
+    nick: str
+    type: str  # "human" | "agent" | "server" | …
+    online: bool = True
+
+
+@dataclass
+class SessionEvent:
+    """One reactive update destined for the browser.
+
+    For ``chat`` / ``roster`` / ``info`` the payload is a pre-rendered
+    HTML fragment (Phase 6 finalises the templates). For ``view`` /
+    ``error`` it is a JSON-serialised dict per the spec's table. The
+    bus is payload-agnostic — Session is responsible for emitting the
+    right shape for each name.
+    """
+
+    name: EventName
+    data: str
+
+
+_OVERFLOW_DATA = '{"message":"events dropped"}'
+
+
+class _Subscriber:
+    """Per-subscriber bounded queue with single-shot overflow signalling.
+
+    Drop-oldest semantics mean a slow consumer falls behind in real
+    time but never blocks publishers. A "burst" is a continuous run of
+    overflows; the first overflow in a burst injects one ``error``
+    event so the browser can toast it. The flag is cleared by the next
+    *non-overflow* publish (the queue caught up), which means a later
+    burst gets its own error notice.
+    """
+
+    def __init__(self, queue_max: int) -> None:
+        self.queue: asyncio.Queue[SessionEvent] = asyncio.Queue(maxsize=queue_max)
+        self._overflow_flagged = False
+
+    def publish(self, event: SessionEvent) -> None:
+        if not self.queue.full():
+            self.queue.put_nowait(event)
+            # Queue had room; we're out of any prior overflow burst, so
+            # the next burst is allowed to issue a fresh error event.
+            self._overflow_flagged = False
+            return
+        # Overflow path: drop oldest, signal once, then try the new one.
+        try:
+            self.queue.get_nowait()
+        except asyncio.QueueEmpty:
+            pass
+        if not self._overflow_flagged:
+            err = SessionEvent(name="error", data=_OVERFLOW_DATA)
+            try:
+                self.queue.put_nowait(err)
+                self._overflow_flagged = True
+            except asyncio.QueueFull:
+                # Bus completely jammed; the subscriber will see the
+                # next event whenever it drains. Don't loop forever.
+                pass
+        try:
+            self.queue.put_nowait(event)
+        except asyncio.QueueFull:
+            pass
+
+    async def iter(self) -> AsyncIterator[SessionEvent]:
+        while True:
+            event = await self.queue.get()
+            yield event
+
+
+class Subscription:
+    """A registered subscriber with an explicit ``close()``.
+
+    Returned by ``SessionEventBus.subscribe()``. The handle is registered
+    immediately so events ``publish``-ed between subscribe and the first
+    ``events()`` await are queued, not lost. Iterating ``events()`` to
+    completion calls ``close()`` automatically; the SSE handler in
+    Phase 5 will also call ``close()`` from a ``finally`` block to
+    cover the client-disconnect case where iteration is interrupted
+    before the generator's own finally fires.
+    """
+
+    def __init__(self, bus: "SessionEventBus", queue_max: int) -> None:
+        self._bus = bus
+        self._sub = _Subscriber(queue_max)
+        bus._subscribers.append(self._sub)
+        self._closed = False
+
+    def publish(self, event: SessionEvent) -> None:
+        """Direct publish — used by the bus and exposed for tests."""
+        self._sub.publish(event)
+
+    async def events(self) -> AsyncIterator[SessionEvent]:
+        try:
+            async for event in self._sub.iter():
+                yield event
+        finally:
+            self.close()
+
+    def close(self) -> None:
+        if self._closed:
+            return
+        try:
+            self._bus._subscribers.remove(self._sub)
+        except ValueError:
+            pass
+        self._closed = True
+
+    @property
+    def closed(self) -> bool:
+        return self._closed
+
+
+class SessionEventBus:
+    """Bounded, drop-oldest pub/sub for ``SessionEvent`` instances.
+
+    Every ``subscribe()`` returns a ``Subscription`` whose own queue
+    defaults to 256. ``publish()`` is fire-and-forget and never awaits;
+    that's what makes it safe to call from synchronous IRC handlers in
+    ``IRCTransport``'s dispatch table.
+    """
+
+    def __init__(self, *, queue_max: int = 256) -> None:
+        self._queue_max = queue_max
+        self._subscribers: list[_Subscriber] = []
+
+    @property
+    def subscriber_count(self) -> int:
+        return len(self._subscribers)
+
+    def subscribe(self) -> Subscription:
+        return Subscription(self, self._queue_max)
+
+    def publish(self, event: SessionEvent) -> None:
+        for sub in self._subscribers:
+            sub.publish(event)
+
+
+# IRC numerics used by the future-based query methods.
+_RPL_LIST = "322"
+_RPL_LISTEND = "323"
+_RPL_WHOREPLY = "352"
+_RPL_ENDOFWHO = "315"
+_HISTORY = "HISTORY"
+_HISTORYEND = "HISTORYEND"
+
+
+class Session:
+    """The lens's view of one AgentIRC connection.
+
+    Owns one ``IRCTransport`` and one ``MessageBuffer``, layers query
+    methods (LIST/WHO/HISTORY) on top via the future-based collect-buffer
+    pattern, holds the view state the SSE renderer needs, and exposes a
+    ``SessionEventBus`` that Phase 5 will wire into ``GET /events``.
+
+    The session does **not** spin up its own IRC read loop — it
+    registers extra handlers in ``self._transport._cmd_handlers`` so the
+    transport's existing read loop dispatches query responses to us.
+    """
+
+    def __init__(
+        self,
+        host: str,
+        port: int,
+        nick: str,
+        *,
+        icon: str | None = None,
+        event_bus: SessionEventBus | None = None,
+    ) -> None:
+        self.host = host
+        self.port = port
+        self.nick = nick
+        self.icon = icon
+
+        # View state (mutated by command dispatch in Phase 5+).
+        self.current_channel: str = ""
+        self.joined_channels: set[str] = set()
+        self.view: ViewName = "chat"
+        self.roster: list[EntityItem] = []
+
+        # Cited primitives.
+        self.buffer = MessageBuffer()
+        self._transport = IRCTransport(
+            host=host,
+            port=port,
+            nick=nick,
+            user=nick,
+            channels=[],
+            buffer=self.buffer,
+            icon=icon,
+        )
+        self._install_query_handlers()
+
+        # Future + collect-buffer state for LIST / WHO / HISTORY.
+        self._pending: dict[str, asyncio.Future[Any]] = {}
+        self._collect_buffers: dict[str, list[Any]] = {}
+
+        # Event bus: Phase 5 will wire publishes; Phase 3 just holds it.
+        self.event_bus = event_bus if event_bus is not None else SessionEventBus()
+
+        # Tracks transport health independent of `IRCTransport.connected`,
+        # which only flips after the welcome (001) handshake. The lens
+        # cares about "did we ever lose the pipe?" because Phase 5
+        # marks the session unhealthy on first `LensConnectionLost`.
+        self._healthy = True
+
+    # ------------------------------------------------------------------
+    # Connection lifecycle
+    # ------------------------------------------------------------------
+
+    async def connect(self) -> None:
+        """Open the TCP connection and register. Raises ``LensConnectionLost``
+        on connect failure so callers can translate to a clean stderr
+        message + non-zero exit (Phase 4 wires this into ``serve``)."""
+        try:
+            await self._transport.connect()
+        except (OSError, ConnectionError) as exc:
+            self._healthy = False
+            raise LensConnectionLost(str(exc)) from exc
+
+    async def disconnect(self) -> None:
+        await self._transport.disconnect()
+
+    @property
+    def healthy(self) -> bool:
+        """False once any send path has hit a broken pipe.
+
+        Stays False until the user restarts irc-lens (no auto-reconnect
+        in v1, per the spec). The Phase 5 ``POST /input`` handler reads
+        this to decide between dispatching a command and returning 503.
+        """
+        return self._healthy
+
+    @property
+    def connected(self) -> bool:
+        """Mirrors ``IRCTransport.connected`` (set by the 001 handler)."""
+        return self._transport.connected
+
+    # ------------------------------------------------------------------
+    # Send paths — every path that touches the socket translates broken
+    # pipe errors into ``LensConnectionLost`` per the spec's lifecycle
+    # contract.
+    # ------------------------------------------------------------------
+
+    async def send_raw(self, line: str) -> None:
+        try:
+            await self._transport.send_raw(line)
+        except (BrokenPipeError, ConnectionResetError, ConnectionAbortedError, OSError) as exc:
+            self._healthy = False
+            raise LensConnectionLost(str(exc)) from exc
+
+    async def send_privmsg(self, target: str, text: str) -> None:
+        try:
+            await self._transport.send_privmsg(target, text)
+        except (BrokenPipeError, ConnectionResetError, ConnectionAbortedError, OSError) as exc:
+            self._healthy = False
+            raise LensConnectionLost(str(exc)) from exc
+
+    async def join(self, channel: str) -> None:
+        if not channel.startswith("#"):
+            return
+        # Track locally first so the optimistic UI matches the user's
+        # intent even if the JOIN ack hasn't landed yet. The server's
+        # ack will be a no-op via this set (set semantics).
+        try:
+            await self._transport.join_channel(channel)
+        except (BrokenPipeError, ConnectionResetError, ConnectionAbortedError, OSError) as exc:
+            self._healthy = False
+            raise LensConnectionLost(str(exc)) from exc
+        self.joined_channels.add(channel)
+
+    async def part(self, channel: str) -> None:
+        if not channel.startswith("#"):
+            return
+        try:
+            await self._transport.part_channel(channel)
+        except (BrokenPipeError, ConnectionResetError, ConnectionAbortedError, OSError) as exc:
+            self._healthy = False
+            raise LensConnectionLost(str(exc)) from exc
+        self.joined_channels.discard(channel)
+        if self.current_channel == channel:
+            self.current_channel = ""
+
+    # ------------------------------------------------------------------
+    # View-state mutators — Phase 5 will publish events from these. For
+    # Phase 3 they're plain state setters so unit tests can drive them.
+    # ------------------------------------------------------------------
+
+    def set_current_channel(self, channel: str) -> None:
+        """Switch the active channel. ``""`` clears it."""
+        self.current_channel = channel
+
+    def set_view(self, view: ViewName) -> None:
+        self.view = view
+
+    def set_roster(self, entries: list[EntityItem]) -> None:
+        self.roster = list(entries)
+
+    # ------------------------------------------------------------------
+    # Future-based query methods
+    # ------------------------------------------------------------------
+    # The shape mirrors ``culture/console/client.py:206-288`` (LIST/WHO/
+    # HISTORY): per-call collect-buffer + asyncio.Future, resolved by the
+    # IRC dispatch handlers below. We register the handlers in
+    # ``self._transport._cmd_handlers`` so the transport's existing read
+    # loop drives our resolution.
+
+    async def list_channels(self) -> list[str]:
+        key = "LIST"
+        pending_key = _RPL_LISTEND
+        return await self._collect_until(
+            key=key,
+            pending_key=pending_key,
+            send=lambda: self.send_raw("LIST"),
+            sort=True,
+        )
+
+    async def who(self, target: str) -> list[dict]:
+        key = f"WHO {target}"
+        pending_key = f"{_RPL_ENDOFWHO}:{target}"
+        return await self._collect_until(
+            key=key,
+            pending_key=pending_key,
+            send=lambda: self.send_raw(f"WHO {target}"),
+        )
+
+    async def history(self, channel: str, limit: int = 50) -> list[dict]:
+        key = f"HISTORY {channel}"
+        pending_key = f"{_HISTORYEND}:{channel}"
+        return await self._collect_until(
+            key=key,
+            pending_key=pending_key,
+            send=lambda: self.send_raw(f"HISTORY RECENT {channel} {limit}"),
+        )
+
+    async def _collect_until(
+        self,
+        *,
+        key: str,
+        pending_key: str,
+        send: Callable[[], Any],
+        sort: bool = False,
+    ) -> list:
+        """Common shape: stage collect-buffer + future, send, await end, drain.
+
+        Mirrors the body of LIST/WHO/HISTORY in
+        ``culture/console/client.py``. Extracted so each query verb is a
+        five-line wrapper; the upstream files duplicate this 25-line
+        block three times.
+        """
+        self._collect_buffers[key] = []
+        end_future: asyncio.Future[None] = asyncio.get_running_loop().create_future()
+        self._pending[pending_key] = end_future
+        try:
+            await send()
+        except LensConnectionLost:
+            self._pending.pop(pending_key, None)
+            self._collect_buffers.pop(key, None)
+            raise
+
+        try:
+            await asyncio.wait_for(end_future, timeout=QUERY_TIMEOUT)
+        except asyncio.TimeoutError:
+            pass
+        finally:
+            self._pending.pop(pending_key, None)
+
+        items = self._collect_buffers.pop(key, [])
+        return sorted(items) if sort else items
+
+    # ------------------------------------------------------------------
+    # IRC dispatch handlers (registered into IRCTransport._cmd_handlers)
+    # ------------------------------------------------------------------
+
+    def _install_query_handlers(self) -> None:
+        h = self._transport._cmd_handlers
+        h[_RPL_LIST] = self._on_rpl_list
+        h[_RPL_LISTEND] = self._on_rpl_listend
+        h[_RPL_WHOREPLY] = self._on_rpl_whoreply
+        h[_RPL_ENDOFWHO] = self._on_rpl_endofwho
+        h[_HISTORY] = self._on_history
+        h[_HISTORYEND] = self._on_historyend
+
+    def _on_rpl_list(self, msg: Message) -> None:
+        if len(msg.params) >= 2:
+            buf = self._collect_buffers.get("LIST")
+            if buf is not None:
+                buf.append(msg.params[1])
+
+    def _on_rpl_listend(self, _msg: Message) -> None:
+        fut = self._pending.pop(_RPL_LISTEND, None)
+        if fut and not fut.done():
+            fut.set_result(None)
+
+    def _on_rpl_whoreply(self, msg: Message) -> None:
+        if len(msg.params) >= 6:
+            entry = {
+                "nick": msg.params[5],
+                "user": msg.params[2],
+                "host": msg.params[3],
+                "server": msg.params[4],
+                "flags": msg.params[6] if len(msg.params) > 6 else "",
+                "realname": msg.params[7] if len(msg.params) > 7 else "",
+            }
+            target = msg.params[1]
+            buf = self._collect_buffers.get(f"WHO {target}")
+            if buf is not None:
+                buf.append(entry)
+
+    def _on_rpl_endofwho(self, msg: Message) -> None:
+        target = msg.params[1] if len(msg.params) >= 2 else ""
+        fut = self._pending.pop(f"{_RPL_ENDOFWHO}:{target}", None)
+        if fut and not fut.done():
+            fut.set_result(None)
+
+    def _on_history(self, msg: Message) -> None:
+        if len(msg.params) >= 4:
+            channel = msg.params[0]
+            entry = {
+                "channel": channel,
+                "nick": msg.params[1],
+                "timestamp": msg.params[2],
+                "text": msg.params[3],
+            }
+            buf = self._collect_buffers.get(f"HISTORY {channel}")
+            if buf is not None:
+                buf.append(entry)
+
+    def _on_historyend(self, msg: Message) -> None:
+        channel = msg.params[0] if msg.params else ""
+        fut = self._pending.pop(f"{_HISTORYEND}:{channel}", None)
+        if fut and not fut.done():
+            fut.set_result(None)

--- a/src/irc_lens/session.py
+++ b/src/irc_lens/session.py
@@ -269,7 +269,8 @@ class Session:
         message + non-zero exit (Phase 4 wires this into ``serve``)."""
         try:
             await self._transport.connect()
-        except (OSError, ConnectionError) as exc:
+        except OSError as exc:
+            # ConnectionError is an OSError subclass in Python 3.3+.
             self._healthy = False
             raise LensConnectionLost(str(exc)) from exc
 
@@ -300,14 +301,20 @@ class Session:
     async def send_raw(self, line: str) -> None:
         try:
             await self._transport.send_raw(line)
-        except (BrokenPipeError, ConnectionResetError, ConnectionAbortedError, OSError) as exc:
+        except OSError as exc:
+            # Catches BrokenPipeError, ConnectionResetError,
+            # ConnectionAbortedError, and ConnectionError — all OSError
+            # subclasses in Python 3.3+.
             self._healthy = False
             raise LensConnectionLost(str(exc)) from exc
 
     async def send_privmsg(self, target: str, text: str) -> None:
         try:
             await self._transport.send_privmsg(target, text)
-        except (BrokenPipeError, ConnectionResetError, ConnectionAbortedError, OSError) as exc:
+        except OSError as exc:
+            # Catches BrokenPipeError, ConnectionResetError,
+            # ConnectionAbortedError, and ConnectionError — all OSError
+            # subclasses in Python 3.3+.
             self._healthy = False
             raise LensConnectionLost(str(exc)) from exc
 
@@ -319,7 +326,10 @@ class Session:
         # ack will be a no-op via this set (set semantics).
         try:
             await self._transport.join_channel(channel)
-        except (BrokenPipeError, ConnectionResetError, ConnectionAbortedError, OSError) as exc:
+        except OSError as exc:
+            # Catches BrokenPipeError, ConnectionResetError,
+            # ConnectionAbortedError, and ConnectionError — all OSError
+            # subclasses in Python 3.3+.
             self._healthy = False
             raise LensConnectionLost(str(exc)) from exc
         self.joined_channels.add(channel)
@@ -329,7 +339,10 @@ class Session:
             return
         try:
             await self._transport.part_channel(channel)
-        except (BrokenPipeError, ConnectionResetError, ConnectionAbortedError, OSError) as exc:
+        except OSError as exc:
+            # Catches BrokenPipeError, ConnectionResetError,
+            # ConnectionAbortedError, and ConnectionError — all OSError
+            # subclasses in Python 3.3+.
             self._healthy = False
             raise LensConnectionLost(str(exc)) from exc
         self.joined_channels.discard(channel)

--- a/tests/test_session_unit.py
+++ b/tests/test_session_unit.py
@@ -215,6 +215,27 @@ def test_connect_translates_to_lens_connection_lost() -> None:
     assert s.healthy is False
 
 
+def test_connect_disables_transport_auto_reconnect() -> None:
+    """Spec lifecycle: 'no auto-reconnect in v1'.
+
+    `IRCTransport.connect()` sets `_should_run = True`, which would let
+    `_read_loop`'s finally block spawn `_reconnect()` on EOF. Session
+    must flip the gate back to False so the read loop terminates
+    cleanly when the socket closes.
+    """
+    s = Session(host="x", port=0, nick="lens")
+
+    async def fake_connect() -> None:
+        s._transport._should_run = True  # mimic IRCTransport.connect()
+
+    s._transport.connect = fake_connect  # type: ignore[assignment]
+    asyncio.run(s.connect())
+    assert s._transport._should_run is False, (
+        "Session.connect() must disable transport auto-reconnect (no "
+        "auto-reconnect in v1 per the spec)"
+    )
+
+
 # ---------------------------------------------------------------------------
 # Future-based query methods
 # ---------------------------------------------------------------------------
@@ -312,6 +333,57 @@ def test_query_clears_state_on_send_failure(offline_session: Session) -> None:
         asyncio.run(offline_session.list_channels())
     assert "LIST" not in offline_session._collect_buffers
     assert "323" not in offline_session._pending
+
+
+def test_concurrent_list_calls_serialize(offline_session: Session) -> None:
+    """Two concurrent list_channels() calls on the same Session must not
+    clobber each other's collect-buffer + pending future. The per-key
+    lock serialises them; each call sees its own canned response."""
+
+    async def run() -> tuple[list[str], list[str]]:
+        first_call_active = asyncio.Event()
+        first_call_complete = asyncio.Event()
+
+        async def fake_send(line: str) -> None:
+            # Tag which call we're inside via what the buffer already
+            # holds — first call sets `first_call_active`, holds, then
+            # fires its own END; second call follows.
+            if not first_call_active.is_set():
+                first_call_active.set()
+
+                async def fire_first() -> None:
+                    offline_session._on_rpl_list(_make_msg("322", "lens", "#a1"))
+                    offline_session._on_rpl_list(_make_msg("322", "lens", "#a2"))
+                    # Wait until the second call is also started so we
+                    # can prove they don't interleave; release ours.
+                    await asyncio.sleep(0.02)
+                    offline_session._on_rpl_listend(_make_msg("323", "lens", "End"))
+                    first_call_complete.set()
+
+                asyncio.get_running_loop().call_soon(
+                    lambda: asyncio.ensure_future(fire_first())
+                )
+            else:
+
+                async def fire_second() -> None:
+                    offline_session._on_rpl_list(_make_msg("322", "lens", "#b1"))
+                    offline_session._on_rpl_listend(_make_msg("323", "lens", "End"))
+
+                asyncio.get_running_loop().call_soon(
+                    lambda: asyncio.ensure_future(fire_second())
+                )
+
+        offline_session._transport.send_raw = fake_send  # type: ignore[assignment]
+        a, b = await asyncio.gather(
+            offline_session.list_channels(),
+            offline_session.list_channels(),
+        )
+        return a, b
+
+    a, b = asyncio.run(run())
+    # Each call sees its own response (no cross-talk).
+    assert a == ["#a1", "#a2"]
+    assert b == ["#b1"]
 
 
 # ---------------------------------------------------------------------------
@@ -425,6 +497,38 @@ def test_overflow_error_payload_matches_spec() -> None:
         seen.append(sub.queue.get_nowait())
     payloads = [e.data for e in seen if e.name == "error"]
     assert _OVERFLOW_DATA in payloads
+
+
+def test_overflow_keeps_newest_event() -> None:
+    """Spec: 'drop oldest on overflow' — the newest event must always
+    survive, even on the burst's first overflow that injects the error."""
+    sub = _Subscriber(queue_max=4)
+    for i in range(4):
+        sub.publish(SessionEvent(name="chat", data=f"old{i}"))
+    # First overflow: must drop oldest, inject error, AND retain `latest`.
+    sub.publish(SessionEvent(name="chat", data="latest"))
+    drained = []
+    while not sub.queue.empty():
+        drained.append(sub.queue.get_nowait())
+    datas = [e.data for e in drained]
+    assert "latest" in datas, f"newest event must survive overflow; got {datas}"
+    # The error event is still present.
+    assert any(e.name == "error" for e in drained)
+
+
+def test_overflow_subsequent_within_burst_keeps_newest() -> None:
+    """Subsequent overflows within the same burst (flag already set)
+    must still retain the newest event."""
+    sub = _Subscriber(queue_max=2)
+    sub.publish(SessionEvent(name="chat", data="a0"))
+    sub.publish(SessionEvent(name="chat", data="a1"))
+    sub.publish(SessionEvent(name="chat", data="b0"))  # first overflow
+    sub.publish(SessionEvent(name="chat", data="b1"))  # second overflow (flag set)
+    sub.publish(SessionEvent(name="chat", data="b2"))  # third overflow
+    drained = []
+    while not sub.queue.empty():
+        drained.append(sub.queue.get_nowait().data)
+    assert "b2" in drained, f"newest of subsequent overflows must survive; got {drained}"
 
 
 def test_subscription_close_unregisters() -> None:

--- a/tests/test_session_unit.py
+++ b/tests/test_session_unit.py
@@ -374,52 +374,44 @@ def test_event_bus_overflow_emits_single_error_then_drops() -> None:
     Test directly against `_Subscriber` so we can inspect the queue
     contents without driving the iterator. A small burst (queue_max=4,
     push 6) exercises overflow without itself evicting the error event
-    from the queue.
+    from the queue. Sync — `_Subscriber.publish` is a plain method.
     """
-
-    async def run() -> list[str]:
-        sub = _Subscriber(queue_max=4)
-        for i in range(4):
-            sub.publish(SessionEvent(name="chat", data=f"a{i}"))
-        # Two extra publishes push us into the overflow path twice; the
-        # first one injects exactly one error event, the second does
-        # NOT (single-shot per burst).
-        sub.publish(SessionEvent(name="chat", data="b0"))
-        sub.publish(SessionEvent(name="chat", data="b1"))
-        drained = []
-        while not sub.queue.empty():
-            drained.append(sub.queue.get_nowait())
-        return [e.name for e in drained]
-
-    names = asyncio.run(run())
+    sub = _Subscriber(queue_max=4)
+    for i in range(4):
+        sub.publish(SessionEvent(name="chat", data=f"a{i}"))
+    # Two extra publishes push us into the overflow path twice; the
+    # first one injects exactly one error event, the second does NOT
+    # (single-shot per burst).
+    sub.publish(SessionEvent(name="chat", data="b0"))
+    sub.publish(SessionEvent(name="chat", data="b1"))
+    drained = []
+    while not sub.queue.empty():
+        drained.append(sub.queue.get_nowait())
+    names = [e.name for e in drained]
     assert names.count("error") == 1, f"expected exactly one error event; got {names}"
 
 
 def test_overflow_flag_clears_after_queue_drains() -> None:
     """A later overflow burst (after the queue catches up) issues its own
-    error notice, rather than being silently coalesced forever."""
-
-    async def run() -> tuple[int, int]:
-        sub = _Subscriber(queue_max=2)
-        sub.publish(SessionEvent(name="chat", data="a0"))
-        sub.publish(SessionEvent(name="chat", data="a1"))
-        sub.publish(SessionEvent(name="chat", data="b0"))  # first overflow
-        first_names: list[str] = []
-        while not sub.queue.empty():
-            first_names.append(sub.queue.get_nowait().name)
-        # Second burst: first the queue gets a normal publish (clears
-        # the flag because the queue had room), then refills + overflows.
-        sub.publish(SessionEvent(name="chat", data="c0"))
-        sub.publish(SessionEvent(name="chat", data="c1"))
-        sub.publish(SessionEvent(name="chat", data="d0"))  # second overflow
-        second_names: list[str] = []
-        while not sub.queue.empty():
-            second_names.append(sub.queue.get_nowait().name)
-        return first_names.count("error"), second_names.count("error")
-
-    first, second = asyncio.run(run())
-    assert first == 1
-    assert second == 1
+    error notice, rather than being silently coalesced forever. Sync —
+    `_Subscriber.publish` is a plain method."""
+    sub = _Subscriber(queue_max=2)
+    sub.publish(SessionEvent(name="chat", data="a0"))
+    sub.publish(SessionEvent(name="chat", data="a1"))
+    sub.publish(SessionEvent(name="chat", data="b0"))  # first overflow
+    first_names: list[str] = []
+    while not sub.queue.empty():
+        first_names.append(sub.queue.get_nowait().name)
+    # Second burst: first the queue gets a normal publish (clears the
+    # flag because the queue had room), then refills + overflows.
+    sub.publish(SessionEvent(name="chat", data="c0"))
+    sub.publish(SessionEvent(name="chat", data="c1"))
+    sub.publish(SessionEvent(name="chat", data="d0"))  # second overflow
+    second_names: list[str] = []
+    while not sub.queue.empty():
+        second_names.append(sub.queue.get_nowait().name)
+    assert first_names.count("error") == 1
+    assert second_names.count("error") == 1
 
 
 def test_overflow_error_payload_matches_spec() -> None:

--- a/tests/test_session_unit.py
+++ b/tests/test_session_unit.py
@@ -1,0 +1,475 @@
+"""Unit tests for `Session` state transitions and the event bus.
+
+Phase 3 only covers behaviour that doesn't need a live AgentIRC server:
+view-state mutators, no-op safety when the transport is offline, the
+`LensConnectionLost` translation around the send paths, the IRC
+dispatch handlers (driven by hand-built `Message` instances), and the
+`SessionEventBus` overflow contract.
+
+The live transport / connect / read-loop sweep lands in Phase 9b
+against the real AgentIRC server fixture.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from collections.abc import AsyncIterator
+
+import pytest
+
+from irc_lens.irc import Message, MessageBuffer
+from irc_lens.session import (
+    EntityItem,
+    LensConnectionLost,
+    Session,
+    SessionEvent,
+    SessionEventBus,
+    _OVERFLOW_DATA,
+    _Subscriber,
+)
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def offline_session() -> Session:
+    """A Session whose transport is constructed but never connected.
+
+    `IRCTransport.send_*` writes to `self._writer`, which is None until
+    `connect()` runs — so any send is a no-op rather than a real write.
+    Perfect for state-transition tests.
+    """
+    return Session(host="127.0.0.1", port=6667, nick="lens-test")
+
+
+# ---------------------------------------------------------------------------
+# Construction
+# ---------------------------------------------------------------------------
+
+
+def test_session_initial_state(offline_session: Session) -> None:
+    s = offline_session
+    assert s.host == "127.0.0.1"
+    assert s.port == 6667
+    assert s.nick == "lens-test"
+    assert s.icon is None
+    assert s.current_channel == ""
+    assert s.joined_channels == set()
+    assert s.view == "chat"
+    assert s.roster == []
+    assert s.healthy is True
+    assert s.connected is False
+    assert isinstance(s.event_bus, SessionEventBus)
+    assert isinstance(s.buffer, MessageBuffer)
+
+
+def test_session_uses_supplied_event_bus() -> None:
+    bus = SessionEventBus(queue_max=4)
+    s = Session(host="x", port=0, nick="lens", event_bus=bus)
+    assert s.event_bus is bus
+
+
+def test_session_installs_query_handlers(offline_session: Session) -> None:
+    """The transport's dispatch table must include our query numerics."""
+    h = offline_session._transport._cmd_handlers
+    for cmd in ("322", "323", "352", "315", "HISTORY", "HISTORYEND"):
+        assert cmd in h, f"missing dispatcher for {cmd}"
+
+
+# ---------------------------------------------------------------------------
+# View-state mutators
+# ---------------------------------------------------------------------------
+
+
+def test_set_current_channel(offline_session: Session) -> None:
+    offline_session.set_current_channel("#ops")
+    assert offline_session.current_channel == "#ops"
+    offline_session.set_current_channel("")
+    assert offline_session.current_channel == ""
+
+
+def test_set_view(offline_session: Session) -> None:
+    for view in ("chat", "help", "overview", "status"):
+        offline_session.set_view(view)  # type: ignore[arg-type]
+        assert offline_session.view == view
+
+
+def test_set_roster_copies_input(offline_session: Session) -> None:
+    """Mutating the input list afterwards must not mutate session state."""
+    src = [EntityItem(nick="alice", type="human")]
+    offline_session.set_roster(src)
+    src.append(EntityItem(nick="bob", type="agent"))
+    assert [e.nick for e in offline_session.roster] == ["alice"]
+
+
+# ---------------------------------------------------------------------------
+# join / part — no-op safety when offline
+# ---------------------------------------------------------------------------
+
+
+def test_join_non_channel_is_noop(offline_session: Session) -> None:
+    asyncio.run(offline_session.join("not-a-channel"))
+    assert offline_session.joined_channels == set()
+
+
+def test_join_tracks_channel(offline_session: Session) -> None:
+    asyncio.run(offline_session.join("#ops"))
+    asyncio.run(offline_session.join("#general"))
+    assert offline_session.joined_channels == {"#ops", "#general"}
+
+
+def test_part_clears_current_when_active(offline_session: Session) -> None:
+    asyncio.run(offline_session.join("#ops"))
+    offline_session.set_current_channel("#ops")
+    asyncio.run(offline_session.part("#ops"))
+    assert "#ops" not in offline_session.joined_channels
+    assert offline_session.current_channel == ""
+
+
+def test_part_keeps_current_when_inactive(offline_session: Session) -> None:
+    asyncio.run(offline_session.join("#ops"))
+    asyncio.run(offline_session.join("#general"))
+    offline_session.set_current_channel("#general")
+    asyncio.run(offline_session.part("#ops"))
+    assert offline_session.current_channel == "#general"
+    assert offline_session.joined_channels == {"#general"}
+
+
+def test_part_non_channel_is_noop(offline_session: Session) -> None:
+    asyncio.run(offline_session.join("#ops"))
+    asyncio.run(offline_session.part("not-a-channel"))
+    assert offline_session.joined_channels == {"#ops"}
+
+
+# ---------------------------------------------------------------------------
+# LensConnectionLost translation
+# ---------------------------------------------------------------------------
+
+
+def _broken_pipe_transport(session: Session) -> None:
+    """Replace transport send paths with broken-pipe stubs."""
+
+    async def boom_raw(_line: str) -> None:
+        raise BrokenPipeError("simulated")
+
+    async def boom_priv(_target: str, _text: str) -> None:
+        raise ConnectionResetError("simulated")
+
+    async def boom_join(_ch: str) -> None:
+        raise OSError("simulated")
+
+    async def boom_part(_ch: str) -> None:
+        raise ConnectionAbortedError("simulated")
+
+    session._transport.send_raw = boom_raw  # type: ignore[assignment]
+    session._transport.send_privmsg = boom_priv  # type: ignore[assignment]
+    session._transport.join_channel = boom_join  # type: ignore[assignment]
+    session._transport.part_channel = boom_part  # type: ignore[assignment]
+
+
+def test_send_raw_translates_pipe_error(offline_session: Session) -> None:
+    _broken_pipe_transport(offline_session)
+    with pytest.raises(LensConnectionLost):
+        asyncio.run(offline_session.send_raw("PING :x"))
+    assert offline_session.healthy is False
+
+
+def test_send_privmsg_translates_pipe_error(offline_session: Session) -> None:
+    _broken_pipe_transport(offline_session)
+    with pytest.raises(LensConnectionLost):
+        asyncio.run(offline_session.send_privmsg("#ops", "hi"))
+    assert offline_session.healthy is False
+
+
+def test_join_translates_pipe_error(offline_session: Session) -> None:
+    _broken_pipe_transport(offline_session)
+    with pytest.raises(LensConnectionLost):
+        asyncio.run(offline_session.join("#ops"))
+    assert offline_session.healthy is False
+    # Membership state must NOT advance on a failed JOIN.
+    assert "#ops" not in offline_session.joined_channels
+
+
+def test_part_translates_pipe_error(offline_session: Session) -> None:
+    _broken_pipe_transport(offline_session)
+    # Pre-seed the joined set so we can verify it survives a failed PART.
+    offline_session.joined_channels.add("#ops")
+    with pytest.raises(LensConnectionLost):
+        asyncio.run(offline_session.part("#ops"))
+    assert offline_session.healthy is False
+    assert "#ops" in offline_session.joined_channels
+
+
+def test_connect_translates_to_lens_connection_lost() -> None:
+    s = Session(host="127.0.0.1", port=1, nick="lens-test")  # closed port
+
+    async def boom_connect() -> None:
+        raise ConnectionError("Cannot connect")
+
+    s._transport.connect = boom_connect  # type: ignore[assignment]
+    with pytest.raises(LensConnectionLost):
+        asyncio.run(s.connect())
+    assert s.healthy is False
+
+
+# ---------------------------------------------------------------------------
+# Future-based query methods
+# ---------------------------------------------------------------------------
+
+
+def _make_msg(command: str, *params: str) -> Message:
+    return Message(prefix=None, command=command, params=list(params), tags={})
+
+
+def test_list_channels_collects_and_sorts(offline_session: Session) -> None:
+    """Drive _on_rpl_list/_on_rpl_listend by hand and assert sorting."""
+
+    async def run() -> list[str]:
+        sent: list[str] = []
+
+        async def fake_send(line: str) -> None:
+            sent.append(line)
+
+            async def fire() -> None:
+                offline_session._on_rpl_list(_make_msg("322", "lens-test", "#zeta"))
+                offline_session._on_rpl_list(_make_msg("322", "lens-test", "#alpha"))
+                offline_session._on_rpl_list(_make_msg("322", "lens-test", "#mid"))
+                offline_session._on_rpl_listend(_make_msg("323", "lens-test", "End"))
+
+            asyncio.get_running_loop().call_soon(lambda: asyncio.ensure_future(fire()))
+
+        offline_session._transport.send_raw = fake_send  # type: ignore[assignment]
+        result = await offline_session.list_channels()
+        assert sent == ["LIST"]
+        return result
+
+    assert asyncio.run(run()) == ["#alpha", "#mid", "#zeta"]
+
+
+def test_who_collects_entries(offline_session: Session) -> None:
+    async def run() -> list[dict]:
+        async def fake_send(line: str) -> None:
+            async def fire() -> None:
+                offline_session._on_rpl_whoreply(
+                    _make_msg("352", "lens-test", "#ops", "alice", "host1", "srv", "a", "H", "alice real")
+                )
+                offline_session._on_rpl_endofwho(_make_msg("315", "lens-test", "#ops", "End"))
+
+            asyncio.get_running_loop().call_soon(lambda: asyncio.ensure_future(fire()))
+
+        offline_session._transport.send_raw = fake_send  # type: ignore[assignment]
+        return await offline_session.who("#ops")
+
+    entries = asyncio.run(run())
+    assert len(entries) == 1
+    assert entries[0]["nick"] == "a"  # WHO param[5] per upstream shape
+
+
+def test_history_collects_entries(offline_session: Session) -> None:
+    async def run() -> list[dict]:
+        async def fake_send(line: str) -> None:
+            async def fire() -> None:
+                offline_session._on_history(
+                    _make_msg("HISTORY", "#ops", "alice", "1234", "hello")
+                )
+                offline_session._on_historyend(_make_msg("HISTORYEND", "#ops"))
+
+            asyncio.get_running_loop().call_soon(lambda: asyncio.ensure_future(fire()))
+
+        offline_session._transport.send_raw = fake_send  # type: ignore[assignment]
+        return await offline_session.history("#ops", limit=10)
+
+    entries = asyncio.run(run())
+    assert entries == [{"channel": "#ops", "nick": "alice", "timestamp": "1234", "text": "hello"}]
+
+
+def test_query_timeout_returns_partial(offline_session: Session, monkeypatch) -> None:
+    """When the END numeric never arrives, the query times out and returns
+    whatever was collected so far rather than raising."""
+
+    monkeypatch.setattr("irc_lens.session.QUERY_TIMEOUT", 0.05)
+
+    async def run() -> list[str]:
+        async def fake_send(line: str) -> None:
+            offline_session._on_rpl_list(_make_msg("322", "lens-test", "#solo"))
+            # No 323 — wait_for hits the timeout.
+
+        offline_session._transport.send_raw = fake_send  # type: ignore[assignment]
+        return await offline_session.list_channels()
+
+    assert asyncio.run(run()) == ["#solo"]
+
+
+def test_query_clears_state_on_send_failure(offline_session: Session) -> None:
+    """If the underlying send raises LensConnectionLost, we must drop the
+    pending future + collect-buffer; otherwise a retry would deadlock or
+    stack stale state."""
+    _broken_pipe_transport(offline_session)
+    with pytest.raises(LensConnectionLost):
+        asyncio.run(offline_session.list_channels())
+    assert "LIST" not in offline_session._collect_buffers
+    assert "323" not in offline_session._pending
+
+
+# ---------------------------------------------------------------------------
+# SessionEventBus
+# ---------------------------------------------------------------------------
+
+
+def test_event_bus_publish_to_one_subscriber() -> None:
+    bus = SessionEventBus(queue_max=8)
+
+    async def run() -> list[SessionEvent]:
+        received: list[SessionEvent] = []
+        sub = bus.subscribe()
+        # Subscription is registered immediately, so publish-before-iterate
+        # still queues into our subscriber.
+        bus.publish(SessionEvent(name="chat", data="<li>hi</li>"))
+        bus.publish(SessionEvent(name="roster", data="<aside/>"))
+        async for event in sub.events():
+            received.append(event)
+            if len(received) == 2:
+                break
+        return received
+
+    received = asyncio.run(run())
+    assert [(e.name, e.data) for e in received] == [
+        ("chat", "<li>hi</li>"),
+        ("roster", "<aside/>"),
+    ]
+
+
+def test_event_bus_publish_to_multiple_subscribers() -> None:
+    bus = SessionEventBus(queue_max=8)
+
+    async def run() -> tuple[list[str], list[str]]:
+        a = bus.subscribe()
+        b = bus.subscribe()
+        bus.publish(SessionEvent(name="chat", data="<x/>"))
+
+        async def first(sub) -> str:
+            async for event in sub.events():
+                return event.name
+            return ""
+
+        return await asyncio.gather(first(a), first(b))  # type: ignore[return-value]
+
+    a, b = asyncio.run(run())
+    assert a == "chat"
+    assert b == "chat"
+
+
+def test_event_bus_publish_no_subscribers_is_noop() -> None:
+    bus = SessionEventBus()
+    bus.publish(SessionEvent(name="chat", data="ignored"))  # must not raise
+    assert bus.subscriber_count == 0
+
+
+def test_event_bus_overflow_emits_single_error_then_drops() -> None:
+    """Spec: bounded per-subscriber queue, drop-oldest, single overflow error.
+
+    Test directly against `_Subscriber` so we can inspect the queue
+    contents without driving the iterator. A small burst (queue_max=4,
+    push 6) exercises overflow without itself evicting the error event
+    from the queue.
+    """
+
+    async def run() -> list[str]:
+        sub = _Subscriber(queue_max=4)
+        for i in range(4):
+            sub.publish(SessionEvent(name="chat", data=f"a{i}"))
+        # Two extra publishes push us into the overflow path twice; the
+        # first one injects exactly one error event, the second does
+        # NOT (single-shot per burst).
+        sub.publish(SessionEvent(name="chat", data="b0"))
+        sub.publish(SessionEvent(name="chat", data="b1"))
+        drained = []
+        while not sub.queue.empty():
+            drained.append(sub.queue.get_nowait())
+        return [e.name for e in drained]
+
+    names = asyncio.run(run())
+    assert names.count("error") == 1, f"expected exactly one error event; got {names}"
+
+
+def test_overflow_flag_clears_after_queue_drains() -> None:
+    """A later overflow burst (after the queue catches up) issues its own
+    error notice, rather than being silently coalesced forever."""
+
+    async def run() -> tuple[int, int]:
+        sub = _Subscriber(queue_max=2)
+        sub.publish(SessionEvent(name="chat", data="a0"))
+        sub.publish(SessionEvent(name="chat", data="a1"))
+        sub.publish(SessionEvent(name="chat", data="b0"))  # first overflow
+        first_names: list[str] = []
+        while not sub.queue.empty():
+            first_names.append(sub.queue.get_nowait().name)
+        # Second burst: first the queue gets a normal publish (clears
+        # the flag because the queue had room), then refills + overflows.
+        sub.publish(SessionEvent(name="chat", data="c0"))
+        sub.publish(SessionEvent(name="chat", data="c1"))
+        sub.publish(SessionEvent(name="chat", data="d0"))  # second overflow
+        second_names: list[str] = []
+        while not sub.queue.empty():
+            second_names.append(sub.queue.get_nowait().name)
+        return first_names.count("error"), second_names.count("error")
+
+    first, second = asyncio.run(run())
+    assert first == 1
+    assert second == 1
+
+
+def test_overflow_error_payload_matches_spec() -> None:
+    """Overflow error event uses the documented payload shape."""
+    sub = _Subscriber(queue_max=1)
+    sub.publish(SessionEvent(name="chat", data="first"))
+    sub.publish(SessionEvent(name="chat", data="second"))  # triggers overflow
+
+    seen = []
+    while not sub.queue.empty():
+        seen.append(sub.queue.get_nowait())
+    payloads = [e.data for e in seen if e.name == "error"]
+    assert _OVERFLOW_DATA in payloads
+
+
+def test_subscription_close_unregisters() -> None:
+    """Phase 5's SSE handler calls ``Subscription.close()`` from a
+    ``finally`` to handle client-disconnect mid-stream."""
+    bus = SessionEventBus()
+    sub = bus.subscribe()
+    assert bus.subscriber_count == 1
+    sub.close()
+    assert bus.subscriber_count == 0
+    assert sub.closed is True
+
+
+def test_subscription_close_is_idempotent() -> None:
+    bus = SessionEventBus()
+    sub = bus.subscribe()
+    sub.close()
+    sub.close()  # must not raise or double-remove
+    assert bus.subscriber_count == 0
+
+
+def test_subscription_iterator_closes_on_explicit_aclose() -> None:
+    """The events() generator's finally fires on aclose(), unregistering
+    the subscription. The Phase 5 SSE handler will also call
+    Subscription.close() in a `finally` to handle the client-disconnect
+    path where the generator is suspended waiting on `queue.get()` and
+    the consuming task is cancelled before the generator can run its
+    own cleanup."""
+    bus = SessionEventBus(queue_max=4)
+
+    async def run() -> int:
+        sub = bus.subscribe()
+        bus.publish(SessionEvent(name="chat", data="x"))
+        gen = sub.events()
+        async for _ev in gen:
+            break
+        await gen.aclose()
+        return bus.subscriber_count
+
+    assert asyncio.run(run()) == 0


### PR DESCRIPTION
## Summary

Phase 3 of the [build plan](docs/superpowers/plans/2026-04-27-irc-lens-build-plan.md). Adds the `Session` class — the lens's owner of one IRC connection — which wires together the cited transport / buffer / commands and adds the bits the spec asks for that don't belong in a re-cited file.

### What's in the file

- **`LensConnectionLost(ConnectionError)`** — raised by every send path (`send_raw`, `send_privmsg`, `join`, `part`, `connect`) when the underlying socket is broken. Phase 5's `POST /input` will translate this to HTTP 503; meanwhile `Session.healthy` flips to `False` and stays there (no auto-reconnect in v1, per the spec).
- **View state** — `current_channel`, `joined_channels: set[str]`, `view: Literal["chat","help","overview","status"]`, `roster: list[EntityItem]`. Mutators (`set_current_channel`, `set_view`, `set_roster`) are plain state setters for now; Phase 5 will have them publish events.
- **Future-based query methods** — `list_channels()`, `who(target)`, `history(channel, limit)` — implementing the *collect-buffer + asyncio.Future* shape from `culture/console/client.py:206-288`. Reused per the citation-don't-import rule (that file is **not** imported). Per-IRC-numeric handlers (`322`, `323`, `352`, `315`, `HISTORY`, `HISTORYEND`) are registered into `IRCTransport._cmd_handlers` so the transport's existing read loop drives query resolution.
- **`SessionEvent` + `SessionEventBus`** (interface only — SSE wiring is Phase 5). Bounded per-subscriber `asyncio.Queue` (default 256), drop-oldest on overflow, single error event per burst (cleared by the next non-overflow publish). `Subscription` returned by `subscribe()` exposes an explicit `close()` so the SSE handler can clean up from a `finally` block — async-generator finally semantics aren't reliable for suspended-then-cancelled iterators.

### Two minor refactors vs the upstream pattern

1. The 25-line LIST/WHO/HISTORY body upstream duplicates three times is collapsed into a single `_collect_until` helper. Each query verb is now a 5-line wrapper.
2. The `_overflow_flagged` reset moved from the consumer (where I started) to the publisher's non-overflow branch, which gave cleaner "burst" semantics without per-event consumer-side flag tracking.

### Tests (`tests/test_session_unit.py`, 30 cases)

- Initial state, custom event-bus injection, query-handler registration in the dispatch table.
- View-state mutators (incl. `set_roster` defensive copy).
- `join`/`part` no-op safety on non-channels; current-channel cleared when active channel is parted; survives parting an inactive channel.
- `LensConnectionLost` translation across all send paths and `connect()`; state isolation (failed JOIN doesn't advance `joined_channels`; failed PART doesn't discard).
- Future-based queries: hand-built `Message` instances drive `_on_rpl_*` handlers; LIST sorts; WHO/HISTORY round-trip; query timeout returns partial; failed send clears collect-buffer + pending future.
- Event bus: single + multi subscriber, no-subscriber publish, overflow emits exactly one error per burst, flag clears after queue drains, overflow payload matches `{"message":"events dropped"}`, explicit `close()` is idempotent and unregisters, generator `aclose()` triggers cleanup.

## Local verification

\`\`\`text
uv run pytest tests/test_session_unit.py -v   # 30 passed
uv run pytest                                  # 67 passed (was 37 before this PR)
afi cli verify                                 # 22/22, no rubric regression
\`\`\`

## Test plan

- [ ] CI green (test job).
- [ ] SonarCloud Quality Gate passes on the new code.
- [ ] Reviewer can run \`afi cli verify\` locally and see 22/22.

- Claude