### PR TITLE
phase 6: enrich fragments + wire view-switch verbs

### DIFF
--- a/src/irc_lens/session.py
+++ b/src/irc_lens/session.py
@@ -487,15 +487,15 @@ class Session:
         self._publish_info()
 
     async def _exec_help(self, _parsed: ParsedCommand) -> None:
-        await self._switch_view("help")
+        self._switch_view("help")
 
     async def _exec_overview(self, _parsed: ParsedCommand) -> None:
-        await self._switch_view("overview")
+        self._switch_view("overview")
 
     async def _exec_status(self, _parsed: ParsedCommand) -> None:
-        await self._switch_view("status")
+        self._switch_view("status")
 
-    async def _switch_view(self, name: ViewName) -> None:
+    def _switch_view(self, name: ViewName) -> None:
         """Common body for the three view-switch verbs.
 
         Sets `view`, then publishes the spec-strict `view` event
@@ -503,6 +503,12 @@ class Session:
         re-rendered pane for the new view. Two events because they
         target different DOM regions in Phase 7's lens.js: `view`
         toggles `<body data-view>` classes; `info` swaps `#info`.
+
+        Sync because every body call here (set_view, _publish_view,
+        _publish_info) is sync. The three `_exec_*` callers must
+        stay `async def` (dispatch-table contract — `await
+        handler(parsed)` in `Session.execute`) and call this
+        without `await`.
         """
         self.set_view(name)
         self._publish_view()

--- a/src/irc_lens/session.py
+++ b/src/irc_lens/session.py
@@ -519,8 +519,9 @@ class Session:
 
     async def _exec_unsupported(self, parsed: ParsedCommand) -> None:
         # Slash commands defined in commands.py but not yet wired
-        # (TOPIC/WHO/HISTORY/QUIT/HELP/...). Surface a non-fatal error
-        # event rather than 503ing the browser.
+        # (CHANNELS/WHO/READ/AGENTS/START/STOP/RESTART/ICON/TOPIC/
+        # KICK/INVITE/SERVER/QUIT). Surface a non-fatal error event
+        # rather than 503ing the browser.
         self._publish_error(f"{parsed.type.name.lower()}: not yet supported")
 
     async def dispatch(self, msg: Message) -> None:

--- a/src/irc_lens/session.py
+++ b/src/irc_lens/session.py
@@ -22,6 +22,7 @@ from __future__ import annotations
 import asyncio
 import json
 import logging
+import time
 from collections.abc import AsyncIterator
 from dataclasses import dataclass, field
 from typing import Any, Callable, Literal
@@ -422,6 +423,9 @@ class Session:
             CommandType.SEND: self._exec_send,
             CommandType.JOIN: self._exec_join,
             CommandType.PART: self._exec_part,
+            CommandType.HELP: self._exec_help,
+            CommandType.OVERVIEW: self._exec_overview,
+            CommandType.STATUS: self._exec_status,
             CommandType.UNKNOWN: self._exec_unknown,
         }
 
@@ -464,7 +468,11 @@ class Session:
         await self.join(channel)
         self.set_current_channel(channel)
         self._publish_roster()
-        self._publish_view()
+        # JOIN/PART change channel context, not the named view —
+        # publish `info` (per spec line 161, "channel info refreshed"),
+        # not `view` (which is reserved for /help/overview/status switches
+        # per spec line 162).
+        self._publish_info()
 
     async def _exec_part(self, parsed: ParsedCommand) -> None:
         if not parsed.args:
@@ -476,7 +484,29 @@ class Session:
             return
         await self.part(channel)
         self._publish_roster()
+        self._publish_info()
+
+    async def _exec_help(self, _parsed: ParsedCommand) -> None:
+        await self._switch_view("help")
+
+    async def _exec_overview(self, _parsed: ParsedCommand) -> None:
+        await self._switch_view("overview")
+
+    async def _exec_status(self, _parsed: ParsedCommand) -> None:
+        await self._switch_view("status")
+
+    async def _switch_view(self, name: ViewName) -> None:
+        """Common body for the three view-switch verbs.
+
+        Sets `view`, then publishes the spec-strict `view` event
+        (`{view: <name>}`) followed by an `info` event with the
+        re-rendered pane for the new view. Two events because they
+        target different DOM regions in Phase 7's lens.js: `view`
+        toggles `<body data-view>` classes; `info` swaps `#info`.
+        """
+        self.set_view(name)
         self._publish_view()
+        self._publish_info()
 
     async def _exec_unknown(self, parsed: ParsedCommand) -> None:
         self._publish_error(f"unknown command: {parsed.text}")
@@ -530,8 +560,14 @@ class Session:
     def _publish_chat(self, nick: str, text: str) -> None:
         from irc_lens.web.render import render_fragment
 
+        # Pre-format the timestamp so the SSE payload is byte-stable
+        # (the initial-render path goes through a Jinja2 strftime
+        # filter on `BufferedMessage.timestamp`; live publishes use
+        # the wall clock here).
+        ts_display = time.strftime("%H:%M:%S", time.localtime(time.time()))
         fragment = render_fragment(
-            "_chat_line.html.j2", msg={"nick": nick, "text": text}
+            "_chat_line.html.j2",
+            msg={"nick": nick, "text": text, "ts_display": ts_display},
         )
         self.event_bus.publish(SessionEvent(name="chat", data=fragment))
 
@@ -541,10 +577,22 @@ class Session:
         fragment = render_fragment("_sidebar.html.j2", session=self)
         self.event_bus.publish(SessionEvent(name="roster", data=fragment))
 
+    def _publish_info(self) -> None:
+        """Re-render and publish the info pane for the current view.
+
+        Triggered by JOIN/PART (channel context changed) and by view
+        switches (HELP/OVERVIEW/STATUS) — the template branches on
+        ``session.view`` to pick the right per-view content.
+        """
+        from irc_lens.web.render import render_fragment
+
+        fragment = render_fragment("_info.html.j2", session=self)
+        self.event_bus.publish(SessionEvent(name="info", data=fragment))
+
     def _publish_view(self) -> None:
-        payload = json.dumps(
-            {"view": self.view, "current_channel": self.current_channel}
-        )
+        # Spec line 162 defines the payload as `{view: <name>}` only —
+        # nothing else. Channel context belongs in the `info` event.
+        payload = json.dumps({"view": self.view})
         self.event_bus.publish(SessionEvent(name="view", data=payload))
 
     def _publish_error(self, message: str) -> None:

--- a/src/irc_lens/templates/_chat_line.html.j2
+++ b/src/irc_lens/templates/_chat_line.html.j2
@@ -1,4 +1,10 @@
 <div data-testid="chat-line" class="lens-chat-line">
+  {# Live SSE publishes pass `ts_display` (pre-formatted string) so the
+     wire payload is byte-stable. Initial render receives BufferedMessage
+     which has a numeric `timestamp` — fall back through the strftime
+     filter for that path. Either branch ends up rendering an HH:MM:SS
+     stamp in the same span. #}
+  <span class="lens-chat-ts">{{ msg.ts_display if msg.ts_display is defined else (msg.timestamp|strftime) }}</span>
   <span data-testid="chat-line-nick" class="lens-chat-nick">{{ msg.nick }}</span>
   <span data-testid="chat-line-text" class="lens-chat-text">{{ msg.text }}</span>
 </div>

--- a/src/irc_lens/templates/_info.html.j2
+++ b/src/irc_lens/templates/_info.html.j2
@@ -2,7 +2,55 @@
   <span data-testid="view-indicator" data-view="{{ session.view }}" class="lens-view">
     view: {{ session.view }}
   </span>
-  {% if session.current_channel %}
-    <p class="lens-info-channel">channel: {{ session.current_channel }}</p>
+  {% if session.view == "help" %}
+    <section class="lens-info-help">
+      <h2>Slash commands</h2>
+      <dl>
+        <dt><code>/join #channel</code></dt><dd>Join a channel and switch the chat pane to it.</dd>
+        <dt><code>/part #channel</code></dt><dd>Leave a channel.</dd>
+        <dt><code>/send target text…</code></dt><dd>Send a message to a specific channel or nick.</dd>
+        <dt><code>/help</code></dt><dd>Show this help pane.</dd>
+        <dt><code>/overview</code></dt><dd>Show the joined-channels overview.</dd>
+        <dt><code>/status</code></dt><dd>Show the connection / session status pane.</dd>
+        <dt><em>(plain text)</em></dt><dd>Sends a message to the active channel.</dd>
+      </dl>
+    </section>
+  {% elif session.view == "overview" %}
+    <section class="lens-info-overview">
+      <h2>Joined channels ({{ session.joined_channels|length }})</h2>
+      {% if session.joined_channels %}
+        <ul>
+          {% for ch in session.joined_channels|sort %}
+            <li>
+              <code>{{ ch }}</code>
+              {% if ch == session.current_channel %}<small>(active)</small>{% endif %}
+            </li>
+          {% endfor %}
+        </ul>
+      {% else %}
+        <p class="lens-info-empty">No channels joined. Try <code>/join #general</code>.</p>
+      {% endif %}
+    </section>
+  {% elif session.view == "status" %}
+    <section class="lens-info-status">
+      <h2>Session status</h2>
+      <dl>
+        <dt>Nick</dt><dd>{{ session.nick }}</dd>
+        <dt>Server</dt><dd>{{ session.host }}:{{ session.port }}</dd>
+        <dt>Connected</dt><dd>{{ "yes" if session.connected else "no" }}</dd>
+        <dt>Healthy</dt><dd>{{ "yes" if session.healthy else "no" }}</dd>
+        <dt>Channels</dt><dd>{{ session.joined_channels|length }}</dd>
+        <dt>SSE subscribers</dt><dd>{{ session.event_bus.subscriber_count }}</dd>
+      </dl>
+    </section>
+  {% else %}
+    <section class="lens-info-chat">
+      {% if session.current_channel %}
+        <p class="lens-info-channel">channel: <code>{{ session.current_channel }}</code></p>
+        <p class="lens-info-topic">Topic: <em>not set</em></p>
+      {% else %}
+        <p class="lens-info-empty">No active channel. <code>/join #general</code> to start.</p>
+      {% endif %}
+    </section>
   {% endif %}
 </div>

--- a/src/irc_lens/web/render.py
+++ b/src/irc_lens/web/render.py
@@ -9,6 +9,7 @@ ship in the wheel without a separate ``MANIFEST.in``.
 
 from __future__ import annotations
 
+import time
 from typing import TYPE_CHECKING, Any
 
 from jinja2 import Environment, PackageLoader, select_autoescape
@@ -17,12 +18,26 @@ if TYPE_CHECKING:
     from irc_lens.session import Session
 
 
+def _strftime(value: Any, fmt: str = "%H:%M:%S") -> str:
+    """Jinja2 filter: format a UNIX timestamp.
+
+    Used by `_chat_line.html.j2` for the initial-render path, which
+    receives `BufferedMessage` instances that carry a raw `timestamp`
+    (float). Live SSE publishes pre-format the string (`ts_display`)
+    in Python so the wire payload is byte-stable.
+    """
+    if value is None:
+        return ""
+    return time.strftime(fmt, time.localtime(float(value)))
+
+
 _env = Environment(
     loader=PackageLoader("irc_lens", "templates"),
     autoescape=select_autoescape(["html", "html.j2"]),
     trim_blocks=True,
     lstrip_blocks=True,
 )
+_env.filters["strftime"] = _strftime
 
 
 def render_fragment(template: str, **ctx: Any) -> str:

--- a/tests/test_render.py
+++ b/tests/test_render.py
@@ -12,9 +12,10 @@ guard against here:
    each branch must render identifiable content (so the SSE
    consumer can tell the four views apart).
 3. **Autoescape** — Jinja2's autoescape policy is set on
-   `[".html", ".html.j2"]`; nick/text containing `<` must not
-   render as raw HTML in the chat fragment (this is the same XSS
-   path that PR #6 closed by renaming `.j2` → `.html.j2`).
+   `["html", "html.j2"]` (extensions, no leading dots — see
+   `web/render.py`); nick/text containing `<` must not render as
+   raw HTML in the chat fragment (this is the same XSS path that
+   PR #6 closed by renaming `.j2` → `.html.j2`).
 """
 
 from __future__ import annotations

--- a/tests/test_render.py
+++ b/tests/test_render.py
@@ -1,0 +1,156 @@
+"""Template-rendering unit tests (Phase 6).
+
+Exercises `render_fragment` directly so the per-fragment shape is
+locked independently of the SSE / aiohttp surface. Three things we
+guard against here:
+
+1. **DOM contract drift** — every fragment that the spec's testid
+   table promises must keep emitting that `data-testid`. Phase 7's
+   browser glue and Phase 9c's Playwright tests will both grep for
+   these attributes.
+2. **Per-view content** — `_info.html.j2` branches on `session.view`;
+   each branch must render identifiable content (so the SSE
+   consumer can tell the four views apart).
+3. **Autoescape** — Jinja2's autoescape policy is set on
+   `[".html", ".html.j2"]`; nick/text containing `<` must not
+   render as raw HTML in the chat fragment (this is the same XSS
+   path that PR #6 closed by renaming `.j2` → `.html.j2`).
+"""
+
+from __future__ import annotations
+
+import time
+
+import pytest
+
+from irc_lens.session import EntityItem, Session
+from irc_lens.web.render import render_fragment
+
+
+@pytest.fixture
+def session() -> Session:
+    return Session(host="127.0.0.1", port=6667, nick="lens-test")
+
+
+# ---------------------------------------------------------------------------
+# _chat_line.html.j2
+# ---------------------------------------------------------------------------
+
+
+def test_chat_line_renders_all_required_testids() -> None:
+    out = render_fragment(
+        "_chat_line.html.j2",
+        msg={"nick": "alice", "text": "hello", "ts_display": "12:34:56"},
+    )
+    assert 'data-testid="chat-line"' in out
+    assert 'data-testid="chat-line-nick"' in out
+    assert 'data-testid="chat-line-text"' in out
+    assert "12:34:56" in out
+    assert "alice" in out
+    assert "hello" in out
+
+
+def test_chat_line_falls_back_to_strftime_for_initial_render() -> None:
+    """Initial render path: msg is a `BufferedMessage`-shaped object
+    with `.timestamp` (float), no `.ts_display`. The template uses
+    the `strftime` filter, which formats in local time — assert
+    against that same formatting so this test is timezone-stable."""
+
+    ts = time.time()
+    expected = time.strftime("%H:%M:%S", time.localtime(ts))
+
+    class _Buf:
+        nick = "bob"
+        text = "from history"
+        timestamp = ts
+
+    out = render_fragment("_chat_line.html.j2", msg=_Buf())
+    assert expected in out
+    assert "bob" in out
+
+
+def test_chat_line_escapes_html_in_nick_and_text() -> None:
+    """Autoescape must defeat the obvious XSS path through chat fields."""
+    out = render_fragment(
+        "_chat_line.html.j2",
+        msg={
+            "nick": "<script>x</script>",
+            "text": "<img onerror=y>",
+            "ts_display": "00:00:00",
+        },
+    )
+    assert "<script>" not in out
+    assert "<img" not in out
+    assert "&lt;script&gt;" in out
+
+
+# ---------------------------------------------------------------------------
+# _info.html.j2 — per-view branches
+# ---------------------------------------------------------------------------
+
+
+def test_info_chat_view_shows_active_channel(session: Session) -> None:
+    session.set_current_channel("#general")
+    out = render_fragment("_info.html.j2", session=session)
+    assert 'data-testid="view-indicator"' in out
+    assert 'data-view="chat"' in out
+    assert "#general" in out
+
+
+def test_info_chat_view_empty_state(session: Session) -> None:
+    out = render_fragment("_info.html.j2", session=session)
+    assert "No active channel" in out
+
+
+def test_info_help_view_lists_slash_commands(session: Session) -> None:
+    session.set_view("help")
+    out = render_fragment("_info.html.j2", session=session)
+    assert 'data-view="help"' in out
+    assert "Slash commands" in out
+    for cmd in ("/join", "/part", "/send", "/help", "/overview", "/status"):
+        assert cmd in out, f"help view missing {cmd}"
+
+
+def test_info_overview_view_lists_joined_channels(session: Session) -> None:
+    session.joined_channels.add("#ops")
+    session.joined_channels.add("#dev")
+    session.set_current_channel("#ops")
+    session.set_view("overview")
+    out = render_fragment("_info.html.j2", session=session)
+    assert 'data-view="overview"' in out
+    assert "Joined channels" in out
+    assert "#dev" in out
+    assert "#ops" in out
+    assert "(active)" in out  # marks current_channel
+
+
+def test_info_overview_empty_state(session: Session) -> None:
+    session.set_view("overview")
+    out = render_fragment("_info.html.j2", session=session)
+    assert "No channels joined" in out
+
+
+def test_info_status_view_shows_session_metadata(session: Session) -> None:
+    session.set_view("status")
+    out = render_fragment("_info.html.j2", session=session)
+    assert 'data-view="status"' in out
+    assert "Session status" in out
+    assert "lens-test" in out  # nick
+    assert "127.0.0.1" in out  # host
+    assert "6667" in out  # port
+
+
+# ---------------------------------------------------------------------------
+# _sidebar.html.j2 — testid contract
+# ---------------------------------------------------------------------------
+
+
+def test_sidebar_pins_testid_contract(session: Session) -> None:
+    session.joined_channels.add("#ops")
+    session.set_current_channel("#ops")
+    session.set_roster([EntityItem(nick="alice", type="human")])
+    out = render_fragment("_sidebar.html.j2", session=session)
+    assert 'data-testid="sidebar-channel"' in out
+    assert 'data-channel="#ops"' in out
+    assert 'data-testid="sidebar-entity"' in out
+    assert 'data-nick="alice"' in out

--- a/tests/test_session_dispatch.py
+++ b/tests/test_session_dispatch.py
@@ -54,7 +54,11 @@ def _run(coro):
 # ---------------------------------------------------------------------------
 
 
-def test_execute_join_publishes_roster_and_view(session: Session) -> None:
+def test_execute_join_publishes_roster_and_info(session: Session) -> None:
+    """JOIN changes channel context — publishes `roster` (channel list
+    changed) and `info` (channel context changed). Per spec line 162
+    the `view` event is reserved for /help/overview/status switches,
+    so it must NOT fire here."""
     sub = session.event_bus.subscribe()
     asyncio.run(session.execute(ParsedCommand(type=CommandType.JOIN, args=["#ops"])))
     events = []
@@ -66,14 +70,19 @@ def test_execute_join_publishes_roster_and_view(session: Session) -> None:
     assert session.current_channel == "#ops"
     names = [e.name for e in events]
     assert "roster" in names
-    assert "view" in names
+    assert "info" in names
+    assert "view" not in names, (
+        "JOIN must not publish a `view` event — that's reserved for "
+        "/help/overview/status (spec line 162)."
+    )
     # The roster fragment carries the channel testid + data attribute.
     roster = next(e for e in events if e.name == "roster")
     assert 'data-testid="sidebar-channel"' in roster.data
     assert 'data-channel="#ops"' in roster.data
-    # View payload is JSON with current_channel set.
-    view = next(e for e in events if e.name == "view")
-    assert json.loads(view.data)["current_channel"] == "#ops"
+    # The info fragment carries the view-indicator and the new channel.
+    info = next(e for e in events if e.name == "info")
+    assert 'data-testid="view-indicator"' in info.data
+    assert "#ops" in info.data
 
 
 def test_execute_join_without_args_publishes_error(session: Session) -> None:
@@ -273,3 +282,65 @@ def test_dispatch_join_publishes_roster(session: Session) -> None:
         events.append(sub._sub.queue.get_nowait())
     sub.close()
     assert any(e.name == "roster" for e in events)
+
+
+# ---------------------------------------------------------------------------
+# Phase 6: view-switch verbs (/help, /overview, /status)
+# ---------------------------------------------------------------------------
+
+
+def _events_after(session: Session, parsed: ParsedCommand) -> list[SessionEvent]:
+    sub = session.event_bus.subscribe()
+    asyncio.run(session.execute(parsed))
+    out: list[SessionEvent] = []
+    while not sub._sub.queue.empty():
+        out.append(sub._sub.queue.get_nowait())
+    sub.close()
+    return out
+
+
+def test_execute_help_switches_view_and_publishes_info(session: Session) -> None:
+    events = _events_after(session, ParsedCommand(type=CommandType.HELP))
+    assert session.view == "help"
+    names = [e.name for e in events]
+    assert names.count("view") == 1
+    assert names.count("info") == 1
+    view = next(e for e in events if e.name == "view")
+    payload = json.loads(view.data)
+    assert payload == {"view": "help"}, (
+        "spec line 162 defines the view payload as `{view: <name>}` only"
+    )
+    info = next(e for e in events if e.name == "info")
+    assert "Slash commands" in info.data
+    assert 'data-testid="view-indicator"' in info.data
+    assert 'data-view="help"' in info.data
+
+
+def test_execute_overview_switches_view(session: Session) -> None:
+    session.joined_channels.add("#ops")
+    session.joined_channels.add("#dev")
+    session.set_current_channel("#ops")
+    events = _events_after(session, ParsedCommand(type=CommandType.OVERVIEW))
+    assert session.view == "overview"
+    info = next(e for e in events if e.name == "info")
+    assert "Joined channels" in info.data
+    assert "#dev" in info.data
+    assert "#ops" in info.data
+
+
+def test_execute_status_switches_view(session: Session) -> None:
+    events = _events_after(session, ParsedCommand(type=CommandType.STATUS))
+    assert session.view == "status"
+    info = next(e for e in events if e.name == "info")
+    assert "Session status" in info.data
+    # Status pane shows nick/server.
+    assert "lens-test" in info.data
+
+
+def test_view_event_payload_is_spec_strict(session: Session) -> None:
+    """`view` payload must be exactly {view: <name>} — nothing else."""
+    events = _events_after(session, ParsedCommand(type=CommandType.HELP))
+    view = next(e for e in events if e.name == "view")
+    payload = json.loads(view.data)
+    assert set(payload.keys()) == {"view"}
+    assert payload["view"] in ("chat", "help", "overview", "status")


### PR DESCRIPTION
## Summary

- Each SSE event type from the spec's table (line 153–164) now produces a real, populated fragment that HTMX can swap; `/help`, `/overview`, `/status` are reachable from the chat input.
- **Spec compliance fix:** the `view` event payload was `{view, current_channel}` from Phase 5; spec line 162 defines it as `{view: <name>}` only. Channel context now flows through `info` (spec line 161). JOIN/PART switched from publishing `view` to publishing `info`.
- **`_info.html.j2`** branches on `session.view`: chat / help / overview / status, each with the `view-indicator` testid + a `data-view` attribute on the top span.
- **`_chat_line.html.j2`** gains a timestamp span. Live publishes pre-format `ts_display` in Python (byte-stable SSE payload); the initial-render path falls through a new `strftime` Jinja2 filter on `BufferedMessage.timestamp`.
- 14 new tests (10 in new `tests/test_render.py`, 4 in `test_session_dispatch.py`) — pin testid contract per fragment, per-view branches in `_info`, autoescape XSS guard on chat nick/text, spec-strict `view` payload, no-`view`-on-JOIN regression guard.

## Test plan

- [x] `uv run pytest -v` — **136/136** green
- [x] `afi cli verify` — **22/22**
- [x] Manual smoke: `/help` → view+info, `/join #ops` → roster+info (no view), `hello` → chat with HH:MM:SS prefix, `/overview` and `/status` → view+info each. All emit the right event sequence end-to-end.

## Build-plan reference

`docs/superpowers/plans/2026-04-27-irc-lens-build-plan.md` Phase 6 (lines 200–215). Verification gate met.

🤖 Generated with [Claude Code](https://claude.com/claude-code)