### PR TITLE
phase 11: trusted-publisher PyPI workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,105 @@
+name: Publish to PyPI
+
+# PR → TestPyPI (`.devN` build, `testpypi` environment).
+# push to main → PyPI (`x.y.z` build, `pypi` environment).
+#
+# The path filter keeps doc-only PRs from churning TestPyPI; bumps to
+# the workflow itself still trigger so changes get validated before
+# they land. Trusted-publishing means no long-lived tokens — both
+# environments are pre-provisioned with PyPI Trusted Publishers
+# pointing at this repo.
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - "pyproject.toml"
+      - "src/**"
+      - ".github/workflows/publish.yml"
+  pull_request:
+    branches: [main]
+    paths:
+      - "pyproject.toml"
+      - "src/**"
+      - ".github/workflows/publish.yml"
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+
+      - uses: astral-sh/setup-uv@38f3f104447c67c051c4a08e39b64a148898af3a # v4
+
+      - run: uv python install 3.12
+
+      - run: uv venv
+
+      - run: uv pip install -e ".[dev]"
+
+      - name: pytest
+        run: uv run pytest -v
+
+  test-publish:
+    if: github.event_name == 'pull_request'
+    needs: test
+    runs-on: ubuntu-latest
+    environment: testpypi
+    permissions:
+      contents: read
+      id-token: write
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+
+      - uses: astral-sh/setup-uv@38f3f104447c67c051c4a08e39b64a148898af3a # v4
+
+      - run: uv python install 3.12
+
+      - name: Mint dev version
+        # Trusted-publishing won't accept the same version twice, so
+        # every PR build needs a unique suffix. `github.run_number` is
+        # monotonic per workflow file and survives re-runs of the same
+        # workflow run (those reuse the run_attempt, not run_number).
+        run: |
+          BASE=$(python -c "import tomllib; print(tomllib.load(open('pyproject.toml','rb'))['project']['version'])")
+          DEV_VERSION="${BASE}.dev${{ github.run_number }}"
+          sed -i "s/^version = .*/version = \"${DEV_VERSION}\"/" pyproject.toml
+          echo "DEV_VERSION=${DEV_VERSION}" >> "$GITHUB_ENV"
+          echo "Publishing ${DEV_VERSION} to TestPyPI"
+
+      - name: Build and publish to TestPyPI
+        run: |
+          uv build
+          uv publish \
+            --publish-url https://test.pypi.org/legacy/ \
+            --trusted-publishing always \
+            --check-url https://test.pypi.org/simple/
+
+      - name: Print install command
+        if: always()
+        run: |
+          echo "::notice::Test with: pip install --index-url https://test.pypi.org/simple/ --extra-index-url https://pypi.org/simple/ irc-lens==${DEV_VERSION}"
+
+  publish:
+    if: github.event_name == 'push'
+    needs: test
+    runs-on: ubuntu-latest
+    environment: pypi
+    permissions:
+      contents: read
+      id-token: write
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+
+      - uses: astral-sh/setup-uv@38f3f104447c67c051c4a08e39b64a148898af3a # v4
+
+      - run: uv python install 3.12
+
+      - name: Build and publish to PyPI
+        run: |
+          uv build
+          uv publish \
+            --trusted-publishing always \
+            --check-url https://pypi.org/simple/

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -12,12 +12,18 @@ name: Publish to PyPI
 on:
   push:
     branches: [main]
+    # Push triggers `publish` against PyPI, which rejects re-uploads of
+    # an existing version. Gate it on `pyproject.toml` so the publish
+    # only fires when `[project] version` bumps. `src/**` changes still
+    # run on PRs (test-publish) and are validated by `ci.yml`'s `test`
+    # job on push to main; we just don't try to re-publish them.
     paths:
       - "pyproject.toml"
-      - "src/**"
       - ".github/workflows/publish.yml"
   pull_request:
     branches: [main]
+    # PRs are safe to run on broader changes — `test-publish` mints a
+    # unique `.devN` per run_number so re-uploads can't collide.
     paths:
       - "pyproject.toml"
       - "src/**"
@@ -62,8 +68,11 @@ jobs:
         # every PR build needs a unique suffix. `github.run_number` is
         # monotonic per workflow file and survives re-runs of the same
         # workflow run (those reuse the run_attempt, not run_number).
+        # Use the uv-installed 3.12 interpreter explicitly so this step
+        # doesn't depend on whatever `python` the runner happens to
+        # ship (tomllib is 3.11+).
         run: |
-          BASE=$(python -c "import tomllib; print(tomllib.load(open('pyproject.toml','rb'))['project']['version'])")
+          BASE=$(uv run --python 3.12 python -c "import tomllib; print(tomllib.load(open('pyproject.toml','rb'))['project']['version'])")
           DEV_VERSION="${BASE}.dev${{ github.run_number }}"
           sed -i "s/^version = .*/version = \"${DEV_VERSION}\"/" pyproject.toml
           echo "DEV_VERSION=${DEV_VERSION}" >> "$GITHUB_ENV"


### PR DESCRIPTION
## Summary

Phase 11 of the irc-lens build plan — the final phase. Adds the
three-job PyPI publish workflow per the build plan, mirroring
`../culture/.github/workflows/publish.yml`:

* **`test`** — `uv run pytest -v` on every PR + push. Mirrors the
  existing `ci.yml` `test` shape (irc-lens uses
  `[project.optional-dependencies]`, not the PEP-735
  `[dependency-groups]`, so plain `uv sync` won't pull in dev
  deps).
* **`test-publish`** — PR-only. Mints
  `${BASE}.dev${{ github.run_number }}`, builds, publishes to
  TestPyPI in the `testpypi` GitHub environment via Trusted
  Publishers. Prints the install command via `::notice::`.
* **`publish`** — push-to-main only. Builds and publishes the
  pyproject `version` to PyPI in the `pypi` GitHub environment
  via Trusted Publishers.

Triggers are path-filtered to `pyproject.toml` + `src/**` +
`.github/workflows/publish.yml` so doc-only PRs don't churn
TestPyPI; bumps to the workflow itself still validate.

Action SHAs pinned to the same v4 commits as the existing
`ci.yml` and culture's reference workflow:

* `actions/checkout@34e114876b…`
* `astral-sh/setup-uv@38f3f10…`

The `pypi` and `testpypi` environments are pre-provisioned in
the repo settings with PyPI Trusted Publishers pointing at
`agentculture/irc-lens` (verified via
`gh api repos/agentculture/irc-lens/environments`). No
long-lived tokens.

## Test plan

- [x] `uv build` locally produces both sdist (`irc_lens-0.1.0.tar.gz`) and wheel (`irc_lens-0.1.0-py3-none-any.whl`).
- [x] Wheel contains `irc_lens/templates/*.j2`, `irc_lens/static/{lens.{js,css},vendor/{htmx.min.js,sse.js}}`, and every `irc_lens/**/*.py` (verified via `unzip -l`).
- [ ] CI `test` job passes (212 default + Playwright opt-in skipped).
- [ ] `test-publish` puts `0.1.0.dev<N>` on TestPyPI in the `testpypi` environment.
- [ ] After merge, `publish` puts `0.1.0` on PyPI in the `pypi` environment.
- [ ] Final acceptance: `pip install irc-lens` succeeds end-to-end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)