### PR TITLE
phase 9c: Playwright e2e tests (opt-in) + CI job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,3 +24,24 @@ jobs:
 
       - name: pytest
         run: uv run pytest -v
+
+  playwright:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+
+      - uses: astral-sh/setup-uv@38f3f104447c67c051c4a08e39b64a148898af3a # v4
+
+      - run: uv python install 3.12
+
+      - run: uv venv
+
+      - run: uv pip install -e ".[dev]"
+
+      - name: Install chromium for pytest-playwright
+        run: uv run playwright install --with-deps chromium
+
+      - name: pytest -m playwright
+        run: uv run pytest -m playwright -v

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,6 +52,11 @@ packages = ["src/irc_lens"]
 [tool.pytest.ini_options]
 testpaths = ["tests"]
 asyncio_mode = "auto"
+# Default-exclude the `playwright` marker: a bare `pytest` run skips
+# browser tests so local dev / the existing CI `test` job stays fast
+# (no chromium download, no per-test browser spin-up). The Playwright
+# CI job overrides via `pytest -m playwright`.
+addopts = "-m 'not playwright'"
 markers = [
     "playwright: opt-in browser end-to-end tests (requires `playwright install chromium`).",
 ]

--- a/src/irc_lens/cli/_commands/serve.py
+++ b/src/irc_lens/cli/_commands/serve.py
@@ -32,9 +32,16 @@ from aiohttp import web
 
 from irc_lens.cli._errors import EXIT_ENV_ERROR, EXIT_USER_ERROR, AfiError
 from irc_lens.cli._output import emit_diagnostic
-from irc_lens.seed import apply_seed
 from irc_lens.session import LensConnectionLost, Session
 from irc_lens.web import make_app
+
+# `irc_lens.seed` is imported function-locally inside `_serve_async`
+# to avoid a real-but-latent module-load cycle:
+#   seed.py -> cli._errors -> cli/__init__.py (which eagerly imports
+#   serve.py) -> serve.py -> seed.py (partially initialized)
+# Phase 9c's `seeded_lens_client` fixture is the first place that
+# imports `irc_lens.seed` at module-load time, which uncovered this.
+# Keep the cycle broken at the production-code import edge.
 
 
 class _JsonLineFormatter(logging.Formatter):
@@ -122,6 +129,8 @@ async def _serve_async(args: argparse.Namespace) -> None:
         # connected IRC session past process exit would orphan state
         # in the AgentIRC server. BaseException (KeyboardInterrupt,
         # SystemExit) still propagates untouched.
+        from irc_lens.seed import apply_seed  # see module top comment
+
         try:
             apply_seed(session, Path(args.seed))
         except Exception:

--- a/src/irc_lens/cli/_commands/serve.py
+++ b/src/irc_lens/cli/_commands/serve.py
@@ -128,10 +128,13 @@ async def _serve_async(args: argparse.Namespace) -> None:
         # connection cleanup runs on every failure path — leaking a
         # connected IRC session past process exit would orphan state
         # in the AgentIRC server. BaseException (KeyboardInterrupt,
-        # SystemExit) still propagates untouched.
-        from irc_lens.seed import apply_seed  # see module top comment
-
+        # SystemExit) still propagates untouched. The function-local
+        # import lives INSIDE the try so an import-time failure on
+        # `irc_lens.seed` (or any module it loads) also triggers the
+        # disconnect cleanup branch.
         try:
+            from irc_lens.seed import apply_seed  # see module top comment
+
             apply_seed(session, Path(args.seed))
         except Exception:
             await session.disconnect()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -11,20 +11,40 @@ dep.
 from __future__ import annotations
 
 from collections.abc import AsyncIterator
+from pathlib import Path
 
 import pytest_asyncio
 from aiohttp import web
 from aiohttp.test_utils import TestClient, TestServer
 
-from pathlib import Path
-
-from irc_lens.seed import apply_seed
 from irc_lens.session import Session
 from irc_lens.web import make_app
 
 from _agentirc_server import AgentIRCTestServer
 
+# `irc_lens.seed` is imported function-locally inside
+# `seeded_lens_client` to avoid eagerly loading the cli package
+# (seed.py -> cli._errors -> cli/__init__.py) for every test.
+# Tests that don't use the seeded fixture skip the cost.
+
 _BASIC_SEED = Path(__file__).parent / "fixtures" / "basic.yaml"
+
+
+async def _serve_lens(session: Session) -> AsyncIterator[TestClient]:
+    """Spin up an aiohttp ``TestClient`` against ``session``.
+
+    Helper that ``lens_client`` and ``seeded_lens_client`` share so
+    the start/teardown shape lives in one place — no drift if either
+    fixture grows new behaviour.
+    """
+    app: web.Application = make_app(session)
+    test_server = TestServer(app)
+    client = TestClient(test_server)
+    await client.start_server()
+    try:
+        yield client
+    finally:
+        await client.close()
 
 
 @pytest_asyncio.fixture
@@ -65,14 +85,8 @@ async def lens_client(lens_session: Session) -> AsyncIterator[TestClient]:
     streaming via ``client.get('/events')`` — the same handlers
     production traffic hits, just without binding a real port.
     """
-    app: web.Application = make_app(lens_session)
-    test_server = TestServer(app)
-    client = TestClient(test_server)
-    await client.start_server()
-    try:
+    async for client in _serve_lens(lens_session):
         yield client
-    finally:
-        await client.close()
 
 
 @pytest_asyncio.fixture
@@ -82,12 +96,8 @@ async def seeded_lens_client(lens_session: Session) -> AsyncIterator[TestClient]
     deterministic DOM. ``apply_seed`` is pure state mutation, so the
     SSE bus has nothing to publish; the initial ``GET /`` render
     reads the seeded state directly."""
+    from irc_lens.seed import apply_seed  # see module top comment
+
     apply_seed(lens_session, _BASIC_SEED)
-    app: web.Application = make_app(lens_session)
-    test_server = TestServer(app)
-    client = TestClient(test_server)
-    await client.start_server()
-    try:
+    async for client in _serve_lens(lens_session):
         yield client
-    finally:
-        await client.close()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -16,10 +16,15 @@ import pytest_asyncio
 from aiohttp import web
 from aiohttp.test_utils import TestClient, TestServer
 
+from pathlib import Path
+
+from irc_lens.seed import apply_seed
 from irc_lens.session import Session
 from irc_lens.web import make_app
 
 from _agentirc_server import AgentIRCTestServer
+
+_BASIC_SEED = Path(__file__).parent / "fixtures" / "basic.yaml"
 
 
 @pytest_asyncio.fixture
@@ -60,6 +65,24 @@ async def lens_client(lens_session: Session) -> AsyncIterator[TestClient]:
     streaming via ``client.get('/events')`` — the same handlers
     production traffic hits, just without binding a real port.
     """
+    app: web.Application = make_app(lens_session)
+    test_server = TestServer(app)
+    client = TestClient(test_server)
+    await client.start_server()
+    try:
+        yield client
+    finally:
+        await client.close()
+
+
+@pytest_asyncio.fixture
+async def seeded_lens_client(lens_session: Session) -> AsyncIterator[TestClient]:
+    """Like ``lens_client`` but applies ``tests/fixtures/basic.yaml``
+    after connect — Phase 9c (Playwright) starts every test from a
+    deterministic DOM. ``apply_seed`` is pure state mutation, so the
+    SSE bus has nothing to publish; the initial ``GET /`` render
+    reads the seeded state directly."""
+    apply_seed(lens_session, _BASIC_SEED)
     app: web.Application = make_app(lens_session)
     test_server = TestServer(app)
     client = TestClient(test_server)

--- a/tests/test_e2e_playwright.py
+++ b/tests/test_e2e_playwright.py
@@ -30,6 +30,12 @@ from playwright.async_api import async_playwright, expect
 
 pytestmark = pytest.mark.playwright
 
+# Per-locator timeout. Local runs assert in <2s; CI runners can be
+# noticeably slower under cold-cache chromium starts or hot
+# parallel jobs, so leave generous margin. Single constant so the
+# next adjustment is one edit.
+_LOCATOR_TIMEOUT_MS = 5000
+
 
 def _url(client: TestClient, path: str = "/") -> str:
     """Resolve an absolute URL the headless browser can navigate to.
@@ -50,7 +56,7 @@ async def test_seeded_chat_lines_render(seeded_lens_client: TestClient) -> None:
             page = await browser.new_page()
             await page.goto(_url(seeded_lens_client))
             await expect(page.locator('[data-testid="chat-line"]')).to_have_count(
-                2, timeout=2000
+                2, timeout=_LOCATOR_TIMEOUT_MS
             )
         finally:
             await browser.close()
@@ -68,10 +74,10 @@ async def test_typing_chat_input_appends_chat_line(
             page = await browser.new_page()
             await page.goto(_url(seeded_lens_client))
             chat_lines = page.locator('[data-testid="chat-line"]')
-            await expect(chat_lines).to_have_count(2, timeout=2000)
+            await expect(chat_lines).to_have_count(2, timeout=_LOCATOR_TIMEOUT_MS)
             await page.locator('[data-testid="chat-input"]').fill("browser hello")
             await page.locator('[data-testid="chat-input"]').press("Enter")
-            await expect(chat_lines).to_have_count(3, timeout=2000)
+            await expect(chat_lines).to_have_count(3, timeout=_LOCATOR_TIMEOUT_MS)
             await expect(chat_lines.last).to_contain_text("browser hello")
         finally:
             await browser.close()
@@ -95,7 +101,7 @@ async def test_active_channel_renders_with_active_class(
                 '[data-testid="sidebar-channel"][data-channel="#general"]'
             )
             await expect(active).to_have_class(
-                "lens-channel lens-channel--active", timeout=2000
+                "lens-channel lens-channel--active", timeout=_LOCATOR_TIMEOUT_MS
             )
         finally:
             await browser.close()
@@ -111,9 +117,9 @@ async def test_view_switch_via_help_command(seeded_lens_client: TestClient) -> N
             page = await browser.new_page()
             await page.goto(_url(seeded_lens_client))
             indicator = page.locator('[data-testid="view-indicator"]')
-            await expect(indicator).to_have_attribute("data-view", "chat", timeout=2000)
+            await expect(indicator).to_have_attribute("data-view", "chat", timeout=_LOCATOR_TIMEOUT_MS)
             await page.locator('[data-testid="chat-input"]').fill("/help")
             await page.locator('[data-testid="chat-input"]').press("Enter")
-            await expect(indicator).to_have_attribute("data-view", "help", timeout=2000)
+            await expect(indicator).to_have_attribute("data-view", "help", timeout=_LOCATOR_TIMEOUT_MS)
         finally:
             await browser.close()

--- a/tests/test_e2e_playwright.py
+++ b/tests/test_e2e_playwright.py
@@ -1,0 +1,119 @@
+"""Phase 9c — Playwright end-to-end tests (opt-in).
+
+Drives a real chromium against the lens's `aiohttp.web.Application`
+(via Phase 9b's `seeded_lens_client` fixture, which preloads
+`tests/fixtures/basic.yaml` so every test starts from a known DOM).
+
+Run via:
+
+    uv run playwright install chromium      # one-time browser install
+    uv run pytest -m playwright -v
+
+A bare `pytest` run *skips* this module — `addopts = "-m 'not
+playwright'"` in `pyproject.toml` keeps default test runs (and the
+existing CI `test` job) free of browser overhead. The new CI
+`playwright` job overrides via `pytest -m playwright`.
+
+We use ``playwright.async_api`` (not the sync ``page`` fixture from
+pytest-playwright) because the test stack already runs under
+pytest-asyncio's auto loop — mixing the sync API into an active loop
+trips ``RuntimeError: Cannot run the event loop while another loop
+is running``. The async API integrates cleanly via ``async with
+async_playwright() as p:``.
+"""
+
+from __future__ import annotations
+
+import pytest
+from aiohttp.test_utils import TestClient
+from playwright.async_api import async_playwright, expect
+
+pytestmark = pytest.mark.playwright
+
+
+def _url(client: TestClient, path: str = "/") -> str:
+    """Resolve an absolute URL the headless browser can navigate to.
+
+    `aiohttp.test_utils.TestClient.make_url` returns a ``yarl.URL``
+    bound to the random port the test server picked; Playwright
+    expects a string."""
+    return str(client.make_url(path))
+
+
+async def test_seeded_chat_lines_render(seeded_lens_client: TestClient) -> None:
+    """Spec verification gate (build plan line 287): the seeded
+    chat lines render with the correct ``data-testid="chat-line"``
+    count. ``basic.yaml`` preloads two messages in #general."""
+    async with async_playwright() as p:
+        browser = await p.chromium.launch()
+        try:
+            page = await browser.new_page()
+            await page.goto(_url(seeded_lens_client))
+            await expect(page.locator('[data-testid="chat-line"]')).to_have_count(
+                2, timeout=2000
+            )
+        finally:
+            await browser.close()
+
+
+async def test_typing_chat_input_appends_chat_line(
+    seeded_lens_client: TestClient,
+) -> None:
+    """Type into ``#chat-input`` and submit; the new chat-line must
+    appear via the local-echo SSE path (HTMX form → POST /input →
+    Session.execute → _publish_chat → SSE → lens.js append)."""
+    async with async_playwright() as p:
+        browser = await p.chromium.launch()
+        try:
+            page = await browser.new_page()
+            await page.goto(_url(seeded_lens_client))
+            chat_lines = page.locator('[data-testid="chat-line"]')
+            await expect(chat_lines).to_have_count(2, timeout=2000)
+            await page.locator('[data-testid="chat-input"]').fill("browser hello")
+            await page.locator('[data-testid="chat-input"]').press("Enter")
+            await expect(chat_lines).to_have_count(3, timeout=2000)
+            await expect(chat_lines.last).to_contain_text("browser hello")
+        finally:
+            await browser.close()
+
+
+async def test_active_channel_renders_with_active_class(
+    seeded_lens_client: TestClient,
+) -> None:
+    """``basic.yaml`` pins ``#general`` as the current channel; the
+    sidebar item for it must carry the ``lens-channel--active``
+    class. (The build plan's "click to switch" assertion presupposes
+    a sidebar click handler that doesn't exist in the shipped
+    ``lens.js``; this adapted assertion proves the active-state
+    wiring is live without inventing new product features.)"""
+    async with async_playwright() as p:
+        browser = await p.chromium.launch()
+        try:
+            page = await browser.new_page()
+            await page.goto(_url(seeded_lens_client))
+            active = page.locator(
+                '[data-testid="sidebar-channel"][data-channel="#general"]'
+            )
+            await expect(active).to_have_class(
+                "lens-channel lens-channel--active", timeout=2000
+            )
+        finally:
+            await browser.close()
+
+
+async def test_view_switch_via_help_command(seeded_lens_client: TestClient) -> None:
+    """End-to-end view switch: type ``/help``, submit, the
+    ``view-indicator`` must reflect the new view via the
+    SSE ``info`` swap."""
+    async with async_playwright() as p:
+        browser = await p.chromium.launch()
+        try:
+            page = await browser.new_page()
+            await page.goto(_url(seeded_lens_client))
+            indicator = page.locator('[data-testid="view-indicator"]')
+            await expect(indicator).to_have_attribute("data-view", "chat", timeout=2000)
+            await page.locator('[data-testid="chat-input"]').fill("/help")
+            await page.locator('[data-testid="chat-input"]').press("Enter")
+            await expect(indicator).to_have_attribute("data-view", "help", timeout=2000)
+        finally:
+            await browser.close()

--- a/tests/test_serve_cli.py
+++ b/tests/test_serve_cli.py
@@ -247,7 +247,10 @@ def test_serve_seed_loads_yaml_fixture(
         captured["session"] = session
         captured["path"] = path
 
-    monkeypatch.setattr("irc_lens.cli._commands.serve.apply_seed", fake_apply)
+    # Patch at the definition site since serve.py imports
+    # `apply_seed` function-locally (see serve.py module top comment
+    # — there's a real production-code import cycle to avoid).
+    monkeypatch.setattr("irc_lens.seed.apply_seed", fake_apply)
     rc = main(
         [
             "serve",


### PR DESCRIPTION
## Summary

- Adds 4 Playwright tests driving real chromium against the Phase 9b fixture stack with a deterministic seed (`tests/fixtures/basic.yaml`):
  - `test_seeded_chat_lines_render` — spec verification gate (≥ 2 chat-lines from the seed)
  - `test_typing_chat_input_appends_chat_line` — full HTMX form → POST /input → SSE → DOM-append round-trip
  - `test_active_channel_renders_with_active_class` — adapted from the build plan's "click sidebar-channel" (no click handler exists in lens.js; shipped behaviour proves the active-state wiring instead)
  - `test_view_switch_via_help_command` — slash-command → SSE `info` swap → view-indicator data-attr update
- Default `pytest` skips them via new `addopts = "-m 'not playwright'"`; new parallel CI `playwright` job runs `playwright install --with-deps chromium` + `pytest -m playwright`.
- New `seeded_lens_client` fixture in `tests/conftest.py` mirrors `lens_client` + `apply_seed`.
- Tests use `playwright.async_api` (not the sync `page` fixture) because mixing sync_api into pytest-asyncio's auto loop trips "Cannot run the event loop while another loop is running" (documented inline).

## Production-code change

Broke a real-but-latent module-load import cycle (`seed.py` → `cli._errors` → `cli/__init__.py` → `serve.py` → `seed.py`). Phase 9c's `seeded_lens_client` was the first place to hit it (conftest imports `irc_lens.seed` at module-load time, before `cli._errors` is initialized). Fixed by deferring `from irc_lens.seed import apply_seed` inside `_serve_async` and documenting at the import site. Updated `test_serve_seed_loads_yaml_fixture` to monkeypatch at the definition site.

## Test plan

- [x] `uv run pytest -q` → 212 passed, 4 deselected (default behaviour: Playwright skipped)
- [x] `uv run pytest -m playwright -v` → 4/4 green (after `playwright install chromium`)
- [x] `afi cli verify` → 22/22 still

🤖 Generated with [Claude Code](https://claude.com/claude-code)