### PR TITLE
phase 9b: HTTP e2e + thin AgentIRC test fixture

### DIFF
--- a/tests/README.md
+++ b/tests/README.md
@@ -1,0 +1,50 @@
+# `irc-lens` test layout
+
+Three layers:
+
+| Layer | Files | Drives |
+| --- | --- | --- |
+| Unit | `test_commands.py`, `test_render.py`, `test_session_unit.py`, `test_session_dispatch.py`, `test_seed.py`, `test_lens_js.py`, `test_web_skeleton.py`, `test_serve_cli.py` | Pure functions, single classes, single Jinja2 templates. No sockets. |
+| HTTP e2e | `test_e2e_http.py` (Phase 9b) | Real `aiohttp.web.Application` driven by `aiohttp.test_utils.TestClient` against a real connected `Session` against a thin AgentIRC server (`_agentirc_server.py`). |
+| Browser e2e | `test_e2e_playwright.py` (Phase 9c, opt-in) | Same fixture stack as HTTP e2e + a chromium browser via pytest-playwright. Marker: `@pytest.mark.playwright`. Run via `pytest -m playwright`. |
+
+## AgentIRC test fixture: why option (b)
+
+The Phase 8 spec offered two paths:
+
+- **(a)** Pull `culture` as a pinned dev dep and import its AgentIRC server fixture.
+- **(b)** Carry a thin AgentIRC test server in this repo (`_agentirc_server.py`).
+
+We took **(b)**. `culture/agentirc/ircd.py` transitively imports `culture.bots.virtual_client`, telemetry/OTel infrastructure, skills, history-store, and protocol modules — pulling those in as a dev dep would massively bloat irc-lens's test environment for ~10 e2e cases. The thin server is ~120 lines and has zero dependencies outside `asyncio`.
+
+The fallback is documented in the build plan (Phase 9b, lines 272–274) as the cleaner-boundary option even if it's slightly more work.
+
+## What `_agentirc_server.py` does
+
+- Binds `127.0.0.1:0` (random port). Tests read the assigned port back.
+- Per connection, line-buffered read loop. Records every line into `server.received: list[_ReceivedLine]`.
+- For `JOIN #x` and `PART #x`, echoes `:<nick>!<nick>@test JOIN :#x` so the lens's `Session.dispatch` listener fires (matches what real ircds send).
+- For `NICK`/`USER`/`PRIVMSG`/`TOPIC`/`QUIT` — silently consumes. No welcome reply needed; `Session.connect()` returns as soon as the TCP connection is up.
+
+## Adding a new HTTP e2e test
+
+```python
+async def test_my_thing(lens_client, agentirc_server):
+    # 1. drive the lens via the test client
+    resp = await lens_client.post("/input", json={"text": "/join #x"})
+    assert resp.status == 204
+
+    # 2. assert what the lens sent on the wire
+    line = await _wait_for_received(agentirc_server, "JOIN", "#x")
+    assert line.params == ["#x"]
+```
+
+`_wait_for_received` is the polling helper in `test_e2e_http.py`. Use it instead of `asyncio.sleep` — it has a 1 s default timeout and prints what *was* received on failure, which makes flakes easy to diagnose.
+
+## Playwright (Phase 9c, opt-in)
+
+Not yet written. Will land in a separate PR with:
+
+- `tests/test_e2e_playwright.py` using `--seed tests/fixtures/basic.yaml` for deterministic DOM.
+- A separate CI job that runs `pytest -m playwright` after `playwright install chromium`.
+- Default `pytest` invocation continues to skip the browser tests.

--- a/tests/_agentirc_server.py
+++ b/tests/_agentirc_server.py
@@ -1,0 +1,156 @@
+"""Thin AgentIRC test server for HTTP e2e tests.
+
+Spec / build-plan offered two paths for the HTTP e2e fixture:
+(a) import a fixture from the ``culture`` package as a pinned dev
+dep, or (b) carry a thin AgentIRC test server in this repo. We took
+(b) — culture's ``culture/agentirc/ircd.py`` transitively imports
+``virtual_client``, telemetry, skills, history-store, and protocol
+modules that would balloon the test environment for a small number
+of e2e cases. This module is ~120 lines and exists only for tests.
+
+Underscore prefix keeps pytest from collecting it as a test module.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from dataclasses import dataclass, field
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class _ReceivedLine:
+    """A single line the lens sent to the server."""
+
+    raw: str
+    command: str
+    params: list[str] = field(default_factory=list)
+    trailing: str | None = None
+
+
+def _parse_line(raw: str) -> _ReceivedLine:
+    """Minimal IRC line parser — enough to pick out command + params.
+
+    The lens never sends tagged lines or prefixes (it's a client),
+    so we don't need ``Message.parse``'s full surface. Keeping this
+    in-test instead of importing keeps the test fixture independent
+    of the production parser's evolution.
+    """
+    line = raw.rstrip("\r\n")
+    trailing: str | None = None
+    if " :" in line:
+        line, trailing = line.split(" :", 1)
+    parts = line.split(" ") if line else []
+    if not parts:
+        return _ReceivedLine(raw=raw, command="", params=[], trailing=trailing)
+    command = parts[0].upper()
+    params = parts[1:]
+    if trailing is not None:
+        params = [*params, trailing]
+    return _ReceivedLine(raw=raw, command=command, params=params, trailing=trailing)
+
+
+class AgentIRCTestServer:
+    """Bind ``127.0.0.1:0`` and behave just enough like an AgentIRC
+    server to keep ``Session.connect`` happy and let tests assert on
+    what the lens sent.
+
+    Public surface:
+      - ``host`` / ``port`` after :meth:`start`.
+      - ``received: list[_ReceivedLine]`` — every line the lens sent
+        across every connection (one server per test, so this is
+        per-test state).
+      - :meth:`start` / :meth:`stop` lifecycle.
+    """
+
+    def __init__(self) -> None:
+        self.host: str = "127.0.0.1"
+        self.port: int = 0
+        self.received: list[_ReceivedLine] = []
+        self._server: asyncio.base_events.Server | None = None
+        self._client_writers: list[asyncio.StreamWriter] = []
+        self._nick: str | None = None  # captured from the first NICK line
+
+    async def start(self) -> None:
+        self._server = await asyncio.start_server(
+            self._handle, host=self.host, port=0
+        )
+        self.port = self._server.sockets[0].getsockname()[1]
+
+    async def stop(self) -> None:
+        # Close client writers first so per-connection coroutines
+        # exit cleanly; then close the listening socket.
+        for w in self._client_writers:
+            try:
+                w.close()
+            except Exception as exc:
+                logger.debug("test server: writer close ignored: %s", exc)
+        self._client_writers.clear()
+        if self._server is not None:
+            self._server.close()
+            await self._server.wait_closed()
+            self._server = None
+
+    async def _handle(
+        self, reader: asyncio.StreamReader, writer: asyncio.StreamWriter
+    ) -> None:
+        self._client_writers.append(writer)
+        try:
+            while True:
+                raw = await reader.readline()
+                if not raw:
+                    return
+                line = _parse_line(raw.decode("utf-8", errors="replace"))
+                if line.command == "":
+                    continue
+                self.received.append(line)
+                await self._respond(line, writer)
+        except (ConnectionResetError, asyncio.CancelledError):
+            return
+        except Exception as exc:
+            # Per-connection error — log and exit, don't take the
+            # test server down for the next test.
+            logger.debug("test server: connection error: %s", exc)
+        finally:
+            try:
+                writer.close()
+            except Exception as exc:
+                logger.debug("test server: writer close in finally ignored: %s", exc)
+
+    async def _respond(
+        self, line: _ReceivedLine, writer: asyncio.StreamWriter
+    ) -> None:
+        if line.command == "NICK" and line.params:
+            self._nick = line.params[0]
+            return
+        if line.command == "USER":
+            return
+        if line.command == "JOIN" and line.params:
+            await self._echo_membership(writer, "JOIN", line.params[0])
+            return
+        if line.command == "PART" and line.params:
+            await self._echo_membership(writer, "PART", line.params[0])
+            return
+        # PRIVMSG / TOPIC / QUIT etc. — just record, no echo. Real
+        # IRC daemons don't echo PRIVMSGs to the sender; the lens
+        # publishes its own chat event from the local-echo path.
+        return
+
+    async def _echo_membership(
+        self, writer: asyncio.StreamWriter, verb: str, channel: str
+    ) -> None:
+        """Send a server-confirmed JOIN/PART back to the lens.
+
+        Format: ``:<nick>!<nick>@test JOIN :#channel`` — matches what
+        a real ircd sends and what `Session.dispatch`'s JOIN/PART
+        listener parses.
+        """
+        nick = self._nick or "lens"
+        line = f":{nick}!{nick}@test {verb} :{channel}\r\n"
+        try:
+            writer.write(line.encode("utf-8"))
+            await writer.drain()
+        except (ConnectionResetError, BrokenPipeError) as exc:
+            logger.debug("test server: echo write failed: %s", exc)

--- a/tests/_agentirc_server.py
+++ b/tests/_agentirc_server.py
@@ -80,14 +80,21 @@ class AgentIRCTestServer:
         self.port = self._server.sockets[0].getsockname()[1]
 
     async def stop(self) -> None:
-        # Close client writers first so per-connection coroutines
-        # exit cleanly; then close the listening socket.
-        for w in self._client_writers:
+        # Close client writers and AWAIT wait_closed so transports
+        # don't end up half-closed (which trips "unclosed transport"
+        # ResourceWarnings in pytest-asyncio teardown).
+        writers = list(self._client_writers)
+        self._client_writers.clear()
+        for w in writers:
             try:
                 w.close()
             except Exception as exc:
                 logger.debug("test server: writer close ignored: %s", exc)
-        self._client_writers.clear()
+        if writers:
+            await asyncio.gather(
+                *(w.wait_closed() for w in writers),
+                return_exceptions=True,
+            )
         if self._server is not None:
             self._server.close()
             await self._server.wait_closed()
@@ -107,8 +114,13 @@ class AgentIRCTestServer:
                     continue
                 self.received.append(line)
                 await self._respond(line, writer)
-        except (ConnectionResetError, asyncio.CancelledError):
+        except ConnectionResetError:
             return
+        except asyncio.CancelledError:
+            # Re-raise so task cancellation semantics propagate
+            # cleanly through fixture teardown — matches the
+            # transport's read-loop pattern.
+            raise
         except Exception as exc:
             # Per-connection error — log and exit, don't take the
             # test server down for the next test.
@@ -136,7 +148,6 @@ class AgentIRCTestServer:
         # PRIVMSG / TOPIC / QUIT etc. — just record, no echo. Real
         # IRC daemons don't echo PRIVMSGs to the sender; the lens
         # publishes its own chat event from the local-echo path.
-        return
 
     async def _echo_membership(
         self, writer: asyncio.StreamWriter, verb: str, channel: str

--- a/tests/_agentirc_server.py
+++ b/tests/_agentirc_server.py
@@ -144,7 +144,6 @@ class AgentIRCTestServer:
             return
         if line.command == "PART" and line.params:
             await self._echo_membership(writer, "PART", line.params[0])
-            return
         # PRIVMSG / TOPIC / QUIT etc. — just record, no echo. Real
         # IRC daemons don't echo PRIVMSGs to the sender; the lens
         # publishes its own chat event from the local-echo path.

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,70 @@
+"""Test fixtures shared across the suite.
+
+Phase 9b adds the e2e fixture stack: a thin AgentIRC test server
+(``_agentirc_server.py``), a connected ``Session`` against that
+server, and an aiohttp test client driving the lens's real
+``Application``. See ``tests/README.md`` for the rationale on
+choosing the in-tree server over pulling ``culture`` as a dev
+dep.
+"""
+
+from __future__ import annotations
+
+from collections.abc import AsyncIterator
+
+import pytest_asyncio
+from aiohttp import web
+from aiohttp.test_utils import TestClient, TestServer
+
+from irc_lens.session import Session
+from irc_lens.web import make_app
+
+from _agentirc_server import AgentIRCTestServer
+
+
+@pytest_asyncio.fixture
+async def agentirc_server() -> AsyncIterator[AgentIRCTestServer]:
+    """Function-scoped: each test gets a fresh server bound to a
+    random port. Teardown closes the listening socket and any open
+    client connections."""
+    server = AgentIRCTestServer()
+    await server.start()
+    try:
+        yield server
+    finally:
+        await server.stop()
+
+
+@pytest_asyncio.fixture
+async def lens_session(agentirc_server: AgentIRCTestServer) -> AsyncIterator[Session]:
+    """A fully-connected ``Session`` against the test server.
+
+    Connection happens inside the fixture so individual tests don't
+    repeat the boilerplate; teardown calls ``disconnect()`` which
+    sends QUIT (the test server silently consumes it).
+    """
+    session = Session(host=agentirc_server.host, port=agentirc_server.port, nick="lens-test")
+    await session.connect()
+    try:
+        yield session
+    finally:
+        await session.disconnect()
+
+
+@pytest_asyncio.fixture
+async def lens_client(lens_session: Session) -> AsyncIterator[TestClient]:
+    """An aiohttp ``TestClient`` driving the lens's real
+    ``Application`` against ``lens_session``.
+
+    Tests get ``client.get('/')``, ``client.post('/input', ...)``,
+    streaming via ``client.get('/events')`` — the same handlers
+    production traffic hits, just without binding a real port.
+    """
+    app: web.Application = make_app(lens_session)
+    test_server = TestServer(app)
+    client = TestClient(test_server)
+    await client.start_server()
+    try:
+        yield client
+    finally:
+        await client.close()

--- a/tests/test_e2e_http.py
+++ b/tests/test_e2e_http.py
@@ -16,10 +16,10 @@ transport to write JOIN #x within 100 ms" are a single
 from __future__ import annotations
 
 import asyncio
-import json
 
-import pytest
 from aiohttp.test_utils import TestClient
+
+from irc_lens.session import Session
 
 from _agentirc_server import AgentIRCTestServer, _ReceivedLine
 
@@ -32,21 +32,26 @@ async def _wait_for_received(
 ) -> _ReceivedLine:
     """Poll ``server.received`` until a matching line appears.
 
-    Cheaper and easier to reason about than wiring an asyncio.Event
-    on every line — tests run on localhost loopback and the lens
-    flushes ``send_raw`` through ``writer.drain``, so the line
-    typically lands within a few ms.
+    Wraps the poll loop in :func:`asyncio.timeout` (Python 3.11+) so
+    a stuck wire shows up as a clean ``AssertionError`` with the
+    received history rather than as a runtime hang.
     """
-    deadline = asyncio.get_event_loop().time() + timeout
-    while asyncio.get_event_loop().time() < deadline:
-        for line in server.received:
-            if line.command == command and list(params) == line.params[: len(params)]:
-                return line
-        await asyncio.sleep(0.01)
-    raise AssertionError(
-        f"timed out after {timeout}s waiting for {command} {list(params)} — "
-        f"server received: {[(line.command, line.params) for line in server.received]}"
-    )
+
+    async def _poll() -> _ReceivedLine:
+        while True:
+            for line in server.received:
+                if line.command == command and list(params) == line.params[: len(params)]:
+                    return line
+            await asyncio.sleep(0.01)
+
+    try:
+        async with asyncio.timeout(timeout):
+            return await _poll()
+    except TimeoutError as exc:
+        raise AssertionError(
+            f"timed out after {timeout}s waiting for {command} {list(params)} — "
+            f"server received: {[(line.command, line.params) for line in server.received]}"
+        ) from exc
 
 
 # ---------------------------------------------------------------------------
@@ -130,33 +135,41 @@ async def test_post_input_413_on_oversize_body(lens_client: TestClient) -> None:
 
 
 async def test_get_events_streams_roster_after_join(
-    lens_client: TestClient, agentirc_server: AgentIRCTestServer
+    lens_client: TestClient,
+    agentirc_server: AgentIRCTestServer,
+    lens_session: Session,
 ) -> None:
     """Open SSE, then trigger a /join via POST /input. The roster
-    event should land on the stream within ~1 s."""
+    event should land on the stream within ~1 s.
+
+    Race-free: instead of sleeping a fixed amount to "ensure" the
+    subscriber registered, we wait on
+    ``lens_session.event_bus.subscriber_count`` so the JOIN cannot
+    publish before the SSE handler is in the bus."""
 
     async def collect_event() -> bytes:
         resp = await lens_client.get("/events")
         assert resp.status == 200
         assert resp.headers["Content-Type"].startswith("text/event-stream")
-        # Read until we see a `roster` event, with a hard cap so a
-        # broken bus doesn't hang the test runner.
         buf = b""
-        deadline = asyncio.get_event_loop().time() + 2.0
-        while asyncio.get_event_loop().time() < deadline:
-            chunk = await asyncio.wait_for(resp.content.read(1024), timeout=2.0)
-            if not chunk:
-                break
-            buf += chunk
-            if b"event: roster" in buf:
-                resp.close()
-                return buf
-        resp.close()
-        raise AssertionError(f"no roster event in {buf!r}")
+        try:
+            async with asyncio.timeout(2.0):
+                while b"event: roster" not in buf:
+                    chunk = await resp.content.read(1024)
+                    if not chunk:
+                        break
+                    buf += chunk
+        finally:
+            resp.close()
+        return buf
 
     collector = asyncio.create_task(collect_event())
-    # Tiny delay so the SSE subscriber registers before we publish.
-    await asyncio.sleep(0.05)
+    # Wait for the SSE handler to actually register on the bus
+    # before publishing — closes the race the previous fixed-sleep
+    # version had.
+    async with asyncio.timeout(1.0):
+        while lens_session.event_bus.subscriber_count == 0:
+            await asyncio.sleep(0.005)
     join_resp = await lens_client.post("/input", json={"text": "/join #ops"})
     assert join_resp.status == 204
     await _wait_for_received(agentirc_server, "JOIN", "#ops")
@@ -189,15 +202,18 @@ async def test_post_input_error_response_uses_error_hint_shape(
 # ---------------------------------------------------------------------------
 
 
-async def test_test_server_recorded_nick_user_handshake(
+async def test_fixture_wires_handshake_and_serves_http(
     lens_client: TestClient, agentirc_server: AgentIRCTestServer
 ) -> None:
-    """The lens's connect path sends NICK + USER immediately. The
-    test server should have recorded both before the first test
-    request runs (the `lens_session` fixture awaited connect)."""
+    """End-to-end fixture sanity: the lens's connect path sent
+    NICK + USER to the test server (proves `Session.connect` ran),
+    and the aiohttp Application is serving requests (proves
+    `make_app` + `TestClient` are wired up)."""
     commands = [line.command for line in agentirc_server.received]
     assert "NICK" in commands
     assert "USER" in commands
+    resp = await lens_client.get("/")
+    assert resp.status == 200
 
 
 async def test_post_input_form_encoded_body_also_works(lens_client: TestClient) -> None:

--- a/tests/test_e2e_http.py
+++ b/tests/test_e2e_http.py
@@ -1,0 +1,225 @@
+"""Phase 9b — HTTP end-to-end tests.
+
+Drives the lens's real ``aiohttp.web.Application`` (via
+``conftest.py``'s ``lens_client``) against a thin AgentIRC test
+server (``_agentirc_server.py``). Asserts the spec's user flows
+(``GET /``, ``POST /input``, ``GET /events``) work against a
+*connected* Session — not a stub-constructed one like
+``test_web_skeleton.py``.
+
+The test server is line-buffered and records every line the lens
+sent, so assertions like "POST /input '/join #x' caused the
+transport to write JOIN #x within 100 ms" are a single
+``await wait_for_received(server, 'JOIN', '#x')`` call.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+
+import pytest
+from aiohttp.test_utils import TestClient
+
+from _agentirc_server import AgentIRCTestServer, _ReceivedLine
+
+
+async def _wait_for_received(
+    server: AgentIRCTestServer,
+    command: str,
+    *params: str,
+    timeout: float = 1.0,
+) -> _ReceivedLine:
+    """Poll ``server.received`` until a matching line appears.
+
+    Cheaper and easier to reason about than wiring an asyncio.Event
+    on every line — tests run on localhost loopback and the lens
+    flushes ``send_raw`` through ``writer.drain``, so the line
+    typically lands within a few ms.
+    """
+    deadline = asyncio.get_event_loop().time() + timeout
+    while asyncio.get_event_loop().time() < deadline:
+        for line in server.received:
+            if line.command == command and list(params) == line.params[: len(params)]:
+                return line
+        await asyncio.sleep(0.01)
+    raise AssertionError(
+        f"timed out after {timeout}s waiting for {command} {list(params)} — "
+        f"server received: {[(line.command, line.params) for line in server.received]}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# GET / — connected lens renders the full three-pane shell.
+# ---------------------------------------------------------------------------
+
+
+async def test_get_index_returns_200_with_required_testids(lens_client: TestClient) -> None:
+    """`GET /` against a real connected session returns 200 + every
+    DOM contract id Phase 9c (Playwright) and the SSE handlers
+    rely on."""
+    resp = await lens_client.get("/")
+    assert resp.status == 200
+    body = await resp.text()
+    for testid in (
+        "chat-log",
+        "sidebar",
+        "info",
+        "chat-input",
+        "chat-submit",
+        "view-indicator",
+        "connection-status",
+    ):
+        assert f'data-testid="{testid}"' in body, f"missing #{testid}"
+
+
+# ---------------------------------------------------------------------------
+# POST /input — the user-driven write path.
+# ---------------------------------------------------------------------------
+
+
+async def test_post_input_join_writes_to_irc(
+    lens_client: TestClient, agentirc_server: AgentIRCTestServer
+) -> None:
+    resp = await lens_client.post("/input", json={"text": "/join #ops"})
+    assert resp.status == 204
+    line = await _wait_for_received(agentirc_server, "JOIN", "#ops")
+    assert line.command == "JOIN"
+
+
+async def test_post_input_chat_writes_privmsg_to_irc(
+    lens_client: TestClient, agentirc_server: AgentIRCTestServer
+) -> None:
+    # Join first so the lens has a current channel for free-text chat.
+    await lens_client.post("/input", json={"text": "/join #ops"})
+    await _wait_for_received(agentirc_server, "JOIN", "#ops")
+
+    resp = await lens_client.post("/input", json={"text": "hello there"})
+    assert resp.status == 204
+    line = await _wait_for_received(agentirc_server, "PRIVMSG", "#ops")
+    # PRIVMSG params are [target, text].
+    assert line.params == ["#ops", "hello there"]
+
+
+async def test_post_input_503_when_session_unhealthy(
+    lens_client: TestClient, lens_session
+) -> None:
+    """Spec line 267: subsequent `POST /input` returns 503 once the
+    session is unhealthy."""
+    lens_session._healthy = False
+    resp = await lens_client.post("/input", json={"text": "hello"})
+    assert resp.status == 503
+    body = await resp.json()
+    assert "error" in body
+    assert "hint" in body
+
+
+async def test_post_input_413_on_oversize_body(lens_client: TestClient) -> None:
+    """Bounded-memory contract: bodies > 4 KiB are rejected before
+    `Session.execute` runs (PR #7 wired this via `client_max_size`
+    on the Application + an in-handler check)."""
+    big = "x" * 5000
+    resp = await lens_client.post("/input", json={"text": big})
+    assert resp.status == 413
+
+
+# ---------------------------------------------------------------------------
+# GET /events — the SSE read path. Stream a few bytes after a /join
+# and assert a roster event arrives.
+# ---------------------------------------------------------------------------
+
+
+async def test_get_events_streams_roster_after_join(
+    lens_client: TestClient, agentirc_server: AgentIRCTestServer
+) -> None:
+    """Open SSE, then trigger a /join via POST /input. The roster
+    event should land on the stream within ~1 s."""
+
+    async def collect_event() -> bytes:
+        resp = await lens_client.get("/events")
+        assert resp.status == 200
+        assert resp.headers["Content-Type"].startswith("text/event-stream")
+        # Read until we see a `roster` event, with a hard cap so a
+        # broken bus doesn't hang the test runner.
+        buf = b""
+        deadline = asyncio.get_event_loop().time() + 2.0
+        while asyncio.get_event_loop().time() < deadline:
+            chunk = await asyncio.wait_for(resp.content.read(1024), timeout=2.0)
+            if not chunk:
+                break
+            buf += chunk
+            if b"event: roster" in buf:
+                resp.close()
+                return buf
+        resp.close()
+        raise AssertionError(f"no roster event in {buf!r}")
+
+    collector = asyncio.create_task(collect_event())
+    # Tiny delay so the SSE subscriber registers before we publish.
+    await asyncio.sleep(0.05)
+    join_resp = await lens_client.post("/input", json={"text": "/join #ops"})
+    assert join_resp.status == 204
+    await _wait_for_received(agentirc_server, "JOIN", "#ops")
+    payload = await collector
+    assert b"event: roster" in payload
+
+
+# ---------------------------------------------------------------------------
+# JSON-shape regression: error response shape (NOT the AfiError CLI
+# triple — see PR #7 pushback memory).
+# ---------------------------------------------------------------------------
+
+
+async def test_post_input_error_response_uses_error_hint_shape(
+    lens_client: TestClient, lens_session
+) -> None:
+    """503 body must be `{error, hint}` — *not* the AfiError
+    `{code, message, remediation}` CLI shape. This is the spec
+    pushback PR #7 ratified; pin it as a regression guard."""
+    lens_session._healthy = False
+    resp = await lens_client.post("/input", json={"text": "x"})
+    body = await resp.json()
+    assert set(body.keys()) == {"error", "hint"}
+    assert isinstance(body["error"], str)
+    assert isinstance(body["hint"], str)
+
+
+# ---------------------------------------------------------------------------
+# Test-server self-check: easy to spot if the fixture itself broke.
+# ---------------------------------------------------------------------------
+
+
+async def test_test_server_recorded_nick_user_handshake(
+    lens_client: TestClient, agentirc_server: AgentIRCTestServer
+) -> None:
+    """The lens's connect path sends NICK + USER immediately. The
+    test server should have recorded both before the first test
+    request runs (the `lens_session` fixture awaited connect)."""
+    commands = [line.command for line in agentirc_server.received]
+    assert "NICK" in commands
+    assert "USER" in commands
+
+
+async def test_post_input_form_encoded_body_also_works(lens_client: TestClient) -> None:
+    """HTMX defaults to application/x-www-form-urlencoded — the
+    content-negotiation path from PR #7 must still work end-to-end."""
+    resp = await lens_client.post(
+        "/input",
+        data={"text": "/join #form"},
+        headers={"Content-Type": "application/x-www-form-urlencoded"},
+    )
+    assert resp.status == 204
+
+
+# ---------------------------------------------------------------------------
+# Negative path: invalid JSON body.
+# ---------------------------------------------------------------------------
+
+
+async def test_post_input_400_on_bad_json(lens_client: TestClient) -> None:
+    resp = await lens_client.post(
+        "/input",
+        data="this is not json",
+        headers={"Content-Type": "application/json"},
+    )
+    assert resp.status == 400


### PR DESCRIPTION
## Summary

- Adds the Phase 9b deliverables from the build plan: a real HTTP e2e harness driving the lens's `aiohttp.web.Application` against a connected `Session` against a thin AgentIRC test server (~120 lines, asyncio-only, zero external deps).
- Took the spec's **option (b)** over (a) — pulling `culture` as a dev dep would transitively import `culture.bots.virtual_client`, telemetry/OTel infrastructure, skills, history-store, and protocol modules just to serve ~10 e2e cases. The choice is justified in `tests/README.md` (build plan Phase 9b lines 272–274 sanctions the fallback).
- New files:
  - `tests/_agentirc_server.py` — `AgentIRCTestServer`. Records every line the lens sent; echoes server-confirmed JOIN/PART so `Session.dispatch` listeners fire.
  - `tests/conftest.py` — `agentirc_server`, `lens_session`, `lens_client` fixtures (function-scoped).
  - `tests/test_e2e_http.py` — 10 e2e tests (GET / contract, POST /input write paths, GET /events streaming, error-shape regression, test-server self-check).
  - `tests/README.md` — three-layer test architecture + option-(b) rationale.

Phase 9c (Playwright opt-in + CI job) follows in its own PR and will reuse this fixture stack with `--seed` for deterministic DOM.

## Test plan

- [x] `uv run pytest -q` → 212/212 green (was 202; +10 e2e)
- [x] `uv run pytest tests/test_e2e_http.py -v` → 10/10
- [x] `afi cli verify` → 22/22 still

🤖 Generated with [Claude Code](https://claude.com/claude-code)