### PR TITLE
phase 10: docs deliverables

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,46 @@
 # irc-lens
-IRC-lens is the lens CLI component for AgentIRC in Culture ecosystem
+
+`irc-lens` is the agent-driven web console for **AgentIRC** in the
+[Culture](https://github.com/agentculture/culture) ecosystem. Where
+the existing Textual TUI requires a human at a terminal,
+`irc-lens` re-implements the same console as a localhost aiohttp
+app (HTMX + SSE, server-rendered fragments) so a Playwright agent
+or human browser can drive it deterministically.
+
+## Quickstart
+
+```bash
+pip install irc-lens
+irc-lens serve --host 127.0.0.1 --port 6667 --nick lens --open
+```
+
+The `--open` flag launches the default browser at the printed
+URL. Quit with Ctrl-C.
+
+## Develop
+
+```bash
+git clone https://github.com/agentculture/irc-lens && cd irc-lens
+uv venv && uv pip install -e ".[dev]"
+uv run pytest -v                         # default suite
+uv run playwright install chromium       # one-time
+uv run pytest -m playwright -v           # browser e2e
+```
+
+## Docs
+
+* [`docs/cli.md`](docs/cli.md) — every flag, exit code, the
+  `--seed` schema.
+* [`docs/slash-commands.md`](docs/slash-commands.md) — verb table
+  (`/join`, `/help`, `/send`, …).
+* [`docs/sse-events.md`](docs/sse-events.md) — SSE event catalogue,
+  fragment templates, `data-testid` contract.
+* [`docs/playwright.md`](docs/playwright.md) — driving the lens
+  with pytest-playwright or Playwright MCP.
+* [`docs/architecture.md`](docs/architecture.md) — runtime
+  topology, module layout, decision log.
+* [`CITATION.md`](CITATION.md) — culture citations + divergences.
+
+## License
+
+See [LICENSE](LICENSE).

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,25 +1,223 @@
-# irc-lens architecture (work in progress)
+# `irc-lens` architecture
 
-> **Status:** stub. Phase 10 produces the full architecture document
-> (runtime diagram, module layout, decision log). For now this file
-> exists so the vendored frontend assets have a documented pinned
-> version, per the build plan's Phase 4 requirement.
+Reference for how the lens is wired internally. Spec: `docs/superpowers/specs/2026-04-27-irc-lens-handover-design.md`.
+Per-phase build plan: `docs/superpowers/plans/2026-04-27-irc-lens-build-plan.md`.
+
+## Runtime topology
+
+```
+┌──────────────────────┐      ┌────────────────────────────┐      ┌──────────────────┐
+│ Browser (HTMX + SSE) │ HTTP │ aiohttp.web.Application    │ TCP  │ AgentIRC server  │
+│ lens.js + lens.css   │ ◄──► │   GET /                    │ ◄──► │ (culture mesh)   │
+│ EventSource("/events")│     │   POST /input              │      │                  │
+└──────────────────────┘      │   GET /events  (SSE)       │      └──────────────────┘
+                              │   GET /static/*            │
+                              │                            │
+                              │  ┌──────────────────────┐  │
+                              │  │  Session             │  │
+                              │  │  ├─ IRCTransport     │──┘ TCP read loop publishes
+                              │  │  ├─ MessageBuffer    │    inbound messages into
+                              │  │  ├─ SessionEventBus ─┼──► subscribed SSE responses
+                              │  │  └─ execute()        │
+                              │  └──────────────────────┘
+                              └────────────────────────────┘
+```
+
+* One `Session` per process, owned by the `aiohttp.web.Application`
+  (`app["session"]`).
+* IRC reads run on the same event loop as the web server — `serve.py`
+  uses one `asyncio.run(_serve_async(...))` so the read task survives
+  until shutdown.
+* Server-rendered HTML fragments are the unit of update over SSE; the
+  browser does no client-side templating.
+
+## Module layout
+
+```
+src/irc_lens/
+├── __init__.py            # __version__ via importlib.metadata
+├── __main__.py            # python -m irc_lens entry point
+├── cli/
+│   ├── __init__.py        # parser + _dispatch + _ArgumentParser override
+│   ├── _errors.py         # AfiError + EXIT_* (stable contract)
+│   ├── _output.py         # stdout/stderr split + --json (stable contract)
+│   └── _commands/         # learn / explain / overview / serve
+├── commands.py            # parse_command + verb dictionary (cited)
+├── irc/
+│   ├── transport.py       # IRCTransport (cited, with add_listener hook)
+│   └── buffer.py          # MessageBuffer (cited, with optional timestamp)
+├── session.py             # Session, SessionEventBus, Subscription, dispatch
+├── seed.py                # apply_seed / load_seed (Phase 8)
+├── web/
+│   ├── __init__.py        # public make_app re-export
+│   ├── app.py             # Application factory + client_max_size
+│   ├── routes.py          # get_index / post_input / get_events
+│   ├── render.py          # Jinja2 env + render_index/render_fragment
+│   └── events.py          # format_sse + SessionEvent re-export
+├── templates/             # *.html.j2 (index + fragments)
+└── static/                # lens.js, lens.css, vendor/
+```
+
+The CLI scaffold (`cli/_errors.py`, `cli/_output.py`, the dispatcher,
+the `learn` / `explain` commands, and the `_ArgumentParser` override)
+came from the AFI `python-cli` reference at bootstrap; see
+`CLAUDE.md` for the citation source and rubric contracts. The IRC
+transport, message buffer, and slash-command parser are **cited
+from `culture@57d3ba8`** (see `CITATION.md`) — not installed as a
+dependency. Divergences from the citation source (the
+`add_listener` hook on the transport, the optional `timestamp`
+kwarg on `MessageBuffer.add`) are tracked in `CITATION.md`.
+
+## Request shapes
+
+| Route | Verb | Body | Response |
+| --- | --- | --- | --- |
+| `/` | `GET` | — | 200 HTML (`render_index`). |
+| `/input` | `POST` | JSON `{"text": "..."}` *or* form-encoded `text=...` | 204 success, 400 bad JSON, 413 oversize, 503 unhealthy. |
+| `/events` | `GET` | — | 200 SSE stream (`text/event-stream`, `Cache-Control: no-store`). |
+| `/static/{path}` | `GET` | — | Vendored assets + `lens.js` / `lens.css`. |
+
+`POST /input` content-negotiates: `application/json` triggers JSON
+parsing, anything else (including HTMX's default
+`application/x-www-form-urlencoded`) reads the `text` field via
+`request.post()`.
+
+## Event flow
+
+A typical `/join #general` round-trip:
+
+1. Browser submits `<form>` → HTMX POSTs `text=/join+%23general` to
+   `/input`.
+2. `post_input` reads the body, runs `parse_command`, calls
+   `await session.execute(parsed)`.
+3. `Session._exec_join` validates the channel name, calls
+   `Session.join` (which sends `JOIN #general` over the wire),
+   updates state, then `_publish_roster()` + `_publish_info()`.
+4. Each `publish` enqueues a `SessionEvent` on every subscriber's
+   bounded queue.
+5. The open `GET /events` response drains its `Subscription` and
+   writes `format_sse(event)` bytes.
+6. `lens.js`'s `EventSource` listener swaps `#sidebar` / `#info`
+   innerHTML.
+
+Inbound traffic uses the transport's per-command listener list:
+`Session.connect` registers `Session.dispatch` for `PRIVMSG`,
+`JOIN`, and `PART`. The transport's primary handler still runs
+first (buffer-add, etc.); the listener emits the user-visible SSE
+event.
+
+## Backpressure + bounded memory
+
+Several caps keep a long session deterministic:
+
+| Surface | Cap | Source | Behaviour on overflow |
+| --- | --- | --- | --- |
+| Subscriber queue | 256 events | `SessionEventBus` | drop-oldest + single-shot `error: events dropped` |
+| `MessageBuffer` | 500 messages per channel | `MessageBuffer` | drop-oldest |
+| `POST /input` body | 4 KiB | `routes._MAX_INPUT_BODY` + `client_max_size` | 413 |
+| Browser chat log | 500 `<div data-testid="chat-line">` nodes | `lens.js` `CHAT_LOG_CAP` | trim oldest |
+
+The browser cap mirrors the server cap so a long session can't grow
+unbounded DOM even if every message is rendered.
+
+## Decision log
+
+### Why SSE, not WebSockets
+
+The lens needs *server → browser* updates only; the input flow is
+plain HTTP `POST`. SSE is one-way over a long-lived HTTP response,
+auto-reconnects in the standard library (`EventSource`), and works
+through every middlebox that allows HTTP/1.1 chunked responses.
+WebSockets would add a second wire format, a second middlebox class
+to debug, and zero capability we'd actually use.
+
+### Why HTMX + server-rendered fragments
+
+The whole point of v1 is that a Playwright agent can drive the UI
+deterministically. Server-rendered fragments mean every state
+change is verifiable from the wire (e.g. `tests/test_e2e_http.py`
+asserts on the rendered HTML fragments without a browser). HTMX is
+a thin attribute layer on top of stable HTML — no transpile step,
+no virtual DOM, no per-request hydration mismatch.
+
+### Why vendor HTMX instead of a CDN
+
+The lens runs on localhost, drives Playwright in offline-friendly
+agent loops, and must boot deterministically without outbound
+network. Vendored assets live under
+`src/irc_lens/static/vendor/` and ship in the wheel. Refreshing
+them is a one-line `curl` per pin (see [Vendored frontend
+assets](#vendored-frontend-assets)).
+
+### Why cite-don't-import from culture
+
+Importing `culture` as a dev dep would pull in
+`culture.bots.virtual_client`, `culture.constants`,
+`culture.telemetry`, and the entire `culture.protocol` /
+`culture.agentirc` graph for three reused modules. We need
+`IRCTransport`, `MessageBuffer`, and the parser table — nothing
+else. Citing keeps the dep graph tight and lets us diverge
+deliberately (e.g. the `add_listener` hook on the transport).
+Divergences are tracked in `CITATION.md`.
+
+### Why an in-tree AgentIRC test server
+
+Phase 9b needs an IRC peer for HTTP e2e tests. Pulling culture as
+a dev dep was the spec's first option; rejected for the same
+footprint reason as the citation choice. The thin
+`tests/_agentirc_server.py` (~145 lines) accepts the connection,
+echoes JOIN/PART, records every line, and ships zero IRC protocol
+semantics beyond what the lens's read loop demands. Same fixture
+stack powers the Playwright suite (Phase 9c).
+
+### Why `--seed` overlays state on a real connection
+
+Spec line 261: even seed mode must verify the AgentIRC server is
+reachable. Headless rendering of preloaded chat lines is a
+side-effect, not the core contract. `--seed` is the determinism
+switch for tests and demos; the connection is the trust boundary.
+
+### Why HTTP error JSON is `{error, hint}` and not `{code, message, remediation}`
+
+`{code, message, remediation}` is the **CLI** contract enforced by
+`afi cli verify`. The spec is silent on HTTP-error JSON shape, and
+the chosen `{error, hint}` mirrors the text-mode CLI rendering
+(`error: X` / `hint: Y`) without coupling the two surfaces.
+Ratified on PR #7 merge after a Qodo pushback; the same
+challenger raised it again on PR #12 and was directed back to the
+ratification.
+
+### Why exit code 1 vs 2 splits user input vs environment
+
+User-supplied bad input (unreachable AgentIRC endpoint, missing
+seed file, malformed YAML) → `EXIT_USER_ERROR (1)`. Environment
+failure to act on a resource that exists (port collision,
+permission denied while reading a seed file) → `EXIT_ENV_ERROR
+(2)`. Canonical precedents: `serve.py:107` (`LensConnectionLost`
+→ `1`) vs `serve.py:154` (port-bind `OSError` → `2`).
+
+### Why dispatch-table entries stay `async def`
+
+`Session.execute` calls `await handler(parsed)`, so every entry in
+`Session._exec_dispatch` must be `async def`. Helpers underneath
+(`_switch_view`, etc.) go sync when they have no real async use
+case so SonarCloud's S7503 rule clears for the inner body. The
+outer `_exec_*` methods accept S7503 with the dispatch-contract
+rationale.
 
 ## Vendored frontend assets
 
-`irc-lens` ships with HTMX vendored under
-`src/irc_lens/static/vendor/`, not loaded from a CDN. Rationale:
-the lens runs on localhost, drives Playwright in offline-friendly
-agent loops, and must boot deterministically without outbound network.
-The assets are wheel-shipped via `tool.hatch.build.targets.wheel`'s
-package include.
+`irc-lens` ships HTMX vendored under
+`src/irc_lens/static/vendor/`, not loaded from a CDN. The assets
+ship in the wheel via `tool.hatch.build.targets.wheel`'s package
+include.
 
 | File | Pin | Source |
 | --- | --- | --- |
-| `htmx.min.js`  | `htmx.org@2.0.4`        | `https://unpkg.com/htmx.org@2.0.4/dist/htmx.min.js` |
-| `sse.js`       | `htmx-ext-sse@2.2.2`    | `https://unpkg.com/htmx-ext-sse@2.2.2/sse.js` |
+| `htmx.min.js` | `htmx.org@2.0.4` | `https://unpkg.com/htmx.org@2.0.4/dist/htmx.min.js` |
+| `sse.js` | `htmx-ext-sse@2.2.2` | `https://unpkg.com/htmx-ext-sse@2.2.2/sse.js` |
 
-To refresh, run:
+To refresh:
 
 ```bash
 curl -fsSL https://unpkg.com/htmx.org@<VERSION>/dist/htmx.min.js \
@@ -30,5 +228,15 @@ curl -fsSL https://unpkg.com/htmx-ext-sse@<VERSION>/sse.js \
 
 …and update the version pins in this table. Don't bump versions
 without verifying the SSE event-listener API still matches what
-`src/irc_lens/static/lens.js` expects (currently a vanilla
-`EventSource` listener; HTMX's SSE wiring is added in Phase 7).
+`src/irc_lens/static/lens.js` expects.
+
+## Further reading
+
+* [`docs/cli.md`](cli.md) — every flag, exit code, the seed schema.
+* [`docs/slash-commands.md`](slash-commands.md) — verb table.
+* [`docs/sse-events.md`](sse-events.md) — every event, fragment, testid.
+* [`docs/playwright.md`](playwright.md) — driving the lens with
+  pytest-playwright or Playwright MCP.
+* [`CITATION.md`](../CITATION.md) — culture citations + divergences.
+* [`docs/superpowers/specs/2026-04-27-irc-lens-handover-design.md`](superpowers/specs/2026-04-27-irc-lens-handover-design.md) — spec.
+* [`docs/superpowers/plans/2026-04-27-irc-lens-build-plan.md`](superpowers/plans/2026-04-27-irc-lens-build-plan.md) — build plan.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -193,8 +193,11 @@ User-supplied bad input (unreachable AgentIRC endpoint, missing
 seed file, malformed YAML) → `EXIT_USER_ERROR (1)`. Environment
 failure to act on a resource that exists (port collision,
 permission denied while reading a seed file) → `EXIT_ENV_ERROR
-(2)`. Canonical precedents: `serve.py:107` (`LensConnectionLost`
-→ `1`) vs `serve.py:154` (port-bind `OSError` → `2`).
+(2)`. Canonical precedents in
+`src/irc_lens/cli/_commands/serve.py`: the `LensConnectionLost`
+branch in `_serve_async` → `1`; the `TCPSite.start()` `OSError`
+branch → `2`. Symbol references are used here deliberately —
+line numbers rot.
 
 ### Why dispatch-table entries stay `async def`
 

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -24,9 +24,12 @@ on the agent-first CLI shape.
 | `2` | Environment error — failure to act on a resource that exists (port collision on `--web-port`, permission denied while reading a seed file). |
 | `3+` | Reserved. |
 
-The split is mandated by the AFI rubric; precedent: `serve.py:107`
-(`LensConnectionLost` → user error) vs `serve.py:154` (port-bind
-`OSError` → env error).
+The split is mandated by the AFI rubric; precedent in
+`src/irc_lens/cli/_commands/serve.py`: the `LensConnectionLost`
+branch in `_serve_async` raises `AfiError(code=EXIT_USER_ERROR)`,
+while the `TCPSite.start()` `OSError` branch raises
+`AfiError(code=EXIT_ENV_ERROR)`. Symbol references are used here
+deliberately — line numbers rot.
 
 Every failure renders on stderr as:
 

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -1,0 +1,163 @@
+# `irc-lens` CLI reference
+
+Phase 10 reference for every flag exposed by `irc-lens`. Source of truth
+is `src/irc_lens/cli/`; this doc enumerates the user-facing surface.
+
+## Globals
+
+| Flag | Purpose |
+| --- | --- |
+| `--version` | Print package version and exit. |
+| `--help`, `-h` | Print top-level usage and exit. |
+
+The top-level globals (`learn`, `explain`, `overview`) are AFI-rubric
+contracts — each exits 0 on success, supports `--json`, and never
+leaks a Python traceback. See `docs/architecture.md` for the rationale
+on the agent-first CLI shape.
+
+## Exit codes
+
+| Code | Meaning |
+| --- | --- |
+| `0` | Success. |
+| `1` | User error — bad input, unreachable AgentIRC, missing seed file, malformed YAML. |
+| `2` | Environment error — failure to act on a resource that exists (port collision on `--web-port`, permission denied while reading a seed file). |
+| `3+` | Reserved. |
+
+The split is mandated by the AFI rubric; precedent: `serve.py:107`
+(`LensConnectionLost` → user error) vs `serve.py:154` (port-bind
+`OSError` → env error).
+
+Every failure renders on stderr as:
+
+```
+error: <message>
+hint: <remediation>
+```
+
+`--json` mode emits the same shape as `{"code": N, "message": "...",
+"remediation": "..."}` on stderr instead. Stdout stays clean on
+success and is never mixed with stderr.
+
+## `irc-lens learn`
+
+Print the agent-onboarding text — purpose, command list, exit codes,
+`--json`, `explain`. ≥ 200 chars on stdout. `--json` emits the same
+content as a JSON payload.
+
+```bash
+irc-lens learn
+irc-lens learn --json
+```
+
+## `irc-lens explain [path]`
+
+Resolve a CLI path to its catalog entry. `irc-lens explain` lists
+every documented entry; `irc-lens explain serve` prints just the
+`serve` entry. Bogus paths exit non-zero with an `error:` + `hint:`
+line per the rubric.
+
+```bash
+irc-lens explain
+irc-lens explain serve
+irc-lens explain --json serve
+```
+
+## `irc-lens overview [path]`
+
+Descriptive (not verifying) walk through the project. Bogus paths
+exit **0** with a warning section — the rubric reserves
+hard-failure on missing targets to `afi cli verify`. `irc-lens cli
+overview` is the noun-scoped variant required by the rubric for
+every noun with action-verbs.
+
+```bash
+irc-lens overview
+irc-lens overview --json
+irc-lens cli overview
+```
+
+## `irc-lens serve`
+
+Launch the aiohttp web console against an AgentIRC server. The
+process establishes the IRC connection first (fail-fast) and only
+then binds the local web port.
+
+| Flag | Required | Default | Purpose |
+| --- | --- | --- | --- |
+| `--host` | yes | — | AgentIRC server host. |
+| `--port` | yes | — | AgentIRC server port. |
+| `--nick` | yes | — | Nick to register on AgentIRC. |
+| `--web-port` | no | `8765` | Local HTTP port for the lens UI. |
+| `--bind` | no | `127.0.0.1` | Bind address for the local web app. `0.0.0.0` prints a no-auth warning to stderr. |
+| `--icon` | no | none | Optional emoji passed to AgentIRC `ICON`. |
+| `--open` | no | off | Auto-launch the default browser at the lens URL after binding. |
+| `--seed` | no | none | Path to a YAML fixture preloading view state — see [Seed schema](#seed-schema). |
+| `--log-json` | no | off | Emit stderr logs as one JSON object per line. |
+
+### Lifecycle
+
+1. Argparse validates the required flags.
+2. `--bind 0.0.0.0` prints a stderr warning (no auth in v1).
+3. `Session.connect()` against AgentIRC. Failure → exit `1` with
+   `error: cannot reach AgentIRC at <host>:<port>: …`.
+4. `--seed PATH` overlays YAML state on the connected `Session`.
+   Errors propagate as exit `1` (user content) or `2`
+   (environment failure on an existing file).
+5. `aiohttp.web.AppRunner.setup()` + `TCPSite.start()`. Port-in-use
+   → exit `2` with `error: cannot bind web port …`.
+6. The display URL is printed on stderr (`irc-lens serving on
+   http://…/`). When binding to `0.0.0.0`, the printed URL uses
+   `127.0.0.1` so it is browser-routable.
+7. Wait until SIGINT / SIGTERM. On signal, disconnect the IRC
+   session, clean up the runner, exit `0`.
+
+### Examples
+
+```bash
+# Local dev against an in-process AgentIRC:
+irc-lens serve --host 127.0.0.1 --port 6667 --nick lens --open
+
+# Same, with a deterministic preload (Phase 9c Playwright pattern):
+irc-lens serve --host 127.0.0.1 --port 6667 --nick lens \
+    --seed tests/fixtures/basic.yaml
+
+# Bind to all interfaces (warning printed, no auth in v1):
+irc-lens serve --host irc.example.org --port 6667 --nick ops \
+    --bind 0.0.0.0 --web-port 8080
+
+# JSON-line stderr for log shipping:
+irc-lens serve --host 127.0.0.1 --port 6667 --nick lens --log-json
+```
+
+## Seed schema
+
+`--seed PATH` reads a YAML document and overlays it onto the
+freshly-connected `Session` before `aiohttp.web.Application`
+binds. Every top-level key is optional; `current_channel` is only
+valid when it also appears in `joined_channels`.
+
+```yaml
+joined_channels:
+  - "#general"
+  - "#ops"
+preload_messages:
+  - {channel: "#general", nick: "alice", text: "hello world", timestamp: 1714000000}
+  - {channel: "#general", nick: "bob",   text: "hi alice",    timestamp: 1714000005}
+roster:
+  - {nick: "alice", type: "human", online: true}
+  - {nick: "bob",   type: "agent", online: true}
+current_channel: "#general"
+```
+
+Validation rules:
+
+* Unknown top-level keys raise (typo guard).
+* Per-section type errors raise with the field name in the message.
+* `current_channel` must appear in `joined_channels`.
+* Timestamps must be finite and renderable by `time.localtime` —
+  `NaN` / `Inf` / out-of-range values are rejected at seed time
+  rather than crashing the initial HTML render.
+
+Errors raise `AfiError` per the exit-code policy above. The
+canonical fixture lives at `tests/fixtures/basic.yaml`.

--- a/docs/playwright.md
+++ b/docs/playwright.md
@@ -2,8 +2,11 @@
 
 `irc-lens` was built so a browser-automation agent (Playwright MCP
 or pytest-playwright) can drive every feature deterministically.
-Every interactive element carries a `data-testid` (catalogued in
-`docs/sse-events.md`); the seed loader (`docs/cli.md` →
+Every element tests need to drive carries a stable selector —
+usually a `data-testid`, occasionally an `id` (the `<form>` is
+`id="chat-form"`); the catalogue is in
+[`docs/sse-events.md`](sse-events.md#dom-contract-data-testid--ids).
+The seed loader (`docs/cli.md` →
 [Seed schema](cli.md#seed-schema)) gives every test a known
 starting DOM without scripting an entire AgentIRC conversation.
 

--- a/docs/playwright.md
+++ b/docs/playwright.md
@@ -1,0 +1,138 @@
+# Playwright + irc-lens
+
+`irc-lens` was built so a browser-automation agent (Playwright MCP
+or pytest-playwright) can drive every feature deterministically.
+Every interactive element carries a `data-testid` (catalogued in
+`docs/sse-events.md`); the seed loader (`docs/cli.md` →
+[Seed schema](cli.md#seed-schema)) gives every test a known
+starting DOM without scripting an entire AgentIRC conversation.
+
+## When to use Playwright
+
+* Verifying the SSE → DOM swap for a new event type end-to-end.
+* Pinning a UI invariant the unit tests can't see (focus order,
+  CSS state cues, scroll behaviour).
+* Reproducing a bug a human reported in the browser.
+
+For pure server-side behaviour, prefer the in-process HTTP e2e
+suite (`tests/test_e2e_http.py`) — it's an order of magnitude
+faster and uses the same fixture stack.
+
+## Suite layout
+
+```
+tests/
+├── _agentirc_server.py      # ~145-line in-tree AgentIRC test server
+├── conftest.py              # agentirc_server / lens_session / lens_client / seeded_lens_client
+├── fixtures/basic.yaml      # canonical seed fixture
+├── test_e2e_http.py         # in-process HTTP e2e (no browser)
+└── test_e2e_playwright.py   # opt-in browser e2e (@pytest.mark.playwright)
+```
+
+`pyproject.toml` sets `addopts = "-m 'not playwright'"`, so a bare
+`pytest` skips the browser layer. The `playwright` job in
+`.github/workflows/ci.yml` overrides via `pytest -m playwright`.
+
+## Local run
+
+```bash
+uv pip install -e ".[dev]"        # one-time
+uv run playwright install chromium  # one-time browser install
+uv run pytest -m playwright -v
+```
+
+To run *both* default and Playwright tests:
+
+```bash
+uv run pytest -m "" -v
+```
+
+## Async-API requirement
+
+`tests/test_e2e_playwright.py` uses `playwright.async_api`, not the
+sync `page` fixture from pytest-playwright. The repo runs under
+pytest-asyncio's auto loop; the sync API trips
+`RuntimeError: Cannot run the event loop while another loop is
+running` when invoked from inside an active loop. Use
+`async with async_playwright() as p: …` instead.
+
+## Worked transcript: drive a slash command
+
+The pattern below is what every test in `test_e2e_playwright.py`
+follows. The `seeded_lens_client` fixture preloads
+`tests/fixtures/basic.yaml`, so `#general` is active with two
+historical chat lines before the browser ever navigates.
+
+```python
+import pytest
+from playwright.async_api import async_playwright, expect
+
+pytestmark = pytest.mark.playwright
+
+async def test_view_switch_via_help_command(seeded_lens_client):
+    async with async_playwright() as p:
+        browser = await p.chromium.launch()
+        try:
+            page = await browser.new_page()
+            await page.goto(str(seeded_lens_client.make_url("/")))
+
+            indicator = page.locator('[data-testid="view-indicator"]')
+            await expect(indicator).to_have_attribute(
+                "data-view", "chat", timeout=5000
+            )
+
+            await page.locator('[data-testid="chat-input"]').fill("/help")
+            await page.locator('[data-testid="chat-input"]').press("Enter")
+
+            await expect(indicator).to_have_attribute(
+                "data-view", "help", timeout=5000
+            )
+        finally:
+            await browser.close()
+```
+
+Three things make this deterministic:
+
+1. **Seeded state.** The fixture overlays a known `current_channel`
+   and chat-line count before the page loads.
+2. **Stable testids.** `[data-testid="chat-input"]` and
+   `[data-testid="view-indicator"]` survive template churn —
+   they're pinned by tests on both sides.
+3. **Auto-retrying assertions.** `expect(...).to_have_attribute(...)`
+   polls until the SSE swap arrives or the timeout
+   (`_LOCATOR_TIMEOUT_MS = 5000`) expires.
+
+## Driving via Playwright MCP
+
+The same patterns translate to a Playwright MCP transcript. Boot
+the lens against any reachable AgentIRC, navigate the MCP browser
+to the printed URL, then drive elements by `data-testid`:
+
+```text
+1. Shell: irc-lens serve --host 127.0.0.1 --port 6667 --nick agent \
+                          --seed tests/fixtures/basic.yaml --web-port 8765
+2. MCP:   navigate "http://127.0.0.1:8765/"
+3. MCP:   read_page  → confirm chat-line count, sidebar contents
+4. MCP:   form_input [data-testid="chat-input"]  text="/join #ops"
+5. MCP:   wait for [data-testid="sidebar-channel"][data-channel="#ops"]
+6. MCP:   form_input [data-testid="chat-input"]  text="hello"
+7. MCP:   wait for chat-line text="hello"
+```
+
+No human in the loop — every assertion has a stable testid hook
+and every state mutation flows through the same `POST /input` →
+SSE path the browser uses.
+
+## Tips
+
+* Bump `_LOCATOR_TIMEOUT_MS` if a CI runner gets noticeably hot;
+  one constant covers every assertion in the file.
+* The `chat-form` element is `id="chat-form"` only. Submit via the
+  `[data-testid="chat-submit"]` button or by pressing Enter on
+  `[data-testid="chat-input"]`.
+* The browser is not aware of seed state vs live state — once the
+  page loads, every subsequent change must come through `POST
+  /input` (or the test server publishing into the SSE bus directly).
+* If you need the raw SSE stream for debugging, the in-process HTTP
+  e2e suite already exercises `GET /events` —
+  `tests/test_e2e_http.py` is a working example.

--- a/docs/slash-commands.md
+++ b/docs/slash-commands.md
@@ -1,0 +1,68 @@
+# Slash commands
+
+The lens parses every input line via `irc_lens.commands.parse_command`.
+Plain text becomes a `CHAT` command targeting the active channel;
+lines starting with `/` are dispatched as slash commands.
+
+The parser table is byte-faithful to `culture@57d3ba8` —
+`src/irc_lens/commands.py` carries the verb dictionary verbatim
+(see `CITATION.md`). Phase 10 documents the *current* server-side
+behaviour: most verbs parse cleanly, a subset are wired to actual
+execution, and the rest publish a non-fatal `error` event so the UI
+keeps responding.
+
+## Wired in v1
+
+| Verb | Args | Behaviour |
+| --- | --- | --- |
+| (none) | text | `CHAT` — sends a PRIVMSG to the active channel; publishes a local-echo `chat` event. |
+| `/join` | `#channel` | Joins the channel, sets it active, publishes `roster` + `info`. |
+| `/part` | `#channel` | Parts the channel, publishes `roster` + `info`. |
+| `/send` | `<target> <text…>` | Sends a PRIVMSG to an explicit target (channel or nick); local-echoes a `chat` event. |
+| `/help` | — | Switches the info pane to the `help` view; publishes `view` + `info`. |
+| `/overview` | — | Switches the info pane to the `overview` view. |
+| `/status` | — | Switches the info pane to the `status` view. |
+
+## Recognised but not-yet-supported
+
+These slashes parse but currently publish an `error` event of the
+form `<command>: not yet supported`. Adding any of them is a
+non-breaking change — wire a new `_exec_*` helper into
+`Session._exec_dispatch`.
+
+| Verb | Args | Spec intent |
+| --- | --- | --- |
+| `/topic` | `<channel> <text…>` | Set channel topic via `TOPIC`. |
+| `/channels` | — | List channels reachable on the server. |
+| `/who` | `<channel>` | Refresh the roster from `WHO`. |
+| `/read` | `<channel> [n]` | Re-read recent buffer for a channel. |
+| `/agents` | — | List agent participants. |
+| `/start` | `<agent>` | Start a managed agent. |
+| `/stop` | `<agent>` | Stop a managed agent. |
+| `/restart` | `<agent>` | Restart a managed agent. |
+| `/icon` | `<emoji>` | Update the lens's `ICON`. |
+| `/kick` | `<channel> <nick>` | Kick a participant. |
+| `/invite` | `<channel> <nick>` | Invite a participant. |
+| `/server` | — | Server-meta query. |
+| `/quit` | — | Quit the IRC session. |
+
+## Errors
+
+Any slash that parses but fails downstream — invalid channel name,
+empty `/send` text, unknown verb — publishes a single `error` SSE
+event (`{"message": "..."}`). The browser surfaces it as a toast via
+`lens.js`. Valid input that can't reach AgentIRC (e.g. the
+connection was lost mid-session) returns HTTP `503` from `POST
+/input` with `{"error": "...", "hint": "..."}` per the lens's HTTP
+error-shape contract — see `docs/sse-events.md` for the full event
+catalogue and `docs/architecture.md` for the HTTP contract notes.
+
+## Examples
+
+```text
+hello world           → CHAT to current channel
+/join #general        → JOIN, sets current channel, refreshes sidebar+info
+/send #ops standup    → PRIVMSG to #ops without switching the active pane
+/help                 → switches info pane to the help view
+/foo                  → publishes `error: unknown command: /foo`
+```

--- a/docs/slash-commands.md
+++ b/docs/slash-commands.md
@@ -18,7 +18,7 @@ keeps responding.
 | (none) | text | `CHAT` — sends a PRIVMSG to the active channel; publishes a local-echo `chat` event. |
 | `/join` | `#channel` | Joins the channel, sets it active, publishes `roster` + `info`. |
 | `/part` | `#channel` | Parts the channel, publishes `roster` + `info`. |
-| `/send` | `<target> <text…>` | Sends a PRIVMSG to an explicit target (channel or nick); local-echoes a `chat` event. |
+| `/send` | `<target> <text…>` | Sends a PRIVMSG to an explicit target (channel or nick). Local-echoes a `chat` event **only when `target == current_channel`** — sending to a non-active target leaves the chat log untouched (the active pane has no place to render it). |
 | `/help` | — | Switches the info pane to the `help` view; publishes `view` + `info`. |
 | `/overview` | — | Switches the info pane to the `overview` view. |
 | `/status` | — | Switches the info pane to the `status` view. |

--- a/docs/sse-events.md
+++ b/docs/sse-events.md
@@ -10,9 +10,9 @@ and streamed to subscribers. Each subscriber owns a bounded queue
 
 | Event | Payload | Fragment template | Browser target |
 | --- | --- | --- | --- |
-| `chat` | rendered `_chat_line.html.j2` (HTML) | `templates/_chat_line.html.j2` | append into `#chat-log` |
-| `roster` | rendered `_sidebar.html.j2` (HTML) | `templates/_sidebar.html.j2` | replace `#sidebar` innerHTML |
-| `info` | rendered `_info.html.j2` (HTML) | `templates/_info.html.j2` | replace `#info` innerHTML |
+| `chat` | rendered `_chat_line.html.j2` (HTML) | `src/irc_lens/templates/_chat_line.html.j2` | append into `#chat-log` |
+| `roster` | rendered `_sidebar.html.j2` (HTML) | `src/irc_lens/templates/_sidebar.html.j2` | replace `#sidebar` innerHTML |
+| `info` | rendered `_info.html.j2` (HTML) | `src/irc_lens/templates/_info.html.j2` | replace `#info` innerHTML |
 | `view` | JSON `{"view": "chat" \| "help" \| "overview" \| "status"}` | — | set `<body data-view>` attribute |
 | `error` | JSON `{"message": "..."}` | — | toast region (`#toast-region`) |
 
@@ -49,8 +49,10 @@ data: <line 2>
 ```
 
 Multi-line HTML payloads are split into one `data:` line per source
-line, terminated by a blank line, per the SSE spec. Tests pin the
-round-trip in `tests/test_render.py` and `tests/test_web_events.py`.
+line, terminated by a blank line, per the SSE spec. The wire-format
+round-trip is pinned by `tests/test_web_events.py`; per-fragment
+template testids (the `chat`/`roster`/`info` payload bodies) are
+pinned by `tests/test_render.py`.
 
 ## DOM contract (`data-testid` + IDs)
 
@@ -67,14 +69,16 @@ round-trip in `tests/test_render.py` and `tests/test_web_events.py`.
 | `[data-testid="chat-line"]` | `_chat_line.html.j2` | One rendered chat line (timestamp + nick + text spans). |
 | `[data-testid="chat-line-nick"]` | `_chat_line.html.j2` | Nick span. |
 | `[data-testid="chat-line-text"]` | `_chat_line.html.j2` | Text span. |
-| `[data-testid="chat-input"]` | `index.html.j2` | The input element (id `chat-input`). |
+| `[data-testid="chat-input"]` | `index.html.j2` | The input element (also `id="chat-input"`). |
 | `[data-testid="chat-submit"]` | `index.html.j2` | Submit button. |
 | `[data-testid="info"]` | `index.html.j2` | Info-pane container `#info`. |
 | `[data-testid="view-indicator"]` | `_info.html.j2` | Carries `data-view="chat\|help\|overview\|status"`. |
 
-The form element itself is `id="chat-form"` (no `data-testid`); the
-testid lives on the submit button. Tests assert against the testid
-contract above.
+The `<form>` element itself is addressed by `id="chat-form"` (no
+`data-testid`) — tests submit by clicking
+`[data-testid="chat-submit"]` or pressing Enter on
+`[data-testid="chat-input"]`. Every other element tests need to
+drive carries a stable `data-testid`.
 
 ## Browser glue
 

--- a/docs/sse-events.md
+++ b/docs/sse-events.md
@@ -1,0 +1,103 @@
+# Server-Sent Events
+
+`GET /events` opens a long-lived SSE stream. Every event published on
+`Session.event_bus` is serialised by `irc_lens.web.events.format_sse`
+and streamed to subscribers. Each subscriber owns a bounded queue
+(default 256 events) with a drop-oldest policy plus a single-shot
+`error: events dropped` notice.
+
+## Event catalogue
+
+| Event | Payload | Fragment template | Browser target |
+| --- | --- | --- | --- |
+| `chat` | rendered `_chat_line.html.j2` (HTML) | `templates/_chat_line.html.j2` | append into `#chat-log` |
+| `roster` | rendered `_sidebar.html.j2` (HTML) | `templates/_sidebar.html.j2` | replace `#sidebar` innerHTML |
+| `info` | rendered `_info.html.j2` (HTML) | `templates/_info.html.j2` | replace `#info` innerHTML |
+| `view` | JSON `{"view": "chat" \| "help" \| "overview" \| "status"}` | — | set `<body data-view>` attribute |
+| `error` | JSON `{"message": "..."}` | — | toast region (`#toast-region`) |
+
+The `view` and `error` payloads are spec-strict (handover-design
+spec lines 162–163) — additional fields are intentionally not
+emitted to keep the contract tight.
+
+## Publish points
+
+Source: `src/irc_lens/session.py`.
+
+| Trigger | Events published |
+| --- | --- |
+| `_exec_chat(text)` (plain text) | `chat` (local echo) |
+| `_exec_send(target, text)` (`/send`) | `chat` (local echo) |
+| `_exec_join(channel)` (`/join`) | `roster` + `info` |
+| `_exec_part(channel)` (`/part`) | `roster` + `info` |
+| `_switch_view(name)` (`/help`, `/overview`, `/status`) | `view` + `info` |
+| Inbound `PRIVMSG` to active channel | `chat` |
+| Inbound `JOIN` / `PART` (server-confirmed) | `roster` |
+| Any `_publish_error` (invalid input, unsupported verb) | `error` |
+| Subscriber queue overflow | one-shot `error` (`events dropped`) |
+
+## Wire format
+
+`format_sse` produces one event block per `SessionEvent`:
+
+```
+event: <name>
+data: <line 1>
+data: <line 2>
+…
+
+```
+
+Multi-line HTML payloads are split into one `data:` line per source
+line, terminated by a blank line, per the SSE spec. Tests pin the
+round-trip in `tests/test_render.py` and `tests/test_web_events.py`.
+
+## DOM contract (`data-testid` + IDs)
+
+`data-testid` attributes are stable contracts for Playwright agents
+(`docs/playwright.md`) and are pinned by `tests/test_e2e_playwright.py`.
+
+| Selector | Source template | Purpose |
+| --- | --- | --- |
+| `[data-testid="connection-status"]` | `index.html.j2` | Conn-state badge (`lens-conn--healthy` / `lens-conn--down`). |
+| `[data-testid="sidebar"]` | `index.html.j2` | Sidebar wrapper. |
+| `[data-testid="sidebar-channel"]` | `_sidebar.html.j2` | Channel row; carries `data-channel="#x"` and `lens-channel--active` for the current channel. |
+| `[data-testid="sidebar-entity"]` | `_sidebar.html.j2` | Roster row. |
+| `[data-testid="chat-log"]` | `index.html.j2` | Container `#chat-log`. |
+| `[data-testid="chat-line"]` | `_chat_line.html.j2` | One rendered chat line (timestamp + nick + text spans). |
+| `[data-testid="chat-line-nick"]` | `_chat_line.html.j2` | Nick span. |
+| `[data-testid="chat-line-text"]` | `_chat_line.html.j2` | Text span. |
+| `[data-testid="chat-input"]` | `index.html.j2` | The input element (id `chat-input`). |
+| `[data-testid="chat-submit"]` | `index.html.j2` | Submit button. |
+| `[data-testid="info"]` | `index.html.j2` | Info-pane container `#info`. |
+| `[data-testid="view-indicator"]` | `_info.html.j2` | Carries `data-view="chat\|help\|overview\|status"`. |
+
+The form element itself is `id="chat-form"` (no `data-testid`); the
+testid lives on the submit button. Tests assert against the testid
+contract above.
+
+## Browser glue
+
+`src/irc_lens/static/lens.js` (~89 lines) wires the EventSource:
+
+* `chat` → append into `#chat-log` via a `<template>` parse,
+  trimming the oldest line once `#chat-log` exceeds 500 children
+  (mirrors the server-side `MessageBuffer` per-channel cap).
+* `roster` / `info` → replace the matching container's innerHTML.
+* `view` → set `document.body.dataset.view` so CSS keyed off
+  `[data-view="..."]` re-skins the layout.
+* `error` → render a toast in `#toast-region` (`role="alert"` /
+  `aria-live="assertive"`).
+
+EventSource transport-level errors (network drop, server restart)
+flip `body[data-conn="down"]`; reconnect clears the marker.
+
+## Backpressure
+
+`SessionEventBus.publish()` is fire-and-forget. Each subscriber's
+queue is drained by its own coroutine; if the consumer can't keep
+up, the oldest events are dropped and a single `error` event with
+`{"message": "events dropped"}` is enqueued so the UI can surface
+the gap. The next non-overflow publish re-arms the notice. This
+keeps a slow browser tab from blocking publishers without silently
+losing the gap signal.


### PR DESCRIPTION
## Summary

Phase 10 of the irc-lens build plan — documentation deliverables.

* **`docs/cli.md`** — every flag in `serve.py` + the global CLI surface (`learn` / `explain` / `overview`), the exit-code policy with the user-vs-environment split (precedent: `serve.py:107` vs `serve.py:154`), and the `--seed` schema lifted from `seed.py`'s docstring per the Phase 8 TODO.
* **`docs/slash-commands.md`** — verb dictionary split into wired-in-v1 (`CHAT` / `JOIN` / `PART` / `SEND` / `HELP` / `OVERVIEW` / `STATUS`) and recognised-but-not-yet-supported (`TOPIC` / `CHANNELS` / `WHO` / …) with the spec-strict `error` event noted.
* **`docs/sse-events.md`** — every `SessionEvent` name + payload + fragment template + browser target, plus the `data-testid` contract pinned by the Playwright tests, plus the bounded-queue / drop-oldest / events-dropped backpressure story.
* **`docs/playwright.md`** — why we use `playwright.async_api` (loop conflict with pytest-asyncio's auto loop), the fixture stack (`seeded_lens_client` + `basic.yaml`), a worked transcript, and the Playwright MCP variant.
* **`docs/architecture.md`** — grew from a vendored-asset stub into the full reference: runtime topology diagram, module layout, request shapes, event flow, bounded-memory caps, and the decision log (SSE-not-WS / vendor-not-CDN / cite-not-import / in-tree-test-server / seed-on-real-connection / HTTP error shape / exit-code split / dispatch-table contract).
* **`README.md`** — trimmed to a quickstart paragraph, install line, dev-command block, and links into `docs/`. < 50 lines per the build plan's requirement.

## Test plan

- [x] `uv run pytest -q` → `212 passed, 4 deselected` (Playwright marker default-off; same baseline as PR #13).
- [x] `afi cli verify` → 22/22.
- [x] All relative links across `README.md` + `docs/*.md` resolve (verified via a one-off Python checker — every Markdown `[text](path)` whose target isn't `http(s)://` or `#anchor` resolves to an existing file).
- [x] `docs/cli.md` enumerates every `add_argument` in `cli/_commands/serve.py` (9 serve flags + 2 globals = 11 entries in the table).
- [x] `docs/sse-events.md` enumerates every `SessionEvent(name=...)` publish point in `session.py` (`chat` / `roster` / `info` / `view` / `error` + the overflow `error`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)