### PR TITLE
fix(session): serialize Session.execute() per session (closes #22)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "irc-lens"
-version = "0.4.1"
+version = "0.4.2"
 description = "Reactive web console for AgentIRC — Playwright-driveable lens for the Culture mesh."
 readme = "README.md"
 requires-python = ">=3.11"

--- a/src/irc_lens/session.py
+++ b/src/irc_lens/session.py
@@ -293,7 +293,14 @@ class Session:
         # out-of-order observable side effects. Issue #22.
         # Distinct from `_query_locks` above, which de-conflicts
         # collect-buffers for IRC numerics carrying no query-id.
-        self._exec_lock = asyncio.Lock()
+        # Lazy + loop-bound: asyncio.Lock binds to the first event loop
+        # that contends it and raises on a different loop. Tests drive
+        # one Session via repeated asyncio.run(...) calls (fresh loop
+        # each), so we re-create the lock when the running loop changes
+        # — see _get_exec_lock(). In production aiohttp runs one loop
+        # for the server's lifetime, so this branch fires once.
+        self._exec_lock: asyncio.Lock | None = None
+        self._exec_lock_loop: asyncio.AbstractEventLoop | None = None
 
         # Event bus: Phase 5 will wire publishes; Phase 3 just holds it.
         self.event_bus = event_bus if event_bus is not None else SessionEventBus()
@@ -479,6 +486,21 @@ class Session:
     # Command execution + inbound dispatch (Phase 5 SSE wiring)
     # ------------------------------------------------------------------
 
+    def _get_exec_lock(self) -> asyncio.Lock:
+        """Per-running-loop dispatch lock. ``asyncio.Lock`` binds to the
+        first event loop that contends it (see ``_LoopBoundMixin``) and
+        raises ``RuntimeError`` on later loops. Tests drive one
+        ``Session`` via repeated ``asyncio.run(...)`` calls — each
+        spawns a fresh loop — so contended use across calls would
+        crash without this reset. Production hits the rebind branch
+        exactly once, when aiohttp's loop first contends the lock.
+        """
+        loop = asyncio.get_running_loop()
+        if self._exec_lock is None or self._exec_lock_loop is not loop:
+            self._exec_lock = asyncio.Lock()
+            self._exec_lock_loop = loop
+        return self._exec_lock
+
     async def execute(self, parsed: ParsedCommand) -> None:
         """Dispatch a `ParsedCommand` from `POST /input`.
 
@@ -489,11 +511,11 @@ class Session:
         unsupported-yet types publish an ``error`` event and return
         normally — typing ``/foo`` should never crash a browser session.
 
-        The body runs under ``self._exec_lock`` so two concurrent
+        The body runs under a per-loop dispatch lock so two concurrent
         ``POST /input`` handlers against the same Session execute in
         submission order rather than interleaving (issue #22).
         """
-        async with self._exec_lock:
+        async with self._get_exec_lock():
             handler = self._exec_dispatch.get(parsed.type, self._exec_unsupported)
             await handler(parsed)
 

--- a/src/irc_lens/session.py
+++ b/src/irc_lens/session.py
@@ -285,6 +285,16 @@ class Session:
         # WHO #b) don't block each other.
         self._query_locks: dict[str, asyncio.Lock] = {}
 
+        # Per-session dispatch lock. Serialises Session.execute() so two
+        # POST /input handlers against the same lens cannot interleave
+        # their verb logic. Without this, any verb that awaits I/O
+        # (LIST, WHO, HISTORY, ...) can yield to a concurrent verb that
+        # mutates view/current_channel/joined_channels/roster, producing
+        # out-of-order observable side effects. Issue #22.
+        # Distinct from `_query_locks` above, which de-conflicts
+        # collect-buffers for IRC numerics carrying no query-id.
+        self._exec_lock = asyncio.Lock()
+
         # Event bus: Phase 5 will wire publishes; Phase 3 just holds it.
         self.event_bus = event_bus if event_bus is not None else SessionEventBus()
 
@@ -478,9 +488,14 @@ class Session:
         layer can translate it to HTTP 503; ``UNKNOWN`` and
         unsupported-yet types publish an ``error`` event and return
         normally — typing ``/foo`` should never crash a browser session.
+
+        The body runs under ``self._exec_lock`` so two concurrent
+        ``POST /input`` handlers against the same Session execute in
+        submission order rather than interleaving (issue #22).
         """
-        handler = self._exec_dispatch.get(parsed.type, self._exec_unsupported)
-        await handler(parsed)
+        async with self._exec_lock:
+            handler = self._exec_dispatch.get(parsed.type, self._exec_unsupported)
+            await handler(parsed)
 
     @property
     def _exec_dispatch(self) -> dict[CommandType, Any]:

--- a/tests/test_session_dispatch.py
+++ b/tests/test_session_dispatch.py
@@ -683,3 +683,63 @@ def test_channels_drops_publish_when_view_changed_during_query(
     assert names == [], (
         f"late LIST completion must publish nothing once view changed; got {names}"
     )
+
+
+def test_execute_serializes_concurrent_invocations(session: Session) -> None:
+    """Issue #22: two concurrent ``Session.execute()`` calls on the same
+    session must run in submission order, not interleave. Without
+    ``self._exec_lock``, the second verb's body could enter while the
+    first is still awaiting I/O — observable as out-of-order
+    side-effects on view/current_channel/roster from the same lens
+    client. Substitutes two verb helpers with ordering recorders so the
+    test stays focused on the dispatch lock, not specific verb logic."""
+
+    order: list[str] = []
+    first_inside = asyncio.Event()
+    release_first = asyncio.Event()
+
+    async def slow_first(_parsed: ParsedCommand) -> None:
+        order.append("first:enter")
+        first_inside.set()
+        await release_first.wait()
+        order.append("first:exit")
+
+    async def fast_second(_parsed: ParsedCommand) -> None:
+        order.append("second:enter")
+        order.append("second:exit")
+
+    # Substitute two existing verbs with our trackers. The
+    # `_exec_dispatch` property re-reads `self._exec_*` on each call,
+    # so an instance-level override wins over the bound method.
+    session._exec_channels = slow_first  # type: ignore[assignment]
+    session._exec_help = fast_second  # type: ignore[assignment]
+
+    async def run() -> None:
+        first = asyncio.create_task(
+            session.execute(ParsedCommand(type=CommandType.CHANNELS))
+        )
+        # Wait until the first verb has actually entered the lock.
+        await first_inside.wait()
+        # Schedule the second; under the lock it must block on
+        # `_exec_lock` until the first releases.
+        second = asyncio.create_task(
+            session.execute(ParsedCommand(type=CommandType.HELP))
+        )
+        # Yield twice to give the loop a chance to (incorrectly) start
+        # the second verb if the lock weren't there.
+        await asyncio.sleep(0)
+        await asyncio.sleep(0)
+        assert "second:enter" not in order, (
+            f"second verb entered while first was still awaiting; order={order}"
+        )
+        release_first.set()
+        await asyncio.gather(first, second)
+
+    asyncio.run(run())
+
+    assert order == [
+        "first:enter",
+        "first:exit",
+        "second:enter",
+        "second:exit",
+    ], f"verbs did not run in submission order: {order}"

--- a/tests/test_session_dispatch.py
+++ b/tests/test_session_dispatch.py
@@ -743,3 +743,48 @@ def test_execute_serializes_concurrent_invocations(session: Session) -> None:
         "second:enter",
         "second:exit",
     ], f"verbs did not run in submission order: {order}"
+
+
+def test_execute_lock_rebinds_across_event_loops(session: Session) -> None:
+    """Issue #22 follow-up (Qodo + Copilot review): tests drive one
+    Session via repeated ``asyncio.run(...)`` calls — each spawns a
+    fresh event loop. ``asyncio.Lock`` binds to the first loop that
+    contends it and raises ``RuntimeError`` on later loops. The
+    per-loop rebind in ``Session._get_exec_lock`` keeps cross-loop
+    drives safe; this test contends the lock in *both* loops to
+    exercise the rebind path (the bug only fires under contention)."""
+
+    async def contend() -> list[str]:
+        order: list[str] = []
+        first_inside = asyncio.Event()
+        release_first = asyncio.Event()
+
+        async def slow_first(_parsed: ParsedCommand) -> None:
+            order.append("a")
+            first_inside.set()
+            await release_first.wait()
+
+        async def fast_second(_parsed: ParsedCommand) -> None:
+            order.append("b")
+
+        session._exec_help = slow_first  # type: ignore[assignment]
+        session._exec_overview = fast_second  # type: ignore[assignment]
+
+        first = asyncio.create_task(
+            session.execute(ParsedCommand(type=CommandType.HELP))
+        )
+        await first_inside.wait()
+        second = asyncio.create_task(
+            session.execute(ParsedCommand(type=CommandType.OVERVIEW))
+        )
+        # Yield twice so the second task has a chance to contend.
+        await asyncio.sleep(0)
+        await asyncio.sleep(0)
+        release_first.set()
+        await asyncio.gather(first, second)
+        return order
+
+    assert asyncio.run(contend()) == ["a", "b"]
+    # Same Session, fresh loop, contended again. Without the rebind
+    # this would raise: "Lock is bound to a different event loop".
+    assert asyncio.run(contend()) == ["a", "b"]

--- a/tests/test_session_dispatch.py
+++ b/tests/test_session_dispatch.py
@@ -705,6 +705,10 @@ def test_execute_serializes_concurrent_invocations(session: Session) -> None:
         order.append("first:exit")
 
     async def fast_second(_parsed: ParsedCommand) -> None:
+        # `asyncio.sleep(0)` keeps sonarcloud's S7503 ("async without
+        # await") quiet without changing semantics — same trick as
+        # `_stub_async_return` above.
+        await asyncio.sleep(0)
         order.append("second:enter")
         order.append("second:exit")
 
@@ -765,6 +769,8 @@ def test_execute_lock_rebinds_across_event_loops(session: Session) -> None:
             await release_first.wait()
 
         async def fast_second(_parsed: ParsedCommand) -> None:
+            # See note in test_execute_serializes_concurrent_invocations.
+            await asyncio.sleep(0)
             order.append("b")
 
         session._exec_help = slow_first  # type: ignore[assignment]

--- a/uv.lock
+++ b/uv.lock
@@ -528,7 +528,7 @@ wheels = [
 
 [[package]]
 name = "irc-lens"
-version = "0.4.1"
+version = "0.4.2"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },


### PR DESCRIPTION
## Summary

- Adds a per-`Session` `asyncio.Lock` (`self._exec_lock`) and wraps the body of `Session.execute()` so two concurrent `POST /input` handlers against the same lens execute in submission order, not interleaved.
- Closes #22. The verb-level `view_at_start` snapshot guards from PR #21 (and the `_fetch_and_publish_history` view-channel guard) stay in place — they still defend against state mutation from the inbound IRC read loop, which the dispatcher lock does not gate.
- Bumps version 0.4.1 → 0.4.2.

## Why

PR #21 patched the specific stale-view race in `/channels` `/who` `/agents`. Qodo flagged that the root cause is structural: aiohttp does not serialize concurrent handlers against the same `Session`, and any verb that awaits I/O (LIST, WHO, HISTORY, future ops) can yield to another verb that mutates view/current_channel/joined_channels/roster, producing out-of-order observable side effects from the same lens. The lock removes that class of dispatcher-vs-dispatcher races so future point fixes don't keep stacking up.

Trade-off (called out in the issue): a slow query holds head-of-line for up to `QUERY_TIMEOUT` (10 s). If that becomes restrictive in practice we can move to a queue-with-cancel design — captured as out-of-scope here.

## Notes

- `Session.execute()` is invoked from exactly one place (`src/irc_lens/web/routes.py:153`); no recursion.
- `_query_locks` (per-query-key, de-conflicts collect buffers for IRC numerics with no query-id) is an orthogonal concern and unchanged.
- Per-verb snapshot guards intentionally retained — see #22 "Once this lands". A follow-up PR can audit each one against the read loop's actual mutation paths and remove the truly redundant ones.

## Test plan

- [x] New `tests/test_session_dispatch.py::test_execute_serializes_concurrent_invocations` — drives two concurrent `session.execute()` calls; asserts the second verb does not enter while the first is still awaiting, then verifies submission-order completion.
- [x] Existing race-related tests stay green: `test_channels_drops_publish_when_view_changed_during_query`, `test_concurrent_list_calls_serialize`.
- [x] Full pytest suite (excluding playwright marker): 241 passed.
- [ ] Smoke (optional): start the lens; issue `/channels` then immediately `/help` from the same lens — `/help` lands after `/channels`'s LIST publish (or the snapshot guard drops it), never before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

- Claude