### PR TITLE
feat(serve): default --host/--port; only --nick required

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,11 +11,13 @@ or human browser can drive it deterministically.
 
 ```bash
 pip install irc-lens
-irc-lens serve --host 127.0.0.1 --port 6667 --nick lens --open
+irc-lens serve --nick lens --open
 ```
 
-The `--open` flag launches the default browser at the printed
-URL. Quit with Ctrl-C.
+`--host` / `--port` default to a local AgentIRC at `127.0.0.1:6667`
+— supply `--host` / `--port` to point at a remote server. The
+`--open` flag launches the default browser at the printed URL. Quit
+with Ctrl-C.
 
 ## Develop
 

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -88,8 +88,8 @@ then binds the local web port.
 
 | Flag | Required | Default | Purpose |
 | --- | --- | --- | --- |
-| `--host` | yes | — | AgentIRC server host. |
-| `--port` | yes | — | AgentIRC server port. |
+| `--host` | no | `127.0.0.1` | AgentIRC server host. |
+| `--port` | no | `6667` | AgentIRC server port. |
 | `--nick` | yes | — | Nick to register on AgentIRC. |
 | `--web-port` | no | `8765` | Local HTTP port for the lens UI. |
 | `--bind` | no | `127.0.0.1` | Bind address for the local web app. `0.0.0.0` prints a no-auth warning to stderr. |
@@ -118,19 +118,20 @@ then binds the local web port.
 ### Examples
 
 ```bash
-# Local dev against an in-process AgentIRC:
-irc-lens serve --host 127.0.0.1 --port 6667 --nick lens --open
+# Common case — host/port default to a local AgentIRC at 127.0.0.1:6667:
+irc-lens serve --nick lens --open
 
 # Same, with a deterministic preload (Phase 9c Playwright pattern):
-irc-lens serve --host 127.0.0.1 --port 6667 --nick lens \
-    --seed tests/fixtures/basic.yaml
+irc-lens serve --nick lens --seed tests/fixtures/basic.yaml
+
+# Point at a remote AgentIRC:
+irc-lens serve --host irc.example.org --port 6667 --nick ops
 
 # Bind to all interfaces (warning printed, no auth in v1):
-irc-lens serve --host irc.example.org --port 6667 --nick ops \
-    --bind 0.0.0.0 --web-port 8080
+irc-lens serve --nick ops --bind 0.0.0.0 --web-port 8080
 
 # JSON-line stderr for log shipping:
-irc-lens serve --host 127.0.0.1 --port 6667 --nick lens --log-json
+irc-lens serve --nick lens --log-json
 ```
 
 ## Seed schema

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "irc-lens"
-version = "0.1.0"
+version = "0.2.0"
 description = "Reactive web console for AgentIRC — Playwright-driveable lens for the Culture mesh."
 readme = "README.md"
 requires-python = ">=3.11"

--- a/src/irc_lens/cli/__init__.py
+++ b/src/irc_lens/cli/__init__.py
@@ -41,6 +41,25 @@ def _argv_requested_json(argv: list[str] | None) -> bool:
 _PARSE_JSON_MODE: bool = False
 
 
+_SERVE_NICK_HINT = (
+    "try 'irc-lens serve --nick <name>' (e.g. --nick lens); "
+    "run 'irc-lens serve --help' for all flags"
+)
+
+
+def _hint_for(prog: str, message: str) -> str:
+    """Pick a remediation tailored to the failing parser + message.
+
+    The default ``run '<prog> --help' …`` is fine for most cases, but when
+    ``serve`` complains about a missing required arg (now just ``--nick``
+    after the host/port defaults) a concrete example is more useful than a
+    pointer to ``--help``.
+    """
+    if prog == "irc-lens serve" and "--nick" in message and "required" in message:
+        return _SERVE_NICK_HINT
+    return f"run '{prog} --help' to see valid arguments"
+
+
 class _ArgumentParser(argparse.ArgumentParser):
     """ArgumentParser that emits errors via our structured format."""
 
@@ -48,7 +67,7 @@ class _ArgumentParser(argparse.ArgumentParser):
         err = AfiError(
             code=EXIT_USER_ERROR,
             message=message,
-            remediation=f"run '{self.prog} --help' to see valid arguments",
+            remediation=_hint_for(self.prog, message),
         )
         emit_error(err, json_mode=_PARSE_JSON_MODE)
         raise SystemExit(err.code)

--- a/src/irc_lens/cli/_commands/serve.py
+++ b/src/irc_lens/cli/_commands/serve.py
@@ -7,7 +7,10 @@ fail-fast on connect, then ``aiohttp.web.run_app``. The Phase 5 wiring
 
 Spec contract enforced:
 
-* ``--host`` / ``--port`` / ``--nick`` are required.
+* ``--nick`` is required (identity is the user's choice — no safe default).
+* ``--host`` / ``--port`` default to ``127.0.0.1`` / ``6667`` so a bare
+  ``irc-lens serve --nick <name>`` reaches a local AgentIRC out of the
+  box. Override either flag to point at a remote server.
 * ``--bind 0.0.0.0`` prints a loud stderr warning (no auth in v1).
 * AgentIRC unreachable → ``error:`` + ``hint:`` on stderr, exit 1,
   aiohttp never binds.
@@ -198,10 +201,39 @@ def register(sub: argparse._SubParsersAction) -> None:
     p = sub.add_parser(
         "serve",
         help="Launch the aiohttp web console against an AgentIRC server.",
+        description=(
+            "Launch the aiohttp web console against an AgentIRC server. "
+            "Defaults target a local culture server on 127.0.0.1:6667 — only "
+            "--nick is required for the common case."
+        ),
+        epilog=(
+            "examples:\n"
+            "  irc-lens serve --nick lens\n"
+            "      Connect to a local AgentIRC (127.0.0.1:6667) and serve the\n"
+            "      web console on http://127.0.0.1:8765/.\n"
+            "  irc-lens serve --nick lens --open\n"
+            "      Same, and auto-launch your default browser at the URL.\n"
+            "  irc-lens serve --host irc.example.org --port 6667 --nick ops\n"
+            "      Point at a remote AgentIRC server.\n"
+        ),
+        formatter_class=argparse.RawDescriptionHelpFormatter,
     )
-    p.add_argument("--host", required=True, help="AgentIRC server host.")
-    p.add_argument("--port", required=True, type=int, help="AgentIRC server port.")
-    p.add_argument("--nick", required=True, help="Nick to register on AgentIRC.")
+    p.add_argument(
+        "--host",
+        default="127.0.0.1",
+        help="AgentIRC server host (default: 127.0.0.1).",
+    )
+    p.add_argument(
+        "--port",
+        type=int,
+        default=6667,
+        help="AgentIRC server port (default: 6667).",
+    )
+    p.add_argument(
+        "--nick",
+        required=True,
+        help="Nick to register on AgentIRC (e.g. --nick lens).",
+    )
     p.add_argument(
         "--web-port",
         type=int,

--- a/src/irc_lens/cli/_commands/serve.py
+++ b/src/irc_lens/cli/_commands/serve.py
@@ -218,16 +218,20 @@ def register(sub: argparse._SubParsersAction) -> None:
         ),
         formatter_class=argparse.RawDescriptionHelpFormatter,
     )
+    # `%(default)s` lets argparse render the actual default at help-time,
+    # so the rendered "(default: …)" string can never drift from the
+    # `default=` value. Guarded by
+    # tests/test_serve_cli.py::test_serve_help_renders_defaults_from_argparse.
     p.add_argument(
         "--host",
         default="127.0.0.1",
-        help="AgentIRC server host (default: 127.0.0.1).",
+        help="AgentIRC server host (default: %(default)s).",
     )
     p.add_argument(
         "--port",
         type=int,
         default=6667,
-        help="AgentIRC server port (default: 6667).",
+        help="AgentIRC server port (default: %(default)s).",
     )
     p.add_argument(
         "--nick",
@@ -238,13 +242,13 @@ def register(sub: argparse._SubParsersAction) -> None:
         "--web-port",
         type=int,
         default=8765,
-        help="Local HTTP port for the lens UI (default: 8765).",
+        help="Local HTTP port for the lens UI (default: %(default)s).",
     )
     p.add_argument(
         "--bind",
         default="127.0.0.1",
         help=(
-            "Bind address for the local web app (default: 127.0.0.1). "
+            "Bind address for the local web app (default: %(default)s). "
             "Using 0.0.0.0 prints a warning — there is no auth in v1."
         ),
     )

--- a/tests/test_serve_cli.py
+++ b/tests/test_serve_cli.py
@@ -111,6 +111,12 @@ def test_serve_requires_only_nick(
     # defaults.
     assert "--host" not in err
     assert "--port" not in err
+    # The hint must be the serve-specific copy-pasteable form, NOT the
+    # generic `run '<prog> --help'` fallback. This is the regression
+    # Copilot flagged on PR #16: a weaker assertion would silently pass
+    # if `_hint_for` regressed to the generic branch.
+    hint_line = next(line for line in err.splitlines() if "hint:" in line)
+    assert "try 'irc-lens serve --nick" in hint_line
 
 
 def test_serve_help_lists_all_flags(capsys: pytest.CaptureFixture[str]) -> None:
@@ -131,6 +137,46 @@ def test_serve_help_lists_all_flags(capsys: pytest.CaptureFixture[str]) -> None:
         "--log-json",
     ):
         assert flag in out, f"--help missing flag {flag!r}"
+
+
+def test_serve_help_renders_defaults_from_argparse(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """Help text for each defaulted flag must show the argparse-stored
+    default value verbatim. This is the drift-catcher Copilot flagged on
+    PR #16: hard-coding the default in the `help=` string makes it
+    possible to change `default=` without updating the help — using
+    `%(default)s` (or any equivalent) keeps them in lockstep, and this
+    test asserts the rendered output proves it.
+
+    Driving the assertion from `parser._actions` rather than the literal
+    values means a future bump (e.g. default --port → 6668) only needs
+    the `default=` change; the test re-derives the expected help string.
+    """
+    from irc_lens.cli import _build_parser  # noqa: PLC0415 - local import keeps the test self-contained
+
+    parser = _build_parser()
+    serve_parser = parser._subparsers._group_actions[0].choices["serve"]
+    expected: dict[str, object] = {
+        action.option_strings[0]: action.default
+        for action in serve_parser._actions
+        if action.option_strings
+        and action.default is not None
+        and action.default is not False  # store_true flags
+        and action.dest != "help"
+    }
+
+    with pytest.raises(SystemExit):
+        main(["serve", "--help"])
+    out = capsys.readouterr().out
+
+    # Every defaulted flag's stored default must surface in the rendered help.
+    for flag, default_value in expected.items():
+        token = f"(default: {default_value})"
+        assert token in out, (
+            f"--help text for {flag} is out of sync with argparse default "
+            f"{default_value!r}: expected to find {token!r} in output"
+        )
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_serve_cli.py
+++ b/tests/test_serve_cli.py
@@ -91,18 +91,26 @@ def successful_connect(monkeypatch: pytest.MonkeyPatch):
 # ---------------------------------------------------------------------------
 
 
-def test_serve_requires_host_port_nick(
+def test_serve_requires_only_nick(
     capsys: pytest.CaptureFixture[str],
 ) -> None:
-    """Missing required flags must error via the AfiError + hint contract,
-    not an argparse traceback."""
+    """``--host`` / ``--port`` default to a local AgentIRC, so only ``--nick``
+    is required. The bare ``irc-lens serve`` invocation still must error via
+    the AfiError + hint contract (no argparse traceback) and the hint must
+    point at the concrete fix — supplying ``--nick``."""
     with pytest.raises(SystemExit) as exc:
         main(["serve"])
     assert exc.value.code != 0
     err = capsys.readouterr().err
     assert "error:" in err
     assert "hint:" in err
+    assert "--nick" in err
     assert "Traceback" not in err
+    # The argparse "required" complaint must mention nick and ONLY nick now
+    # that host/port have defaults — guards against silent regression of the
+    # defaults.
+    assert "--host" not in err
+    assert "--port" not in err
 
 
 def test_serve_help_lists_all_flags(capsys: pytest.CaptureFixture[str]) -> None:

--- a/uv.lock
+++ b/uv.lock
@@ -528,7 +528,7 @@ wheels = [
 
 [[package]]
 name = "irc-lens"
-version = "0.1.0"
+version = "0.2.0"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },


### PR DESCRIPTION
## Summary

- `irc-lens serve` now defaults `--host` to `127.0.0.1` and `--port` to `6667`, so the common local-culture case is just `irc-lens serve --nick <name>`. Override either flag to point at a remote server.
- `irc-lens serve --help` gains a description + examples block (`RawDescriptionHelpFormatter`) so users see concrete invocations alongside the flag list.
- Missing `--nick` now hints with a copy-pasteable example (`try 'irc-lens serve --nick <name>' (e.g. --nick lens); …`) instead of a bare "see --help" pointer. The new `_hint_for(prog, message)` helper keeps the rule local and tested.
- README quickstart and `docs/cli.md` examples updated to the simpler form.

Drives a UX gap surfaced post-deploy: `irc-lens serve --nick ori` previously bailed with `error: the following arguments are required: --host, --port` and no concrete next step. With v0.1.0 already on PyPI, this ships as v0.2.0.

## Test plan

- [x] `uv run pytest -q` — 212 passed, 4 deselected
- [x] `uv run irc-lens serve` — exits 1, error mentions only `--nick`, hint is the new copy-pasteable form
- [x] `uv run irc-lens serve --nick lens-explore --web-port 18765 --seed tests/fixtures/basic.yaml` — binds, `curl /` returns 200, fixture renders ≥ 2 chat-lines
- [x] `uv run irc-lens serve --help` shows defaults + examples block
- [x] `tests/test_serve_cli.py::test_serve_requires_only_nick` guards the regression — bare `serve` must error mentioning `--nick` and NOT `--host`/`--port`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

- Claude