### PR TITLE
Phase 1: config foundation (LensConfig + irc-lens config init)

### DIFF
--- a/docs/superpowers/plans/2026-05-07-remote-connect-cloudflare-access.md
+++ b/docs/superpowers/plans/2026-05-07-remote-connect-cloudflare-access.md
@@ -1,0 +1,3452 @@
+# Remote-connect via Cloudflare Access — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make `irc-lens serve` deployable behind Cloudflare Tunnel + Cloudflare Access, with per-user Sessions keyed by validated identity, while keeping local dev frictionless.
+
+**Architecture:** A single `~/.config/irc-lens/config.yaml` selects `auth.mode: dev | cloudflare-access`. Dev mode preserves today's single-Session behavior with a synthetic identity. CF mode validates Cloudflare Access JWTs, derives per-user nicks (`<server>-<sanitized-local-part>`), and lazily opens one IRC `Session` per principal. New `web/auth.py`, `web/identity.py`, `web/sessions.py` modules; `make_app(session)` becomes `make_app(config)`.
+
+**Tech Stack:** Python 3.11+, aiohttp, PyJWT (new), cryptography (new for JWT verify), PyYAML (already present), pytest / pytest-asyncio / pytest-aiohttp, Playwright (existing e2e), Cloudflare Tunnel + Access (operational), `cloudflared` (operational).
+
+**Spec reference:** `docs/superpowers/specs/2026-05-06-remote-connect-cloudflare-access-design.md`.
+
+**Follow-up issues:** [#27 (CSRF tokens)](https://github.com/agentculture/irc-lens/issues/27), [#28 (CF round-trip GHA automation)](https://github.com/agentculture/irc-lens/issues/28).
+
+---
+
+## File Structure
+
+### New files
+
+| Path | Responsibility |
+| --- | --- |
+| `src/irc_lens/config.py` | YAML config loader, schema validation, defaults, `LensConfig` dataclass. |
+| `src/irc_lens/cli/_commands/config_cmd.py` | `irc-lens config init` and `irc-lens config overview` verbs. |
+| `src/irc_lens/web/identity.py` | `Identity` NamedTuple, `derive_nick()` pure function. |
+| `src/irc_lens/web/auth.py` | CF Access JWT verification, JWKS fetch + cache, middleware factory. |
+| `src/irc_lens/web/sessions.py` | Per-principal Session registry, `get_or_open_session()`, registry shutdown. |
+| `src/irc_lens/web/templates/error.html.j2` | Tiny error page for 503s on lazy-open. |
+| `tests/test_config_loader.py` | Schema validation + defaults + CLI override precedence. |
+| `tests/test_identity.py` | `derive_nick()` cases — sanitization, prefix, empty-after-strip. |
+| `tests/test_auth_middleware.py` | JWT verify + middleware happy/sad paths against a fake JWKS server. |
+| `tests/test_session_registry.py` | Lazy open, double-check lock, shutdown-disconnects-all. |
+| `tests/test_serve_cf_mode.py` | `--nick` rejected, `--bind` coercion notice, JWKS fail-fast on startup. |
+| `tests/test_origin_check.py` | `POST /input` Origin/Referer floor. |
+| `tests/test_healthz.py` | `/healthz` opaque response, no auth, no IRC state. |
+| `tests/test_cf_roundtrip.py` | Real-CF round-trip (skipped unless env set, `@pytest.mark.cloudflare`). |
+| `tests/_jwks_server.py` | In-tree fake JWKS aiohttp server fixture (mirrors `_agentirc_server.py` pattern). |
+| `scripts/cf-roundtrip/setup.sh` | Idempotent CF tunnel/DNS/Access/service-token bootstrap. |
+| `scripts/cf-roundtrip/teardown.sh` | Tear down everything `setup.sh` created. |
+| `docs/deployment-cloudflare-access.md` | Domain-neutral runbook. |
+| `docs/auth.md` | Auth protocol reference. |
+| `docs/security-checklist.md` | Pre-launch yes/no list. |
+
+### Modified files
+
+| Path | Reason |
+| --- | --- |
+| `pyproject.toml` | Add `pyjwt[crypto]` and bump version. New `cloudflare` pytest marker. |
+| `src/irc_lens/web/__init__.py` | Export new symbols if needed. |
+| `src/irc_lens/web/app.py` | `make_app(config)` instead of `make_app(session)`. Mounts middleware, registers /healthz. |
+| `src/irc_lens/web/routes.py` | Use `get_or_open_session`, add `/healthz`, add Origin/Referer check. |
+| `src/irc_lens/cli/_commands/serve.py` | Load config, branch on `auth.mode`, gate `--nick`, coerce `--bind`. |
+| `src/irc_lens/cli/__init__.py` | Register the `config` noun group. |
+| `tests/conftest.py` | New `dev_config` and config-based `lens_client` fixtures; preserve old fixtures for backward-compat where simple. |
+| `docs/architecture.md` | Add deployment-modes subsection. |
+| `docs/cli.md` | Document `--config`, `irc-lens config init`, `--nick`-rejected-in-CF rule. |
+| `README.md` | Pointer to the runbook. |
+
+### Phasing (commit boundaries)
+
+Each phase below maps to one PR. Tasks are ordered for TDD; commit between tasks where called out.
+
+| Phase | Scope | Approx tasks |
+| --- | --- | --- |
+| 1 | Config loader + `irc-lens config init` (no behavior change yet) | T1.1–T1.6 |
+| 2 | Per-user Session registry under dev mode | T2.1–T2.6 |
+| 3 | CF auth middleware + JWT verification | T3.1–T3.7 |
+| 4 | CLI/HTTP cleanups (`--nick`/`--bind`/`/healthz`/Origin) | T4.1–T4.5 |
+| 5 | Docs + round-trip scripts + CF round-trip test | T5.1–T5.6 |
+
+---
+
+## Phase 1 — Config foundation
+
+### Task 1.1: Add PyJWT to dependencies, register `cloudflare` pytest marker
+
+**Files:**
+- Modify: `pyproject.toml`
+
+- [ ] **Step 1: Edit `pyproject.toml` to add `pyjwt[crypto]` and the new marker**
+
+In the `[project] dependencies` block, add `pyjwt[crypto]>=2.8` after `pyyaml>=6.0`:
+
+```toml
+dependencies = [
+    "aiohttp>=3.9",
+    "jinja2>=3.1",
+    "pyyaml>=6.0",
+    "pyjwt[crypto]>=2.8",
+]
+```
+
+In the `[tool.pytest.ini_options] markers` block, append the cloudflare marker:
+
+```toml
+markers = [
+    "playwright: opt-in browser end-to-end tests (requires `playwright install chromium`).",
+    "cloudflare: opt-in real-Cloudflare round-trip tests (requires CF_API_TOKEN and friends).",
+]
+```
+
+Update `addopts` to also exclude `cloudflare` by default:
+
+```toml
+addopts = "-m 'not playwright and not cloudflare'"
+```
+
+- [ ] **Step 2: Sync the lockfile**
+
+Run: `uv sync --extra dev`
+Expected: `uv.lock` updates; `import jwt` works in the venv.
+
+- [ ] **Step 3: Verify import**
+
+Run: `uv run python -c "import jwt; from jwt import PyJWKClient; print(jwt.__version__)"`
+Expected: prints a version `>= 2.8`.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add pyproject.toml uv.lock
+git commit -m "chore: add pyjwt[crypto] dependency, cloudflare pytest marker"
+```
+
+---
+
+### Task 1.2: Write failing tests for `LensConfig` schema validation
+
+**Files:**
+- Create: `tests/test_config_loader.py`
+
+- [ ] **Step 1: Write the failing tests**
+
+```python
+"""Schema validation, defaults, and override semantics for LensConfig."""
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from irc_lens.cli._errors import EXIT_USER_ERROR, AfiError
+from irc_lens.config import LensConfig, load_config
+
+
+def _write(tmp_path: Path, body: str) -> Path:
+    p = tmp_path / "config.yaml"
+    p.write_text(body)
+    return p
+
+
+def test_dev_mode_minimal_loads(tmp_path: Path) -> None:
+    cfg = load_config(_write(tmp_path, """
+auth:
+  mode: dev
+  dev:
+    nick: lens
+    email: dev@local
+server:
+  name: spark
+"""))
+    assert cfg.auth_mode == "dev"
+    assert cfg.dev_nick == "lens"
+    assert cfg.dev_email == "dev@local"
+    assert cfg.server_name == "spark"
+    assert cfg.server_host == "127.0.0.1"   # default
+    assert cfg.server_port == 6667          # default
+    assert cfg.web_bind == "127.0.0.1"      # default
+    assert cfg.web_port == 8765             # default
+
+
+def test_cf_mode_minimal_loads(tmp_path: Path) -> None:
+    cfg = load_config(_write(tmp_path, """
+auth:
+  mode: cloudflare-access
+  cloudflare:
+    aud: aud-tag
+    team_domain: team.cloudflareaccess.com
+  allowed_emails:
+    - alice@example.com
+server:
+  name: spark
+"""))
+    assert cfg.auth_mode == "cloudflare-access"
+    assert cfg.cf_aud == "aud-tag"
+    assert cfg.cf_team_domain == "team.cloudflareaccess.com"
+    assert cfg.allowed_emails == ("alice@example.com",)
+    assert cfg.allowed_service_tokens == ()
+
+
+def test_cf_mode_missing_aud_errors(tmp_path: Path) -> None:
+    with pytest.raises(AfiError) as exc:
+        load_config(_write(tmp_path, """
+auth:
+  mode: cloudflare-access
+  cloudflare:
+    team_domain: team.cloudflareaccess.com
+  allowed_emails:
+    - alice@example.com
+server:
+  name: spark
+"""))
+    assert exc.value.code == EXIT_USER_ERROR
+    assert "auth.cloudflare.aud" in exc.value.message
+
+
+def test_dev_mode_missing_dev_section_errors(tmp_path: Path) -> None:
+    with pytest.raises(AfiError) as exc:
+        load_config(_write(tmp_path, """
+auth:
+  mode: dev
+server:
+  name: spark
+"""))
+    assert "auth.dev.nick" in exc.value.message
+
+
+def test_unknown_mode_errors(tmp_path: Path) -> None:
+    with pytest.raises(AfiError) as exc:
+        load_config(_write(tmp_path, """
+auth:
+  mode: oauth-passport
+server:
+  name: spark
+"""))
+    assert "auth.mode" in exc.value.message
+    assert "dev" in exc.value.remediation
+    assert "cloudflare-access" in exc.value.remediation
+
+
+def test_missing_file_errors(tmp_path: Path) -> None:
+    with pytest.raises(AfiError) as exc:
+        load_config(tmp_path / "nope.yaml")
+    assert exc.value.code == EXIT_USER_ERROR
+    assert "config init" in exc.value.remediation
+
+
+def test_malformed_yaml_errors(tmp_path: Path) -> None:
+    with pytest.raises(AfiError) as exc:
+        load_config(_write(tmp_path, "::: not: yaml :::"))
+    assert "YAML" in exc.value.message or "parse" in exc.value.message
+
+
+def test_empty_allowed_emails_errors_in_cf_mode(tmp_path: Path) -> None:
+    with pytest.raises(AfiError) as exc:
+        load_config(_write(tmp_path, """
+auth:
+  mode: cloudflare-access
+  cloudflare:
+    aud: aud-tag
+    team_domain: team.cloudflareaccess.com
+  allowed_emails: []
+server:
+  name: spark
+"""))
+    assert "allowed_emails" in exc.value.message
+    assert "empty" in exc.value.message.lower()
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `uv run pytest tests/test_config_loader.py -v`
+Expected: FAIL with `ImportError: cannot import name 'LensConfig' from 'irc_lens.config'`.
+
+- [ ] **Step 3: Commit failing test**
+
+```bash
+git add tests/test_config_loader.py
+git commit -m "test: failing tests for LensConfig schema validation"
+```
+
+---
+
+### Task 1.3: Implement `LensConfig` and `load_config`
+
+**Files:**
+- Create: `src/irc_lens/config.py`
+
+- [ ] **Step 1: Write the loader**
+
+```python
+"""YAML config loader and schema for irc-lens.
+
+One file, two top-level sections (`auth` and `server`), optional `web`.
+The loader returns a frozen :class:`LensConfig` dataclass; missing
+required keys raise :class:`AfiError` with an `error:`/`hint:` shape
+the dispatcher renders without leaking a traceback.
+"""
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass
+from pathlib import Path
+
+import yaml
+
+from irc_lens.cli._errors import EXIT_USER_ERROR, AfiError
+
+_AUTH_MODES = ("dev", "cloudflare-access")
+
+
+@dataclass(frozen=True)
+class LensConfig:
+    auth_mode: str
+    # dev fields (set when auth_mode == 'dev'):
+    dev_nick: str | None
+    dev_email: str | None
+    # cloudflare-access fields (set when auth_mode == 'cloudflare-access'):
+    cf_aud: str | None
+    cf_team_domain: str | None
+    allowed_emails: tuple[str, ...]
+    allowed_service_tokens: tuple[str, ...]
+    # server (always required):
+    server_name: str
+    server_host: str
+    server_port: int
+    # web (defaults applied):
+    web_bind: str
+    web_port: int
+
+
+def default_config_path() -> Path:
+    """Resolve the default config file location.
+
+    Honors ``$XDG_CONFIG_HOME`` per the freedesktop spec; falls back to
+    ``~/.config`` so a stock home directory works without setup.
+    """
+    base = os.environ.get("XDG_CONFIG_HOME") or str(Path.home() / ".config")
+    return Path(base) / "irc-lens" / "config.yaml"
+
+
+def _err(message: str, hint: str) -> AfiError:
+    return AfiError(code=EXIT_USER_ERROR, message=message, remediation=hint)
+
+
+def _require(d: dict, key: str, where: str) -> object:
+    if key not in d:
+        raise _err(
+            f"missing required key {where}.{key}",
+            f"add `{key}:` under `{where}:` in the config file",
+        )
+    return d[key]
+
+
+def load_config(path: Path) -> LensConfig:
+    if not path.exists():
+        raise _err(
+            f"no config at {path}",
+            "run 'irc-lens config init' to drop a starter, or pass --config <path>",
+        )
+    try:
+        raw = yaml.safe_load(path.read_text()) or {}
+    except yaml.YAMLError as exc:
+        raise _err(
+            f"could not parse YAML in {path}: {exc}",
+            "fix the YAML syntax; see docs/cli.md for a working example",
+        ) from exc
+    if not isinstance(raw, dict):
+        raise _err(
+            f"config at {path} must be a YAML mapping at the top level",
+            "wrap the file's contents in `auth:` and `server:` keys",
+        )
+
+    auth = _require(raw, "auth", "")
+    if not isinstance(auth, dict):
+        raise _err("auth: must be a mapping", "see docs/cli.md")
+    mode = _require(auth, "mode", "auth")
+    if mode not in _AUTH_MODES:
+        raise _err(
+            f"auth.mode must be one of {_AUTH_MODES}, got {mode!r}",
+            "set `auth.mode:` to either `dev` or `cloudflare-access`",
+        )
+
+    dev_nick = dev_email = None
+    cf_aud = cf_team_domain = None
+    allowed_emails: tuple[str, ...] = ()
+    allowed_service_tokens: tuple[str, ...] = ()
+
+    if mode == "dev":
+        dev = _require(auth, "dev", "auth")
+        if not isinstance(dev, dict):
+            raise _err("auth.dev must be a mapping", "see docs/cli.md")
+        dev_nick = str(_require(dev, "nick", "auth.dev"))
+        dev_email = str(_require(dev, "email", "auth.dev"))
+    else:
+        cf = _require(auth, "cloudflare", "auth")
+        if not isinstance(cf, dict):
+            raise _err("auth.cloudflare must be a mapping", "see docs/cli.md")
+        cf_aud = str(_require(cf, "aud", "auth.cloudflare"))
+        cf_team_domain = str(_require(cf, "team_domain", "auth.cloudflare"))
+        emails_raw = _require(auth, "allowed_emails", "auth")
+        if not isinstance(emails_raw, list) or not all(isinstance(x, str) for x in emails_raw):
+            raise _err(
+                "auth.allowed_emails must be a list of strings",
+                "set `auth.allowed_emails: [you@example.com]`",
+            )
+        if len(emails_raw) == 0 and not auth.get("allowed_service_tokens"):
+            raise _err(
+                "auth.allowed_emails is empty and no service tokens configured",
+                "add at least one email to auth.allowed_emails or one entry to "
+                "auth.allowed_service_tokens",
+            )
+        allowed_emails = tuple(emails_raw)
+        ts_raw = auth.get("allowed_service_tokens", [])
+        if not isinstance(ts_raw, list) or not all(isinstance(x, str) for x in ts_raw):
+            raise _err(
+                "auth.allowed_service_tokens must be a list of strings",
+                "set `auth.allowed_service_tokens: []` or add client-ids",
+            )
+        allowed_service_tokens = tuple(ts_raw)
+
+    server = _require(raw, "server", "")
+    if not isinstance(server, dict):
+        raise _err("server: must be a mapping", "see docs/cli.md")
+    server_name = str(_require(server, "name", "server"))
+    server_host = str(server.get("host", "127.0.0.1"))
+    server_port = int(server.get("port", 6667))
+
+    web = raw.get("web", {}) or {}
+    if not isinstance(web, dict):
+        raise _err("web: must be a mapping", "see docs/cli.md")
+    web_bind = str(web.get("bind", "127.0.0.1"))
+    web_port = int(web.get("port", 8765))
+
+    return LensConfig(
+        auth_mode=mode,
+        dev_nick=dev_nick,
+        dev_email=dev_email,
+        cf_aud=cf_aud,
+        cf_team_domain=cf_team_domain,
+        allowed_emails=allowed_emails,
+        allowed_service_tokens=allowed_service_tokens,
+        server_name=server_name,
+        server_host=server_host,
+        server_port=server_port,
+        web_bind=web_bind,
+        web_port=web_port,
+    )
+```
+
+- [ ] **Step 2: Run tests, expect green**
+
+Run: `uv run pytest tests/test_config_loader.py -v`
+Expected: all 8 tests PASS.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/irc_lens/config.py
+git commit -m "feat(config): YAML loader with schema validation"
+```
+
+---
+
+### Task 1.4: Write failing tests for `irc-lens config init`
+
+**Files:**
+- Create: `tests/test_config_init.py`
+
+- [ ] **Step 1: Write failing tests**
+
+```python
+"""`irc-lens config init` writes a starter dev-mode config."""
+from __future__ import annotations
+
+from pathlib import Path
+
+from irc_lens.cli import main
+
+
+def test_config_init_writes_default_path(tmp_path: Path, monkeypatch) -> None:
+    monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path))
+    rc = main(["config", "init"])
+    assert rc == 0
+    target = tmp_path / "irc-lens" / "config.yaml"
+    assert target.exists()
+    body = target.read_text()
+    assert "auth:" in body
+    assert "mode: dev" in body
+    assert "server:" in body
+
+
+def test_config_init_with_explicit_path(tmp_path: Path) -> None:
+    target = tmp_path / "custom.yaml"
+    rc = main(["config", "init", "--path", str(target)])
+    assert rc == 0
+    assert target.exists()
+
+
+def test_config_init_refuses_overwrite(tmp_path: Path) -> None:
+    target = tmp_path / "exists.yaml"
+    target.write_text("# pre-existing\n")
+    rc = main(["config", "init", "--path", str(target)])
+    assert rc == 1                                 # AfiError EXIT_USER_ERROR
+    assert target.read_text() == "# pre-existing\n"   # unchanged
+
+
+def test_config_init_force_overwrites(tmp_path: Path) -> None:
+    target = tmp_path / "exists.yaml"
+    target.write_text("# stale\n")
+    rc = main(["config", "init", "--path", str(target), "--force"])
+    assert rc == 0
+    assert "auth:" in target.read_text()
+
+
+def test_config_overview_works(tmp_path: Path) -> None:
+    rc = main(["config", "overview"])
+    assert rc == 0
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `uv run pytest tests/test_config_init.py -v`
+Expected: FAIL — `argparse: invalid choice: 'config'` or similar.
+
+- [ ] **Step 3: Commit failing tests**
+
+```bash
+git add tests/test_config_init.py
+git commit -m "test: failing tests for irc-lens config init"
+```
+
+---
+
+### Task 1.5: Implement `irc-lens config init` and `irc-lens config overview`
+
+**Files:**
+- Create: `src/irc_lens/cli/_commands/config_cmd.py`
+- Modify: `src/irc_lens/cli/__init__.py`
+
+- [ ] **Step 1: Write the command module**
+
+```python
+"""`irc-lens config` noun group: init + overview verbs."""
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+
+from irc_lens.cli._errors import EXIT_USER_ERROR, AfiError
+from irc_lens.cli._output import emit_diagnostic
+from irc_lens.config import default_config_path
+
+_STARTER = """\
+# irc-lens — local dev config
+# Written by `irc-lens config init`. See docs/cli.md for the full schema.
+
+auth:
+  mode: dev
+  dev:
+    nick: lens
+    email: dev@local
+
+server:
+  name: spark        # AgentIRC server name (used to derive nicks in CF mode)
+  host: 127.0.0.1
+  port: 6667
+
+web:
+  bind: 127.0.0.1
+  port: 8765
+"""
+
+
+def _resolve_target(args: argparse.Namespace) -> Path:
+    return Path(args.path) if args.path else default_config_path()
+
+
+def cmd_config_init(args: argparse.Namespace) -> int:
+    target = _resolve_target(args)
+    if target.exists() and not args.force:
+        raise AfiError(
+            code=EXIT_USER_ERROR,
+            message=f"config already exists at {target}",
+            remediation="pass --force to overwrite, or pick a different --path",
+        )
+    target.parent.mkdir(parents=True, exist_ok=True)
+    target.write_text(_STARTER)
+    emit_diagnostic(f"wrote starter config to {target}")
+    return 0
+
+
+def cmd_config_overview(_args: argparse.Namespace) -> int:
+    print(
+        "irc-lens config — manage the lens config file.\n"
+        "\n"
+        "verbs:\n"
+        "  init       write a starter dev-mode config\n"
+        "  overview   this help\n"
+        "\n"
+        "default path: ~/.config/irc-lens/config.yaml (XDG_CONFIG_HOME respected)\n"
+    )
+    return 0
+
+
+def register(sub: argparse._SubParsersAction) -> None:
+    cfg = sub.add_parser(
+        "config",
+        help="Manage the irc-lens config file.",
+    )
+    cfg_sub = cfg.add_subparsers(dest="config_command")
+
+    init = cfg_sub.add_parser("init", help="Write a starter dev-mode config.")
+    init.add_argument("--path", default=None, help="Override the default config path.")
+    init.add_argument(
+        "--force",
+        action="store_true",
+        help="Overwrite an existing file (default refuses).",
+    )
+    init.set_defaults(func=cmd_config_init)
+
+    overview = cfg_sub.add_parser("overview", help="Help for the config noun.")
+    overview.set_defaults(func=cmd_config_overview)
+
+    cfg.set_defaults(func=lambda _args: (cfg.print_help() or 0))
+```
+
+- [ ] **Step 2: Wire the noun in `cli/__init__.py`**
+
+In `src/irc_lens/cli/__init__.py`, after the existing `cli_noun` setup (line ~92), import and register:
+
+At the top, add to imports:
+```python
+from irc_lens.cli._commands import config_cmd as _config_cmd
+```
+
+Inside `_build_parser()`, after the `cli_noun.set_defaults(...)` line, add:
+```python
+_config_cmd.register(sub)
+```
+
+- [ ] **Step 3: Run tests, expect green**
+
+Run: `uv run pytest tests/test_config_init.py -v`
+Expected: all 5 tests PASS.
+
+- [ ] **Step 4: Smoke-test the CLI**
+
+Run: `uv run irc-lens config init --path /tmp/lens-smoke.yaml && cat /tmp/lens-smoke.yaml | head -5`
+Expected: `wrote starter config to /tmp/lens-smoke.yaml`, then the first comment line of the starter.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/irc_lens/cli/_commands/config_cmd.py src/irc_lens/cli/__init__.py
+git commit -m "feat(cli): irc-lens config init + overview verbs"
+```
+
+---
+
+### Task 1.6: `cli verify` `overview` rubric — confirm new noun passes
+
+**Files:**
+- (no edits — verification step)
+
+- [ ] **Step 1: Confirm `irc-lens overview` lists the new noun**
+
+Run: `uv run irc-lens overview`
+Expected: output mentions `config` alongside `cli`.
+
+If the existing `overview` walks subparsers automatically, this is free. If not, the existing overview implementation needs the `config` noun added; check `src/irc_lens/cli/_commands/overview.py` and update similarly to how `cli` was registered.
+
+- [ ] **Step 2: Confirm `irc-lens overview --json` is parseable**
+
+Run: `uv run irc-lens overview --json | python -m json.tool > /dev/null`
+Expected: exit 0, no parse error.
+
+- [ ] **Step 3: Confirm `irc-lens config overview` works**
+
+Run: `uv run irc-lens config overview`
+Expected: exit 0, prints the config-noun help.
+
+- [ ] **Step 4: If any rubric item failed, fix the gap and commit**
+
+If `overview.py` needed an update, commit it with `chore(cli): include config noun in overview rubric`.
+
+---
+
+## Phase 2 — Per-user Session registry under dev mode
+
+### Task 2.1: Write failing tests for `Identity` and `derive_nick`
+
+**Files:**
+- Create: `tests/test_identity.py`
+
+- [ ] **Step 1: Write failing tests**
+
+```python
+"""Identity NamedTuple + derive_nick rules."""
+from __future__ import annotations
+
+import pytest
+
+from irc_lens.web.identity import Identity, derive_nick
+
+
+@pytest.mark.parametrize("server,principal,expected", [
+    ("spark", "ori.nachum@gmail.com", "spark-orinachum"),
+    ("spark", "Ori.Nachum@Gmail.com", "spark-orinachum"),     # case-fold
+    ("spark", "alice+irc@example.com", "spark-aliceirc"),     # strip +
+    ("spark", "bob_smith@example.com", "spark-bobsmith"),     # strip _
+    ("spark", "kebab-case@example.com", "spark-kebab-case"),  # keep -
+    ("spark", "svc-token-id", "spark-svc-token-id"),          # no @ ok (service token CN)
+])
+def test_derive_nick_cases(server: str, principal: str, expected: str) -> None:
+    assert derive_nick(server, principal) == expected
+
+
+def test_derive_nick_empty_after_strip_raises() -> None:
+    with pytest.raises(ValueError):
+        derive_nick("spark", "...@example.com")
+
+
+def test_identity_is_namedtuple_like() -> None:
+    i = Identity(principal="alice@example.com", nick="spark-alice", raw_jwt_subject="sub-123")
+    assert i.principal == "alice@example.com"
+    assert i.nick == "spark-alice"
+    assert i.raw_jwt_subject == "sub-123"
+```
+
+- [ ] **Step 2: Run, expect fail**
+
+Run: `uv run pytest tests/test_identity.py -v`
+Expected: ImportError on `irc_lens.web.identity`.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add tests/test_identity.py
+git commit -m "test: failing tests for derive_nick and Identity"
+```
+
+---
+
+### Task 2.2: Implement `Identity` and `derive_nick`
+
+**Files:**
+- Create: `src/irc_lens/web/identity.py`
+
+- [ ] **Step 1: Write the module**
+
+```python
+"""Authenticated identity carried per-request through the web layer.
+
+`Identity.principal` is the email under interactive SSO and the
+service-token client-id / common-name otherwise. Downstream code
+never branches on which.
+"""
+from __future__ import annotations
+
+from typing import NamedTuple
+
+
+class Identity(NamedTuple):
+    principal: str
+    nick: str
+    raw_jwt_subject: str
+
+
+def derive_nick(server_name: str, principal: str) -> str:
+    """Return ``<server_name>-<sanitized-local-part>``.
+
+    Sanitization: lowercase the local part (the bit before ``@``, or the
+    whole string if no ``@``), then drop everything outside ``[a-z0-9-]``.
+    AgentIRC accepts ``-`` in nicks but rejects ``.``, ``_``, ``+``, etc.
+
+    Raises:
+        ValueError: when the sanitized local part is empty.
+    """
+    local = principal.split("@", 1)[0].lower()
+    sanitized = "".join(c for c in local if c.isalnum() or c == "-")
+    if not sanitized:
+        raise ValueError(
+            f"nick derivation produced empty result for principal={principal!r}"
+        )
+    return f"{server_name}-{sanitized}"
+```
+
+- [ ] **Step 2: Run tests, expect green**
+
+Run: `uv run pytest tests/test_identity.py -v`
+Expected: all 8 tests PASS.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/irc_lens/web/identity.py
+git commit -m "feat(web): Identity NamedTuple + derive_nick"
+```
+
+---
+
+### Task 2.3: Write failing tests for the per-principal Session registry
+
+**Files:**
+- Create: `tests/test_session_registry.py`
+
+- [ ] **Step 1: Write failing tests**
+
+```python
+"""Per-principal Session registry: lazy open, double-check, shutdown-all."""
+from __future__ import annotations
+
+import asyncio
+from collections.abc import Callable
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from irc_lens.web.identity import Identity
+from irc_lens.web.sessions import (
+    SessionRegistry,
+    disconnect_all,
+)
+
+
+def _fake_session_factory() -> tuple[Callable[[str], MagicMock], list[MagicMock]]:
+    created: list[MagicMock] = []
+
+    def factory(nick: str) -> MagicMock:
+        s = MagicMock()
+        s.connect = AsyncMock()
+        s.wait_for_welcome = AsyncMock()
+        s.disconnect = AsyncMock()
+        s.nick = nick
+        created.append(s)
+        return s
+
+    return factory, created
+
+
+@pytest.mark.asyncio
+async def test_first_request_opens_session() -> None:
+    factory, created = _fake_session_factory()
+    reg = SessionRegistry(factory=factory)
+    ident = Identity(principal="alice@example.com", nick="spark-alice", raw_jwt_subject="s")
+
+    s = await reg.get_or_open(ident)
+
+    assert s is created[0]
+    s.connect.assert_awaited_once()
+    s.wait_for_welcome.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_second_request_reuses_session() -> None:
+    factory, created = _fake_session_factory()
+    reg = SessionRegistry(factory=factory)
+    ident = Identity(principal="alice@example.com", nick="spark-alice", raw_jwt_subject="s")
+
+    a = await reg.get_or_open(ident)
+    b = await reg.get_or_open(ident)
+
+    assert a is b
+    assert len(created) == 1
+
+
+@pytest.mark.asyncio
+async def test_concurrent_first_requests_share_one_session() -> None:
+    """Two coroutines reaching get_or_open at once must not both build a Session."""
+    factory, created = _fake_session_factory()
+
+    # Make connect() yield to the loop so the race window is real.
+    async def slow_connect() -> None:
+        await asyncio.sleep(0.01)
+
+    reg = SessionRegistry(factory=factory)
+    # Patch the factory to return a session whose connect awaits.
+    base_factory = factory
+
+    def slow_factory(nick: str) -> MagicMock:
+        s = base_factory(nick)
+        s.connect = AsyncMock(side_effect=slow_connect)
+        return s
+
+    reg = SessionRegistry(factory=slow_factory)
+    ident = Identity(principal="alice@example.com", nick="spark-alice", raw_jwt_subject="s")
+
+    a, b = await asyncio.gather(reg.get_or_open(ident), reg.get_or_open(ident))
+
+    assert a is b
+    # Two created mocks would mean the lock failed.
+    assert len(created) == 1
+
+
+@pytest.mark.asyncio
+async def test_failed_open_does_not_register() -> None:
+    factory, created = _fake_session_factory()
+
+    class Boom(Exception):
+        pass
+
+    def bad_factory(nick: str) -> MagicMock:
+        s = factory(nick)
+        s.connect = AsyncMock(side_effect=Boom("nope"))
+        return s
+
+    reg = SessionRegistry(factory=bad_factory)
+    ident = Identity(principal="alice@example.com", nick="spark-alice", raw_jwt_subject="s")
+
+    with pytest.raises(Boom):
+        await reg.get_or_open(ident)
+
+    # Second attempt must build a fresh Session, not reuse a half-open one.
+    with pytest.raises(Boom):
+        await reg.get_or_open(ident)
+    assert len(created) == 2
+
+
+@pytest.mark.asyncio
+async def test_disconnect_all_calls_each_session() -> None:
+    factory, created = _fake_session_factory()
+    reg = SessionRegistry(factory=factory)
+    a = Identity(principal="alice@example.com", nick="spark-alice", raw_jwt_subject="s")
+    b = Identity(principal="bob@example.com", nick="spark-bob", raw_jwt_subject="s")
+    await reg.get_or_open(a)
+    await reg.get_or_open(b)
+
+    await disconnect_all(reg)
+
+    for s in created:
+        s.disconnect.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_disconnect_all_swallows_individual_failures() -> None:
+    factory, created = _fake_session_factory()
+    reg = SessionRegistry(factory=factory)
+    a = Identity(principal="alice@example.com", nick="spark-alice", raw_jwt_subject="s")
+    b = Identity(principal="bob@example.com", nick="spark-bob", raw_jwt_subject="s")
+    await reg.get_or_open(a)
+    await reg.get_or_open(b)
+    created[0].disconnect = AsyncMock(side_effect=RuntimeError("first fails"))
+
+    # Must not raise — both should be attempted.
+    await disconnect_all(reg)
+    created[1].disconnect.assert_awaited_once()
+```
+
+- [ ] **Step 2: Run, expect fail**
+
+Run: `uv run pytest tests/test_session_registry.py -v`
+Expected: ImportError on `irc_lens.web.sessions`.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add tests/test_session_registry.py
+git commit -m "test: failing tests for per-principal Session registry"
+```
+
+---
+
+### Task 2.4: Implement `SessionRegistry` and `disconnect_all`
+
+**Files:**
+- Create: `src/irc_lens/web/sessions.py`
+
+- [ ] **Step 1: Write the module**
+
+```python
+"""Per-principal Session registry.
+
+A registry hands out one :class:`Session` per authenticated principal,
+opening it lazily on first request. Concurrent first-requests for the
+same principal share one Session via a per-key lock + double-check.
+
+Failed opens are *not* registered, so a transient AgentIRC outage
+doesn't poison the cache for that principal.
+"""
+from __future__ import annotations
+
+import asyncio
+from collections import defaultdict
+from collections.abc import Callable
+from typing import TYPE_CHECKING, Any
+
+from irc_lens.web.identity import Identity
+
+if TYPE_CHECKING:
+    from irc_lens.session import Session
+
+SessionFactory = Callable[[str], "Session"]
+
+
+class SessionRegistry:
+    """Maps principal → Session, lazy-opening as needed."""
+
+    def __init__(self, factory: SessionFactory) -> None:
+        self._factory = factory
+        self._sessions: dict[str, Any] = {}
+        self._locks: dict[str, asyncio.Lock] = defaultdict(asyncio.Lock)
+
+    def __contains__(self, principal: str) -> bool:
+        return principal in self._sessions
+
+    def values(self) -> list[Any]:
+        return list(self._sessions.values())
+
+    async def get_or_open(self, identity: Identity) -> Any:
+        if identity.principal in self._sessions:
+            return self._sessions[identity.principal]
+        async with self._locks[identity.principal]:
+            if identity.principal in self._sessions:           # double-check
+                return self._sessions[identity.principal]
+            session = self._factory(identity.nick)
+            await session.connect()
+            await session.wait_for_welcome()
+            self._sessions[identity.principal] = session
+            return session
+
+
+async def disconnect_all(registry: SessionRegistry) -> None:
+    """Disconnect every registered Session, swallowing individual failures."""
+    sessions = registry.values()
+    if not sessions:
+        return
+    await asyncio.gather(*(s.disconnect() for s in sessions), return_exceptions=True)
+```
+
+- [ ] **Step 2: Run tests, expect green**
+
+Run: `uv run pytest tests/test_session_registry.py -v`
+Expected: all 6 tests PASS.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/irc_lens/web/sessions.py
+git commit -m "feat(web): per-principal SessionRegistry with double-check lazy open"
+```
+
+---
+
+### Task 2.5: Refactor `make_app` to take `LensConfig`, install dev-mode middleware, wire registry
+
+**Files:**
+- Modify: `src/irc_lens/web/app.py`
+- Modify: `src/irc_lens/web/routes.py`
+- Modify: `tests/conftest.py`
+
+This is the largest single edit. We change `make_app(session)` → `make_app(config, session_factory)`. Existing routes that read `app["session"]` switch to `await get_or_open_session(request)`. In Phase 2 the middleware always synthesizes the dev identity; CF mode lands in Phase 3.
+
+- [ ] **Step 1: Update `tests/conftest.py` for the new signature first (TDD: tests own the contract)**
+
+Replace the body of `_serve_lens` and add a `dev_config` fixture:
+
+```python
+"""Test fixtures shared across the suite.
+
+Phase 2 changes the lens app signature: `make_app(config, session_factory)`
+instead of `make_app(session)`. Tests build a dev-mode config and a
+session-factory closure that returns the live test Session.
+"""
+from __future__ import annotations
+
+from collections.abc import AsyncIterator
+from pathlib import Path
+
+import pytest_asyncio
+from aiohttp import web
+from aiohttp.test_utils import TestClient, TestServer
+
+from irc_lens.config import LensConfig
+from irc_lens.session import Session
+from irc_lens.web import make_app
+
+from _agentirc_server import AgentIRCTestServer
+
+_BASIC_SEED = Path(__file__).parent / "fixtures" / "basic.yaml"
+
+
+def _dev_config(server_host: str, server_port: int, nick: str = "lens-test") -> LensConfig:
+    return LensConfig(
+        auth_mode="dev",
+        dev_nick=nick,
+        dev_email="dev@local",
+        cf_aud=None,
+        cf_team_domain=None,
+        allowed_emails=(),
+        allowed_service_tokens=(),
+        server_name="testsrv",
+        server_host=server_host,
+        server_port=server_port,
+        web_bind="127.0.0.1",
+        web_port=0,
+    )
+
+
+async def _serve_lens(session: Session, host: str, port: int) -> AsyncIterator[TestClient]:
+    """Spin up an aiohttp TestClient against `session`.
+
+    The session-factory passed to make_app simply returns the already-
+    connected `session` — under dev mode the registry will see the
+    synthetic dev principal on first request, double-check finds a hit
+    only after the first call, so the factory is invoked exactly once
+    and its return value reused.
+    """
+    config = _dev_config(host, port, nick=session.nick)
+    factory = lambda _nick: session   # noqa: E731 — single-line closure is the point
+    app: web.Application = make_app(config, factory)
+    test_server = TestServer(app)
+    client = TestClient(test_server)
+    await client.start_server()
+    try:
+        yield client
+    finally:
+        await client.close()
+
+
+@pytest_asyncio.fixture
+async def agentirc_server() -> AsyncIterator[AgentIRCTestServer]:
+    server = AgentIRCTestServer()
+    await server.start()
+    try:
+        yield server
+    finally:
+        await server.stop()
+
+
+@pytest_asyncio.fixture
+async def lens_session(agentirc_server: AgentIRCTestServer) -> AsyncIterator[Session]:
+    session = Session(host=agentirc_server.host, port=agentirc_server.port, nick="lens-test")
+    await session.connect()
+    try:
+        yield session
+    finally:
+        await session.disconnect()
+
+
+@pytest_asyncio.fixture
+async def lens_client(lens_session: Session, agentirc_server: AgentIRCTestServer) -> AsyncIterator[TestClient]:
+    async for client in _serve_lens(lens_session, agentirc_server.host, agentirc_server.port):
+        yield client
+
+
+@pytest_asyncio.fixture
+async def seeded_lens_client(lens_session: Session, agentirc_server: AgentIRCTestServer) -> AsyncIterator[TestClient]:
+    from irc_lens.seed import apply_seed
+
+    apply_seed(lens_session, _BASIC_SEED)
+    async for client in _serve_lens(lens_session, agentirc_server.host, agentirc_server.port):
+        yield client
+```
+
+The `factory = lambda _nick: session` is the test seam: dev-mode tests need exactly one Session and the conftest reuses the one the agentirc fixture already opened. Production wiring constructs a real factory in `serve.py`.
+
+- [ ] **Step 2: Rewrite `src/irc_lens/web/app.py`**
+
+```python
+"""aiohttp ``Application`` factory for irc-lens.
+
+Phase 2: takes a :class:`LensConfig` and a session factory rather than
+a single connected Session. Builds the per-principal
+:class:`SessionRegistry`, mounts the dev-mode identity middleware, and
+exposes a `/healthz` endpoint.
+
+CF-mode middleware lands in Phase 3.
+"""
+from __future__ import annotations
+
+from importlib.resources import files
+
+from aiohttp import web
+
+from irc_lens.config import LensConfig
+from irc_lens.web import routes
+from irc_lens.web.identity import Identity, derive_nick
+from irc_lens.web.routes import _MAX_INPUT_BODY
+from irc_lens.web.sessions import SessionFactory, SessionRegistry
+
+
+def _dev_identity_middleware(config: LensConfig):
+    """Synthesizes the dev identity on every request.
+
+    Real-world dev mode has a single human at the keyboard; the lens
+    treats every request as them. CF mode replaces this in Phase 3.
+    """
+    assert config.auth_mode == "dev"
+    assert config.dev_email is not None
+    identity = Identity(
+        principal=config.dev_email,
+        nick=config.dev_nick or "lens",
+        raw_jwt_subject="dev",
+    )
+
+    @web.middleware
+    async def middleware(request: web.Request, handler):
+        # Skip identity synthesis for static assets and /healthz.
+        if request.path.startswith("/static/") or request.path == "/healthz":
+            return await handler(request)
+        request["identity"] = identity
+        return await handler(request)
+
+    return middleware
+
+
+def make_app(config: LensConfig, session_factory: SessionFactory) -> web.Application:
+    if config.auth_mode != "dev":
+        # Phase 3 will branch here. Until then, callers must pass dev mode.
+        raise RuntimeError(
+            "make_app: only auth.mode='dev' is wired in Phase 2"
+        )
+
+    middleware = _dev_identity_middleware(config)
+    app = web.Application(client_max_size=_MAX_INPUT_BODY, middlewares=[middleware])
+
+    registry = SessionRegistry(factory=session_factory)
+    app["registry"] = registry
+    app["config"] = config
+
+    app.router.add_get("/", routes.get_index)
+    app.router.add_post("/input", routes.post_input)
+    app.router.add_get("/events", routes.get_events)
+    app.router.add_get("/healthz", routes.get_healthz)
+
+    static_dir = files("irc_lens").joinpath("static")
+    app.router.add_static(
+        "/static/",
+        path=str(static_dir),
+        name="static",
+        show_index=False,
+        follow_symlinks=False,
+    )
+
+    return app
+```
+
+- [ ] **Step 3: Update `src/irc_lens/web/routes.py`**
+
+Add a `get_healthz` handler at the bottom:
+
+```python
+async def get_healthz(_request: web.Request) -> web.Response:
+    """Opaque health probe. No auth, no IRC state, no allowlist leak."""
+    return web.json_response({"ok": True})
+```
+
+Replace each `request.app["session"]` use with `await _resolve_session(request)`. Add this helper near the top of the module:
+
+```python
+from irc_lens.web.sessions import SessionRegistry
+
+
+async def _resolve_session(request: web.Request):
+    """Look up (or lazily open) the Session for this request's identity.
+
+    The dev-mode middleware always sets request["identity"]. Static and
+    /healthz paths skip the middleware and never call this helper.
+    """
+    identity = request["identity"]
+    registry: SessionRegistry = request.app["registry"]
+    return await registry.get_or_open(identity)
+```
+
+In `get_index`, change:
+```python
+session = request.app["session"]
+```
+to:
+```python
+session = await _resolve_session(request)
+```
+
+In `post_input`, the existing line:
+```python
+session = request.app["session"]
+```
+becomes:
+```python
+session = await _resolve_session(request)
+```
+
+In `get_events`, the existing:
+```python
+session = request.app["session"]
+```
+becomes:
+```python
+session = await _resolve_session(request)
+```
+
+- [ ] **Step 4: Run the existing test suite — every dev-mode test must still pass**
+
+Run: `uv run pytest -x -v`
+Expected: all non-playwright, non-cloudflare tests pass. If any test referenced `app["session"]` directly, update it to `app["registry"]` or rebuild via the new fixtures.
+
+- [ ] **Step 5: Run a quick `/healthz` smoke**
+
+In an interactive Python session, or as an inline test addition, hit `/healthz` via `lens_client` and assert 200 + `{"ok": True}`. (Phase 4 has a dedicated test file; this is just sanity.)
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/irc_lens/web/app.py src/irc_lens/web/routes.py tests/conftest.py
+git commit -m "feat(web): per-principal Session registry under dev mode
+
+make_app(session) -> make_app(config, session_factory). Routes resolve
+the Session via the registry on each request. Dev-mode middleware
+synthesizes a fixed identity. /healthz lands as the unauthenticated
+probe. Existing tests migrate via the new dev_config helper in
+conftest."
+```
+
+---
+
+### Task 2.6: Wire `serve.py` to use the new `make_app` signature in dev mode
+
+**Files:**
+- Modify: `src/irc_lens/cli/_commands/serve.py`
+
+- [ ] **Step 1: Replace `make_app(session)` and the singleton-Session model**
+
+Edit `_serve_async` in `serve.py`. Replace the existing `app = make_app(session)` block plus the single-Session connect with:
+
+```python
+from irc_lens.config import LensConfig, default_config_path, load_config
+from irc_lens.web.sessions import disconnect_all
+from irc_lens.session import Session
+```
+
+Above `_serve_async`, add a small helper:
+
+```python
+def _build_dev_config(args: argparse.Namespace) -> LensConfig:
+    """In Phase 2, dev mode still requires --nick. Build a synthetic
+    LensConfig from the CLI args so existing serve invocations work
+    without a config file. Phase 4 reverses this: config file becomes
+    primary; CLI args override.
+    """
+    return LensConfig(
+        auth_mode="dev",
+        dev_nick=args.nick,
+        dev_email="dev@local",
+        cf_aud=None,
+        cf_team_domain=None,
+        allowed_emails=(),
+        allowed_service_tokens=(),
+        server_name="dev",
+        server_host=args.host,
+        server_port=args.port,
+        web_bind=args.bind,
+        web_port=args.web_port,
+    )
+```
+
+Then in `_serve_async`, replace the body up through `app = make_app(session)` with:
+
+```python
+config = _build_dev_config(args)
+session = Session(host=config.server_host, port=config.server_port, nick=config.dev_nick, icon=args.icon)
+try:
+    await session.connect()
+except LensConnectionLost as exc:
+    raise AfiError(...)  # unchanged
+try:
+    await session.wait_for_welcome()
+except LensConnectionLost as exc:
+    await session.disconnect()
+    raise AfiError(...)  # unchanged
+
+if args.seed:
+    try:
+        from irc_lens.seed import apply_seed
+        apply_seed(session, Path(args.seed))
+    except Exception:
+        await session.disconnect()
+        raise
+
+# Single-Session-in-dev: the factory always returns the same instance.
+factory = lambda _nick: session   # noqa: E731
+app = make_app(config, factory)
+runner = web.AppRunner(app, handle_signals=True)
+# … unchanged through site.start()
+
+try:
+    await asyncio.Event().wait()
+finally:
+    await disconnect_all(app["registry"])
+    await runner.cleanup()
+```
+
+Remove the now-redundant standalone `await session.disconnect()` in the outer `finally`; `disconnect_all` covers it.
+
+- [ ] **Step 2: Run the full test suite**
+
+Run: `uv run pytest -x -v`
+Expected: all tests pass, including `test_serve_cli.py` which checks the CLI surface.
+
+- [ ] **Step 3: Manual smoke against a local AgentIRC**
+
+If a local Culture server is available:
+
+Run: `uv run irc-lens serve --nick lens-test --web-port 18765` (in one terminal)
+Then: `curl -sf http://127.0.0.1:18765/healthz`
+Expected: `{"ok": true}`.
+
+If no local AgentIRC, skip — phase 4 tests verify the same thing in CI.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/irc_lens/cli/_commands/serve.py
+git commit -m "feat(serve): dev-mode wires through SessionRegistry
+
+Builds a synthetic dev LensConfig from CLI args, hands a
+factory-of-one to make_app. disconnect_all replaces the bare
+session.disconnect() in the shutdown path."
+```
+
+---
+
+## Phase 3 — CF auth middleware + JWT verification
+
+### Task 3.1: Build the in-tree fake JWKS server fixture
+
+**Files:**
+- Create: `tests/_jwks_server.py`
+
+- [ ] **Step 1: Write the fixture module**
+
+```python
+"""Tiny aiohttp app that mimics Cloudflare's JWKS endpoint for tests.
+
+Tests mint JWTs locally with the matching private key and point the
+lens at this server's URL. Mirrors the in-tree
+``_agentirc_server.py`` pattern so we don't add a network dep.
+"""
+from __future__ import annotations
+
+import json
+from typing import Any
+
+import jwt
+from aiohttp import web
+from cryptography.hazmat.primitives import serialization
+from cryptography.hazmat.primitives.asymmetric import rsa
+
+
+class FakeJWKS:
+    """Generate a keypair, expose the JWK set, mint signed JWTs."""
+
+    def __init__(self, kid: str = "test-kid-1") -> None:
+        self._kid = kid
+        self._key = rsa.generate_private_key(public_exponent=65537, key_size=2048)
+        self._site: web.TCPSite | None = None
+        self._runner: web.AppRunner | None = None
+        self.host: str = "127.0.0.1"
+        self.port: int = 0
+
+    @property
+    def base_url(self) -> str:
+        return f"http://{self.host}:{self.port}"
+
+    @property
+    def team_domain(self) -> str:
+        # The lens treats `https://<team_domain>` as the issuer; use the
+        # bare host so URL composition works for both /cdn-cgi/access/certs
+        # and `iss` claim assertions.
+        return f"{self.host}:{self.port}"
+
+    @property
+    def issuer(self) -> str:
+        return f"http://{self.team_domain}"
+
+    def public_jwk(self) -> dict[str, Any]:
+        numbers = self._key.public_key().public_numbers()
+        from base64 import urlsafe_b64encode
+
+        def _b64(n: int) -> str:
+            blen = (n.bit_length() + 7) // 8
+            return urlsafe_b64encode(n.to_bytes(blen, "big")).rstrip(b"=").decode()
+
+        return {
+            "kty": "RSA",
+            "alg": "RS256",
+            "use": "sig",
+            "kid": self._kid,
+            "n": _b64(numbers.n),
+            "e": _b64(numbers.e),
+        }
+
+    def mint(self, *, aud: str, claims: dict[str, Any], kid: str | None = None) -> str:
+        payload = {"iss": self.issuer, "aud": aud, **claims}
+        return jwt.encode(
+            payload,
+            self._key.private_bytes(
+                encoding=serialization.Encoding.PEM,
+                format=serialization.PrivateFormat.PKCS8,
+                encryption_algorithm=serialization.NoEncryption(),
+            ),
+            algorithm="RS256",
+            headers={"kid": kid or self._kid},
+        )
+
+    async def start(self) -> None:
+        app = web.Application()
+
+        async def certs(_req: web.Request) -> web.Response:
+            return web.json_response({"keys": [self.public_jwk()]})
+
+        app.router.add_get("/cdn-cgi/access/certs", certs)
+        self._runner = web.AppRunner(app)
+        await self._runner.setup()
+        self._site = web.TCPSite(self._runner, self.host, 0)
+        await self._site.start()
+        # Resolve the actual port the OS assigned.
+        sockets = list(self._runner.addresses)
+        if sockets:
+            self.port = sockets[0][1]
+
+    async def stop(self) -> None:
+        if self._runner is not None:
+            await self._runner.cleanup()
+```
+
+- [ ] **Step 2: Smoke import**
+
+Run: `uv run python -c "from tests._jwks_server import FakeJWKS; print(FakeJWKS)"`
+
+If the import fails because `tests` isn't a package: confirm by checking the existing `_agentirc_server.py`. The existing test layout imports it as a sibling module via `conftest.py` adding `tests/` to `sys.path` indirectly (pytest does this by default for files alongside `conftest.py`). Adjust `from tests._jwks_server` → `from _jwks_server` in actual test files if needed.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add tests/_jwks_server.py
+git commit -m "test: in-tree fake JWKS server fixture"
+```
+
+---
+
+### Task 3.2: Write failing tests for the CF auth middleware
+
+**Files:**
+- Create: `tests/test_auth_middleware.py`
+
+- [ ] **Step 1: Write failing tests**
+
+```python
+"""CF Access JWT validation + middleware behavior."""
+from __future__ import annotations
+
+from collections.abc import AsyncIterator
+
+import pytest
+import pytest_asyncio
+from aiohttp import web
+from aiohttp.test_utils import TestClient, TestServer
+
+from irc_lens.config import LensConfig
+from irc_lens.web import make_app
+
+from _jwks_server import FakeJWKS
+
+
+def _cf_config(jwks: FakeJWKS, allowed: list[str]) -> LensConfig:
+    return LensConfig(
+        auth_mode="cloudflare-access",
+        dev_nick=None,
+        dev_email=None,
+        cf_aud="aud-test",
+        cf_team_domain=jwks.team_domain,
+        allowed_emails=tuple(allowed),
+        allowed_service_tokens=(),
+        server_name="testsrv",
+        server_host="127.0.0.1",
+        server_port=6667,
+        web_bind="127.0.0.1",
+        web_port=0,
+    )
+
+
+@pytest_asyncio.fixture
+async def jwks() -> AsyncIterator[FakeJWKS]:
+    j = FakeJWKS()
+    await j.start()
+    try:
+        yield j
+    finally:
+        await j.stop()
+
+
+@pytest_asyncio.fixture
+async def cf_client(jwks: FakeJWKS) -> AsyncIterator[TestClient]:
+    """A lens TestClient in cloudflare-access mode wired to FakeJWKS.
+
+    Sessions never actually open in these tests — the middleware
+    intercepts before any handler that would call get_or_open.
+    The factory raises if invoked, to catch accidental routing.
+    """
+    config = _cf_config(jwks, allowed=["alice@example.com"])
+
+    def boom_factory(_nick: str):
+        raise AssertionError("session factory must not run during auth tests")
+
+    app = make_app(config, boom_factory)
+    server = TestServer(app)
+    client = TestClient(server)
+    await client.start_server()
+    try:
+        yield client
+    finally:
+        await client.close()
+
+
+async def test_missing_jwt_returns_401(cf_client: TestClient) -> None:
+    resp = await cf_client.get("/")
+    assert resp.status == 401
+    body = await resp.json()
+    assert "error" in body and "hint" in body
+
+
+async def test_valid_jwt_in_header_passes_to_handler(cf_client: TestClient, jwks: FakeJWKS) -> None:
+    token = jwks.mint(aud="aud-test", claims={"email": "alice@example.com", "sub": "s-1"})
+    # The boom_factory raises if the handler tries to open a session.
+    # /healthz skips auth and the registry, so use it as the canary that the
+    # *middleware* accepted the token.
+    resp = await cf_client.get("/healthz", headers={"Cf-Access-Jwt-Assertion": token})
+    assert resp.status == 200
+
+
+async def test_valid_jwt_in_cookie_also_accepted(cf_client: TestClient, jwks: FakeJWKS) -> None:
+    token = jwks.mint(aud="aud-test", claims={"email": "alice@example.com", "sub": "s-2"})
+    cf_client.session.cookie_jar.update_cookies({"CF_Authorization": token})
+    resp = await cf_client.get("/healthz")
+    assert resp.status == 200
+
+
+async def test_wrong_audience_returns_401(cf_client: TestClient, jwks: FakeJWKS) -> None:
+    token = jwks.mint(aud="aud-other", claims={"email": "alice@example.com", "sub": "s"})
+    resp = await cf_client.get("/", headers={"Cf-Access-Jwt-Assertion": token})
+    assert resp.status == 401
+
+
+async def test_email_not_on_allowlist_returns_403(cf_client: TestClient, jwks: FakeJWKS) -> None:
+    token = jwks.mint(aud="aud-test", claims={"email": "mallory@example.com", "sub": "s"})
+    resp = await cf_client.get("/", headers={"Cf-Access-Jwt-Assertion": token})
+    assert resp.status == 403
+    body = await resp.json()
+    assert "allowlist" in body["error"].lower()
+
+
+async def test_static_path_skips_auth(cf_client: TestClient) -> None:
+    # Static asset path must not require a JWT (browser fetches assets first
+    # before the SSO redirect lands on every request).
+    resp = await cf_client.get("/static/missing.js")
+    # 404 from the static handler is fine; 401 would mean middleware ran.
+    assert resp.status in (200, 404)
+
+
+async def test_kid_miss_then_refresh_succeeds(cf_client: TestClient, jwks: FakeJWKS) -> None:
+    """If the JWT's kid isn't in cache, we refetch JWKS once and retry."""
+    # First request populates the cache with the current kid.
+    t1 = jwks.mint(aud="aud-test", claims={"email": "alice@example.com", "sub": "s"})
+    r1 = await cf_client.get("/healthz", headers={"Cf-Access-Jwt-Assertion": t1})
+    assert r1.status == 200
+    # Mint with a different kid; the lens must refetch JWKS to discover it
+    # and accept the JWT after the refresh.
+    t2 = jwks.mint(aud="aud-test", claims={"email": "alice@example.com", "sub": "s"}, kid="rotated-kid")
+    # FakeJWKS still serves only the original kid, so this MUST fail.
+    r2 = await cf_client.get("/healthz", headers={"Cf-Access-Jwt-Assertion": t2})
+    assert r2.status == 401
+```
+
+- [ ] **Step 2: Run, expect fail**
+
+Run: `uv run pytest tests/test_auth_middleware.py -v`
+Expected: most tests fail with a `make_app` assertion (`only auth.mode='dev' is wired in Phase 2`).
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add tests/test_auth_middleware.py
+git commit -m "test: failing tests for CF auth middleware"
+```
+
+---
+
+### Task 3.3: Implement `web/auth.py` (JWT verification + JWKS cache + middleware)
+
+**Files:**
+- Create: `src/irc_lens/web/auth.py`
+
+- [ ] **Step 1: Write the module**
+
+```python
+"""Cloudflare Access JWT verification and middleware.
+
+Validates the JWT against the Cloudflare-published JWKS, pinning
+audience and issuer. Caches the JWK set in process; on a `kid` we
+don't recognize, refresh once and retry — but never on every request.
+Identity (email or service-token common-name) becomes
+``request['identity']``; missing/invalid → 401, allowlist deny → 403.
+"""
+from __future__ import annotations
+
+import logging
+import time
+from typing import Any
+
+import aiohttp
+import jwt
+from aiohttp import web
+
+from irc_lens.config import LensConfig
+from irc_lens.web.identity import Identity, derive_nick
+
+logger = logging.getLogger(__name__)
+
+_JWKS_PATH = "/cdn-cgi/access/certs"
+
+
+def _http_error(status: int, error: str, hint: str) -> web.Response:
+    return web.json_response({"error": error, "hint": hint}, status=status)
+
+
+class _JWKSCache:
+    """In-process JWK set cache with kid-miss-then-refresh semantics."""
+
+    def __init__(self, team_domain: str) -> None:
+        self._url = self._build_url(team_domain)
+        self._keys: dict[str, Any] = {}
+        self._last_fetch: float = 0.0
+
+    @staticmethod
+    def _build_url(team_domain: str) -> str:
+        # Tests pass `host:port` as team_domain so we can talk over HTTP;
+        # production team_domain is a real Cloudflare hostname (use HTTPS).
+        scheme = "http" if ":" in team_domain else "https"
+        return f"{scheme}://{team_domain}{_JWKS_PATH}"
+
+    async def _refresh(self) -> None:
+        async with aiohttp.ClientSession() as session:
+            async with session.get(self._url, timeout=aiohttp.ClientTimeout(total=5)) as r:
+                r.raise_for_status()
+                payload = await r.json()
+        self._keys = {k["kid"]: k for k in payload.get("keys", [])}
+        self._last_fetch = time.time()
+
+    async def get_key(self, kid: str) -> Any:
+        if kid in self._keys:
+            return self._keys[kid]
+        # Avoid kid-miss-flood: only refresh if last fetch is older than 5 s.
+        if time.time() - self._last_fetch < 5.0 and self._keys:
+            raise KeyError(kid)
+        await self._refresh()
+        if kid not in self._keys:
+            raise KeyError(kid)
+        return self._keys[kid]
+
+    async def warm(self) -> None:
+        await self._refresh()
+
+
+def _build_issuer(team_domain: str) -> str:
+    scheme = "http" if ":" in team_domain else "https"
+    return f"{scheme}://{team_domain}"
+
+
+def _principal_from_claims(claims: dict[str, Any]) -> str | None:
+    """Email under interactive SSO; common_name under service tokens."""
+    email = claims.get("email")
+    if isinstance(email, str) and email:
+        return email
+    cn = claims.get("common_name")
+    if isinstance(cn, str) and cn:
+        return cn
+    return None
+
+
+def build_cloudflare_middleware(config: LensConfig):
+    assert config.auth_mode == "cloudflare-access"
+    assert config.cf_aud and config.cf_team_domain
+    cache = _JWKSCache(config.cf_team_domain)
+    issuer = _build_issuer(config.cf_team_domain)
+    aud = config.cf_aud
+    allowed_emails = set(config.allowed_emails)
+    allowed_tokens = set(config.allowed_service_tokens)
+    server_name = config.server_name
+
+    @web.middleware
+    async def middleware(request: web.Request, handler):
+        if request.path.startswith("/static/") or request.path == "/healthz":
+            return await handler(request)
+
+        token = request.headers.get("Cf-Access-Jwt-Assertion")
+        if not token:
+            token = request.cookies.get("CF_Authorization")
+        if not token:
+            return _http_error(
+                401,
+                "missing Cloudflare Access identity",
+                "ensure this request is reaching the lens through cloudflared",
+            )
+
+        try:
+            unverified_header = jwt.get_unverified_header(token)
+            kid = unverified_header.get("kid")
+            if not kid:
+                raise jwt.InvalidTokenError("missing kid in JWT header")
+            jwk_data = await cache.get_key(kid)
+            from jwt.algorithms import RSAAlgorithm
+            public_key = RSAAlgorithm.from_jwk(jwk_data)
+            claims = jwt.decode(
+                token,
+                public_key,
+                algorithms=["RS256"],
+                audience=aud,
+                issuer=issuer,
+            )
+        except jwt.ExpiredSignatureError:
+            return _http_error(401, "Cloudflare Access JWT expired", "sign in again")
+        except jwt.InvalidAudienceError:
+            return _http_error(
+                401,
+                "Cloudflare Access JWT failed verification",
+                "audience mismatch — verify auth.cloudflare.aud in the lens config",
+            )
+        except jwt.InvalidIssuerError:
+            return _http_error(
+                401,
+                "Cloudflare Access JWT failed verification",
+                "issuer mismatch — verify auth.cloudflare.team_domain in the lens config",
+            )
+        except (KeyError, jwt.InvalidTokenError) as exc:
+            return _http_error(
+                401,
+                "Cloudflare Access JWT failed verification",
+                f"verify the request came through cloudflared ({type(exc).__name__})",
+            )
+        except aiohttp.ClientError as exc:
+            return _http_error(
+                502,
+                "could not reach Cloudflare JWKS",
+                f"check connectivity to {config.cf_team_domain} ({exc})",
+            )
+
+        principal = _principal_from_claims(claims)
+        if not principal:
+            return _http_error(
+                401,
+                "JWT carried neither email nor common_name",
+                "verify the Access policy issues an email or service-token JWT",
+            )
+
+        # Allowlist enforcement: emails and service tokens are sibling lists.
+        is_email = "email" in claims and isinstance(claims["email"], str)
+        if is_email and principal not in allowed_emails:
+            return _http_error(
+                403,
+                f"{principal} not on allowlist",
+                "add to auth.allowed_emails in the lens config",
+            )
+        if (not is_email) and principal not in allowed_tokens:
+            return _http_error(
+                403,
+                f"service token {principal} not on allowlist",
+                "add to auth.allowed_service_tokens in the lens config",
+            )
+
+        try:
+            nick = derive_nick(server_name, principal)
+        except ValueError as exc:
+            logger.error("nick derivation failed: %s", exc)
+            return _http_error(
+                500,
+                "nick derivation failed",
+                "principal sanitizes to empty; pick a different identity",
+            )
+
+        request["identity"] = Identity(
+            principal=principal,
+            nick=nick,
+            raw_jwt_subject=str(claims.get("sub", "")),
+        )
+        logger.info(
+            "auth=ok principal=%s nick=%s method=%s path=%s",
+            principal, nick, request.method, request.path,
+        )
+        return await handler(request)
+
+    return middleware
+
+
+async def warm_jwks(config: LensConfig) -> None:
+    """Fail fast at startup if Cloudflare's JWKS is unreachable."""
+    if config.auth_mode != "cloudflare-access":
+        return
+    cache = _JWKSCache(config.cf_team_domain or "")
+    await cache.warm()
+```
+
+- [ ] **Step 2: Update `make_app` to install the right middleware per mode**
+
+In `src/irc_lens/web/app.py`, remove the early `RuntimeError` guard and the `_dev_identity_middleware`-only path. Replace with:
+
+```python
+from irc_lens.web.auth import build_cloudflare_middleware
+
+
+def make_app(config: LensConfig, session_factory: SessionFactory) -> web.Application:
+    if config.auth_mode == "dev":
+        middleware = _dev_identity_middleware(config)
+    elif config.auth_mode == "cloudflare-access":
+        middleware = build_cloudflare_middleware(config)
+    else:
+        raise RuntimeError(f"unknown auth_mode {config.auth_mode!r}")
+
+    app = web.Application(client_max_size=_MAX_INPUT_BODY, middlewares=[middleware])
+    # … rest unchanged from Task 2.5.
+```
+
+- [ ] **Step 3: Run middleware tests, expect green**
+
+Run: `uv run pytest tests/test_auth_middleware.py -v`
+Expected: all 7 tests PASS. The kid-miss test asserts the second request fails (FakeJWKS only serves one kid); the lens must refetch but still not find the rotated kid → 401.
+
+- [ ] **Step 4: Run full suite — dev-mode tests must still pass**
+
+Run: `uv run pytest -x -v`
+Expected: green.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/irc_lens/web/auth.py src/irc_lens/web/app.py
+git commit -m "feat(web): Cloudflare Access JWT middleware with JWKS cache"
+```
+
+---
+
+### Task 3.4: Add a positive kid-miss-refresh test (rotation that *succeeds*)
+
+**Files:**
+- Modify: `tests/_jwks_server.py`
+- Modify: `tests/test_auth_middleware.py`
+
+The previous test only proved we *fail* on an unknown kid. We also need to prove we *succeed* when the JWKS rotates and a refresh discovers the new key.
+
+- [ ] **Step 1: Add a key-rotation method to `FakeJWKS`**
+
+In `tests/_jwks_server.py`, after `__init__`, add:
+
+```python
+def rotate(self, new_kid: str) -> None:
+    """Replace the key + kid; subsequent /certs returns the new key only."""
+    self._kid = new_kid
+    self._key = rsa.generate_private_key(public_exponent=65537, key_size=2048)
+```
+
+- [ ] **Step 2: Add the success-path test**
+
+Append to `tests/test_auth_middleware.py`:
+
+```python
+async def test_rotated_kid_accepted_after_refresh(cf_client: TestClient, jwks: FakeJWKS) -> None:
+    """JWT signed with a new key after rotation must validate post-refresh."""
+    # Warm cache with the original kid.
+    t1 = jwks.mint(aud="aud-test", claims={"email": "alice@example.com", "sub": "s"})
+    r1 = await cf_client.get("/healthz", headers={"Cf-Access-Jwt-Assertion": t1})
+    assert r1.status == 200
+
+    # Wait past the 5 s anti-flood window so the next miss triggers a real refresh.
+    import asyncio
+    await asyncio.sleep(5.1)
+
+    # Rotate, mint with the new key, expect success after JWKS refresh.
+    jwks.rotate("kid-after-rotation")
+    t2 = jwks.mint(aud="aud-test", claims={"email": "alice@example.com", "sub": "s"})
+    r2 = await cf_client.get("/healthz", headers={"Cf-Access-Jwt-Assertion": t2})
+    assert r2.status == 200
+```
+
+The 5 s sleep makes this test slow; mark it explicitly:
+
+```python
+import pytest
+@pytest.mark.slow
+async def test_rotated_kid_accepted_after_refresh(...):
+    ...
+```
+
+Add the `slow` marker to `pyproject.toml`:
+
+```toml
+markers = [
+    "playwright: …",
+    "cloudflare: …",
+    "slow: tests with intentional sleeps; default-included.",
+]
+```
+
+(`slow` stays in the default run; the marker is just a label.)
+
+- [ ] **Step 3: Run the new test**
+
+Run: `uv run pytest tests/test_auth_middleware.py::test_rotated_kid_accepted_after_refresh -v`
+Expected: PASS in ~5.5 s.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add tests/_jwks_server.py tests/test_auth_middleware.py pyproject.toml
+git commit -m "test: rotated-kid success path through JWKS refresh"
+```
+
+---
+
+### Task 3.5: Service-token branch test
+
+**Files:**
+- Modify: `tests/test_auth_middleware.py`
+
+- [ ] **Step 1: Add tests for the service-token claim shape**
+
+Append to `tests/test_auth_middleware.py`:
+
+```python
+async def test_service_token_common_name_accepted(jwks: FakeJWKS) -> None:
+    """A JWT with `common_name` (no `email`) is accepted iff CN is in
+    auth.allowed_service_tokens."""
+    config = LensConfig(
+        auth_mode="cloudflare-access",
+        dev_nick=None,
+        dev_email=None,
+        cf_aud="aud-test",
+        cf_team_domain=jwks.team_domain,
+        allowed_emails=(),
+        allowed_service_tokens=("ci-bot",),
+        server_name="testsrv",
+        server_host="127.0.0.1",
+        server_port=6667,
+        web_bind="127.0.0.1",
+        web_port=0,
+    )
+
+    def boom_factory(_n: str):
+        raise AssertionError("not expected to run")
+
+    app = make_app(config, boom_factory)
+    server = TestServer(app)
+    client = TestClient(server)
+    await client.start_server()
+    try:
+        token = jwks.mint(aud="aud-test", claims={"common_name": "ci-bot", "sub": "svc"})
+        r = await client.get("/healthz", headers={"Cf-Access-Jwt-Assertion": token})
+        assert r.status == 200
+
+        bad = jwks.mint(aud="aud-test", claims={"common_name": "rogue", "sub": "svc"})
+        r = await client.get("/healthz", headers={"Cf-Access-Jwt-Assertion": bad})
+        assert r.status == 403
+    finally:
+        await client.close()
+```
+
+- [ ] **Step 2: Run, expect green**
+
+Run: `uv run pytest tests/test_auth_middleware.py::test_service_token_common_name_accepted -v`
+Expected: PASS.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add tests/test_auth_middleware.py
+git commit -m "test: service-token common-name allowlist branch"
+```
+
+---
+
+### Task 3.6: Wire `serve.py` to load config and select mode
+
+**Files:**
+- Modify: `src/irc_lens/cli/_commands/serve.py`
+
+Phase 4 will tighten the CLI rules; this task just lets `serve` consume a real config file.
+
+- [ ] **Step 1: Add `--config` flag and load logic**
+
+In `register()`, add:
+
+```python
+p.add_argument(
+    "--config",
+    default=None,
+    help="Path to irc-lens config.yaml (default: ~/.config/irc-lens/config.yaml).",
+)
+```
+
+In `cmd_serve`, before `_configure_logging`, resolve the config:
+
+```python
+config_path = Path(args.config) if args.config else default_config_path()
+if config_path.exists():
+    config = load_config(config_path)
+else:
+    # Backward-compat: if no config file, fall back to the synthetic dev
+    # config built from CLI args. Phase 4 reverses this: missing file is
+    # an error, with `irc-lens config init` in the hint.
+    config = _build_dev_config(args)
+```
+
+In `_serve_async`, replace the body so the branching lives inline:
+
+```python
+async def _serve_async(args: argparse.Namespace, config: LensConfig) -> None:
+    if config.auth_mode == "dev":
+        # Existing dev path: open one Session at boot.
+        session = Session(host=config.server_host, port=config.server_port,
+                          nick=config.dev_nick, icon=args.icon)
+        await session.connect()
+        await session.wait_for_welcome()
+        if args.seed:
+            from irc_lens.seed import apply_seed
+            apply_seed(session, Path(args.seed))
+        factory = lambda _n: session   # noqa: E731
+    else:
+        # CF mode: warm JWKS, defer IRC connect to first authenticated request.
+        from irc_lens.web.auth import warm_jwks
+        try:
+            await warm_jwks(config)
+        except Exception as exc:
+            raise AfiError(
+                code=EXIT_ENV_ERROR,
+                message=f"could not reach Cloudflare JWKS at {config.cf_team_domain}: {exc}",
+                remediation="verify network egress and team_domain spelling",
+            ) from exc
+
+        def factory(nick: str) -> Session:
+            return Session(host=config.server_host, port=config.server_port,
+                           nick=nick, icon=None)
+
+    app = make_app(config, factory)
+    runner = web.AppRunner(app, handle_signals=True)
+    await runner.setup()
+    site = web.TCPSite(runner, host=config.web_bind, port=config.web_port)
+    try:
+        await site.start()
+    except OSError as exc:
+        raise AfiError(...)
+    # … rest unchanged.
+    try:
+        await asyncio.Event().wait()
+    finally:
+        await disconnect_all(app["registry"])
+        await runner.cleanup()
+```
+
+Pass `config` through:
+
+```python
+asyncio.run(_serve_async(args, config))
+```
+
+- [ ] **Step 2: Run full suite**
+
+Run: `uv run pytest -x -v`
+Expected: green. The `test_serve_cli.py` suite still uses `--nick`-required-required-via-argparse, which Phase 4 changes; in Phase 3 it should keep passing because we haven't removed `--nick`.
+
+- [ ] **Step 3: Smoke CF mode**
+
+Run: `uv run irc-lens config init --path /tmp/lens.yaml`
+Edit `/tmp/lens.yaml` to set `auth.mode: cloudflare-access` with a bogus `team_domain` (e.g. `nope.invalid`).
+Run: `uv run irc-lens serve --config /tmp/lens.yaml --nick dummy --web-port 18765`
+Expected: exits 2 with `error: could not reach Cloudflare JWKS at nope.invalid` and the hint.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/irc_lens/cli/_commands/serve.py
+git commit -m "feat(serve): load config from file, branch on auth.mode
+
+Dev mode keeps the singleton-Session-at-boot. CF mode warms JWKS at
+startup (fail-fast on unreachable Cloudflare) and defers IRC connect
+until the first authenticated request. --config flag added."
+```
+
+---
+
+### Task 3.7: Audit-log integration smoke test
+
+**Files:**
+- Create: `tests/test_audit_log.py`
+
+- [ ] **Step 1: Write the test**
+
+```python
+"""Authenticated requests emit one structured audit line on stderr."""
+from __future__ import annotations
+
+import logging
+
+import pytest_asyncio
+from aiohttp.test_utils import TestClient, TestServer
+
+from irc_lens.config import LensConfig
+from irc_lens.web import make_app
+
+from _jwks_server import FakeJWKS
+
+
+async def test_authenticated_request_logs_principal(jwks: FakeJWKS, caplog) -> None:
+    config = LensConfig(
+        auth_mode="cloudflare-access",
+        dev_nick=None, dev_email=None,
+        cf_aud="aud-test", cf_team_domain=jwks.team_domain,
+        allowed_emails=("alice@example.com",), allowed_service_tokens=(),
+        server_name="testsrv",
+        server_host="127.0.0.1", server_port=6667,
+        web_bind="127.0.0.1", web_port=0,
+    )
+
+    def boom(_n: str):
+        raise AssertionError("not expected")
+
+    app = make_app(config, boom)
+    server = TestServer(app)
+    client = TestClient(server)
+    await client.start_server()
+    try:
+        token = jwks.mint(aud="aud-test", claims={"email": "alice@example.com", "sub": "s"})
+        with caplog.at_level(logging.INFO, logger="irc_lens.web.auth"):
+            r = await client.get("/healthz", headers={"Cf-Access-Jwt-Assertion": token})
+            assert r.status == 200
+        msgs = [rec.getMessage() for rec in caplog.records if rec.name == "irc_lens.web.auth"]
+        assert any("auth=ok" in m and "alice@example.com" in m for m in msgs)
+    finally:
+        await client.close()
+```
+
+The `jwks` fixture is in `tests/test_auth_middleware.py`. To share, lift it into `tests/conftest.py`:
+
+```python
+@pytest_asyncio.fixture
+async def jwks() -> AsyncIterator[FakeJWKS]:
+    j = FakeJWKS()
+    await j.start()
+    try:
+        yield j
+    finally:
+        await j.stop()
+```
+
+(import `FakeJWKS` from `_jwks_server` at the top of conftest).
+
+Remove the duplicate fixture from `test_auth_middleware.py`.
+
+- [ ] **Step 2: Run, expect green**
+
+Run: `uv run pytest tests/test_audit_log.py -v`
+Expected: PASS.
+
+- [ ] **Step 3: Run the full suite**
+
+Run: `uv run pytest -x -v`
+Expected: green.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add tests/test_audit_log.py tests/conftest.py tests/test_auth_middleware.py
+git commit -m "test: audit log emits one auth=ok line per authenticated request"
+```
+
+---
+
+## Phase 4 — CLI/HTTP cleanups
+
+### Task 4.1: `--nick` rejection in CF mode + bind coercion
+
+**Files:**
+- Create: `tests/test_serve_cf_mode.py`
+- Modify: `src/irc_lens/cli/_commands/serve.py`
+
+- [ ] **Step 1: Write failing tests**
+
+```python
+"""--nick is rejected in CF mode; --bind on a non-loopback is coerced."""
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+
+import pytest
+
+from irc_lens.cli._commands.serve import _validate_cli_against_config
+from irc_lens.cli._errors import EXIT_USER_ERROR, AfiError
+from irc_lens.config import LensConfig
+
+
+def _cf_config() -> LensConfig:
+    return LensConfig(
+        auth_mode="cloudflare-access",
+        dev_nick=None, dev_email=None,
+        cf_aud="a", cf_team_domain="t.cloudflareaccess.com",
+        allowed_emails=("a@example.com",),
+        allowed_service_tokens=(),
+        server_name="spark",
+        server_host="127.0.0.1", server_port=6667,
+        web_bind="127.0.0.1", web_port=8765,
+    )
+
+
+def test_nick_rejected_in_cf_mode(tmp_path: Path) -> None:
+    cfg = _cf_config()
+    with pytest.raises(AfiError) as exc:
+        _validate_cli_against_config(cfg, nick="something", bind="127.0.0.1")
+    assert exc.value.code == EXIT_USER_ERROR
+    assert "--nick" in exc.value.message
+
+
+def test_bind_coerced_to_loopback_in_cf_mode(caplog) -> None:
+    cfg = _cf_config()
+    with caplog.at_level(logging.WARNING):
+        coerced = _validate_cli_against_config(cfg, nick=None, bind="0.0.0.0")
+    assert coerced.web_bind == "127.0.0.1"
+    assert any("coerced" in r.getMessage().lower() for r in caplog.records)
+
+
+def test_loopback_bind_unchanged_in_cf_mode() -> None:
+    cfg = _cf_config()
+    coerced = _validate_cli_against_config(cfg, nick=None, bind="127.0.0.1")
+    assert coerced.web_bind == "127.0.0.1"
+```
+
+- [ ] **Step 2: Implement `_validate_cli_against_config`**
+
+In `src/irc_lens/cli/_commands/serve.py`:
+
+```python
+import logging
+logger = logging.getLogger("irc_lens.serve")
+
+_LOOPBACK = {"127.0.0.1", "::1", "localhost"}
+
+
+def _validate_cli_against_config(
+    config: LensConfig,
+    nick: str | None,
+    bind: str | None,
+) -> LensConfig:
+    """Apply CF-mode CLI rules. Returns a possibly-coerced config."""
+    if config.auth_mode != "cloudflare-access":
+        return config
+
+    if nick is not None:
+        raise AfiError(
+            code=EXIT_USER_ERROR,
+            message="--nick is not valid when auth.mode is cloudflare-access",
+            remediation=(
+                "remove --nick — in CF mode the nick is derived per "
+                "authenticated user from auth.allowed_emails"
+            ),
+        )
+
+    effective_bind = bind if bind is not None else config.web_bind
+    if effective_bind not in _LOOPBACK:
+        logger.warning(
+            "web.bind=%s is not loopback; coerced to 127.0.0.1 because "
+            "cloudflared terminates locally",
+            effective_bind,
+        )
+        # Frozen dataclass — return a new one with web_bind replaced.
+        from dataclasses import replace
+        return replace(config, web_bind="127.0.0.1")
+    return config
+```
+
+Then in `cmd_serve`, before `_serve_async`:
+
+```python
+config = _validate_cli_against_config(
+    config,
+    nick=args.nick,
+    bind=args.bind if args.bind != "127.0.0.1" else None,  # only if user passed a non-default
+)
+```
+
+(The default `--bind 127.0.0.1` should pass through silently; only an explicitly passed non-loopback triggers the notice. Easiest: track whether the user passed `--bind` via a sentinel. Replace the argparse default for `--bind` with `None` and treat `None` as "not provided".)
+
+Update the argparse spec:
+
+```python
+p.add_argument(
+    "--bind",
+    default=None,
+    help="…",
+)
+```
+
+And in `_build_dev_config` / wherever `args.bind` is consumed downstream, fall back to `config.web_bind` when `args.bind is None`.
+
+- [ ] **Step 3: Run new tests, expect green**
+
+Run: `uv run pytest tests/test_serve_cf_mode.py -v`
+Expected: 3 PASS.
+
+- [ ] **Step 4: Run full suite**
+
+Run: `uv run pytest -x -v`
+Expected: green.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add tests/test_serve_cf_mode.py src/irc_lens/cli/_commands/serve.py
+git commit -m "feat(serve): reject --nick in CF mode, coerce non-loopback --bind"
+```
+
+---
+
+### Task 4.2: `/healthz` test
+
+**Files:**
+- Create: `tests/test_healthz.py`
+
+- [ ] **Step 1: Write the test**
+
+```python
+"""/healthz is opaque, unauthenticated, leaks no IRC state."""
+from __future__ import annotations
+
+from aiohttp.test_utils import TestClient
+
+
+async def test_healthz_returns_only_ok(lens_client: TestClient) -> None:
+    r = await lens_client.get("/healthz")
+    assert r.status == 200
+    body = await r.json()
+    assert body == {"ok": True}
+
+
+async def test_healthz_without_auth_in_cf_mode_works() -> None:
+    """A /healthz hit on a CF-mode app skips the middleware entirely."""
+    from _jwks_server import FakeJWKS
+    from irc_lens.config import LensConfig
+    from irc_lens.web import make_app
+
+    jwks = FakeJWKS()
+    await jwks.start()
+    try:
+        config = LensConfig(
+            auth_mode="cloudflare-access",
+            dev_nick=None, dev_email=None,
+            cf_aud="a", cf_team_domain=jwks.team_domain,
+            allowed_emails=("alice@example.com",), allowed_service_tokens=(),
+            server_name="spark",
+            server_host="127.0.0.1", server_port=6667,
+            web_bind="127.0.0.1", web_port=0,
+        )
+        def boom(_n): raise AssertionError("no")
+        app = make_app(config, boom)
+        from aiohttp.test_utils import TestServer
+        server = TestServer(app)
+        client = TestClient(server)
+        await client.start_server()
+        try:
+            r = await client.get("/healthz")
+            assert r.status == 200
+            assert await r.json() == {"ok": True}
+        finally:
+            await client.close()
+    finally:
+        await jwks.stop()
+```
+
+- [ ] **Step 2: Run, expect green**
+
+Run: `uv run pytest tests/test_healthz.py -v`
+Expected: PASS.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add tests/test_healthz.py
+git commit -m "test: /healthz opaque + unauthenticated in both modes"
+```
+
+---
+
+### Task 4.3: Origin/Referer floor on `POST /input`
+
+**Files:**
+- Create: `tests/test_origin_check.py`
+- Modify: `src/irc_lens/web/routes.py`
+
+- [ ] **Step 1: Write failing tests**
+
+```python
+"""POST /input rejects cross-origin requests as a CSRF floor."""
+from __future__ import annotations
+
+from aiohttp.test_utils import TestClient
+
+
+async def test_post_input_no_origin_allowed(lens_client: TestClient) -> None:
+    """No Origin header (curl, cloudflared probe) is allowed."""
+    r = await lens_client.post("/input", data={"text": "hello"})
+    assert r.status in (204, 503)
+
+
+async def test_post_input_matching_origin_allowed(lens_client: TestClient) -> None:
+    # In dev mode the public hostname isn't pinned; same-origin always OK.
+    origin = f"http://127.0.0.1:{lens_client.server.port}"
+    r = await lens_client.post("/input", data={"text": "hello"},
+                               headers={"Origin": origin})
+    assert r.status in (204, 503)
+
+
+async def test_post_input_foreign_origin_rejected(lens_client: TestClient) -> None:
+    r = await lens_client.post("/input", data={"text": "hello"},
+                               headers={"Origin": "https://evil.example.com"})
+    assert r.status == 403
+    body = await r.json()
+    assert "origin" in body["error"].lower()
+```
+
+- [ ] **Step 2: Implement the check in `routes.py`**
+
+Add near the top of `routes.py`:
+
+```python
+def _origin_ok(request: web.Request) -> bool:
+    """Best-effort same-origin check against the configured public host.
+
+    Dev mode: any same-origin (matches the request's own Host) passes.
+    CF mode: matches against the configured public hostname (set in
+    Phase 4 via a new config field — for now, allow same-Host).
+    Absent Origin header: pass (curl, cloudflared probes).
+    """
+    origin = request.headers.get("Origin")
+    if not origin:
+        return True
+    # Strip scheme; compare host:port.
+    from urllib.parse import urlparse
+    parsed = urlparse(origin)
+    origin_netloc = parsed.netloc
+    request_host = request.headers.get("Host", "")
+    return origin_netloc == request_host
+```
+
+In `post_input`, immediately after the content-length check:
+
+```python
+if not _origin_ok(request):
+    return web.json_response(
+        {"error": "Origin does not match request host",
+         "hint": "this is a CSRF defense; submit from the lens UI itself"},
+        status=403,
+    )
+```
+
+- [ ] **Step 3: Run tests, expect green**
+
+Run: `uv run pytest tests/test_origin_check.py -v`
+Expected: 3 PASS.
+
+- [ ] **Step 4: Full suite green**
+
+Run: `uv run pytest -x -v`
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add tests/test_origin_check.py src/irc_lens/web/routes.py
+git commit -m "feat(web): same-host Origin check on POST /input (CSRF floor)"
+```
+
+---
+
+### Task 4.4: Tighten config-file-required behavior
+
+**Files:**
+- Modify: `src/irc_lens/cli/_commands/serve.py`
+- Modify: `tests/test_serve_cli.py` (existing — adjust expectations)
+
+The Phase 3 fallback ("if no config, build synthetic dev config from CLI args") is removed. Missing file → `error:` + `hint: irc-lens config init`.
+
+- [ ] **Step 1: Update serve.py**
+
+In `cmd_serve`, replace the conditional load with:
+
+```python
+config_path = Path(args.config) if args.config else default_config_path()
+config = load_config(config_path)   # raises AfiError on missing file
+```
+
+Drop the `_build_dev_config` helper (no longer used) and its imports.
+
+- [ ] **Step 2: Update existing serve CLI tests**
+
+In `tests/test_serve_cli.py`, look for the test that checks `--nick` is required. The contract changes: it's now config that's required. Either:
+
+a) Adjust to set `--config <fixture>` to point at a tmp_path dev config.
+b) Add a new test for "missing config errors" and rewrite the `--nick` requirement test to verify the new behavior.
+
+Choose (a) for the smallest blast radius. Add a fixture:
+
+```python
+@pytest.fixture
+def dev_config_path(tmp_path: Path) -> Path:
+    p = tmp_path / "config.yaml"
+    p.write_text("""
+auth:
+  mode: dev
+  dev:
+    nick: lens-test
+    email: dev@local
+server:
+  name: spark
+  host: 127.0.0.1
+  port: 6667
+""")
+    return p
+```
+
+And add a new test:
+
+```python
+def test_serve_missing_config_errors(tmp_path: Path) -> None:
+    rc = main(["serve", "--config", str(tmp_path / "nope.yaml")])
+    assert rc == 1
+```
+
+- [ ] **Step 3: Run full suite**
+
+Run: `uv run pytest -x -v`
+Expected: green.
+
+- [ ] **Step 4: Smoke**
+
+Run: `uv run irc-lens serve` (no flags, no config file at default path)
+Expected: exit 1, stderr `error: no config at …` + `hint: run 'irc-lens config init'…`.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/irc_lens/cli/_commands/serve.py tests/test_serve_cli.py
+git commit -m "feat(serve): require config file (no synthetic-dev fallback)"
+```
+
+---
+
+### Task 4.5: Bump version, update docs/cli.md, update README
+
+**Files:**
+- Modify: `pyproject.toml`
+- Modify: `src/irc_lens/__init__.py` (if it has `__version__`)
+- Modify: `docs/cli.md`
+- Modify: `README.md`
+
+- [ ] **Step 1: Bump version**
+
+Run: `uv run /version-bump minor` if a version-bump script exists; otherwise hand-edit `pyproject.toml` `version = "0.4.2"` → `"0.5.0"` and the matching `__init__.py`.
+
+- [ ] **Step 2: Update `docs/cli.md`**
+
+Add a new "Configuration" section before any existing serve docs:
+
+```markdown
+## Configuration
+
+irc-lens reads `~/.config/irc-lens/config.yaml` by default (override with
+`--config <path>`, respecting `$XDG_CONFIG_HOME`). Initialize with:
+
+    irc-lens config init
+
+The starter file is in `auth.mode: dev`, suitable for a local AgentIRC
+on `127.0.0.1:6667`. To deploy behind Cloudflare Access, switch
+`auth.mode` to `cloudflare-access` and set `auth.cloudflare.aud`,
+`auth.cloudflare.team_domain`, and `auth.allowed_emails`. See
+[deployment-cloudflare-access.md](deployment-cloudflare-access.md).
+
+### `--nick` and `--bind`
+
+In `auth.mode: dev`, `--nick` overrides `auth.dev.nick`. In
+`auth.mode: cloudflare-access`, passing `--nick` is a hard error: the
+nick is derived per authenticated user from `auth.allowed_emails`.
+A non-loopback `--bind` (or `web.bind`) under CF mode is silently
+coerced to `127.0.0.1` because cloudflared terminates locally.
+```
+
+- [ ] **Step 3: Update README**
+
+At the bottom of `README.md`, after any existing sections, add:
+
+```markdown
+## Production deployment
+
+To host irc-lens behind Cloudflare Access on your own domain, see
+[docs/deployment-cloudflare-access.md](docs/deployment-cloudflare-access.md).
+```
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add pyproject.toml src/irc_lens/__init__.py docs/cli.md README.md
+git commit -m "docs: cli.md config section, README pointer, bump 0.5.0"
+```
+
+---
+
+## Phase 5 — Docs + round-trip scripts + real CF round-trip test
+
+### Task 5.1: Write `docs/auth.md`
+
+**Files:**
+- Create: `docs/auth.md`
+
+- [ ] **Step 1: Write the file**
+
+```markdown
+# Authentication and Identity
+
+irc-lens supports two auth modes, selected by `auth.mode` in the config
+file: `dev` (no auth, single synthetic identity) and
+`cloudflare-access` (per-user JWT-validated identity behind Cloudflare
+Access).
+
+## Identity model
+
+- One `Session` per authenticated principal, opened lazily on first
+  request.
+- Nick is derived: `<server_name>-<sanitized-local-part>`. Sanitization
+  drops everything outside `[a-z0-9-]` from the email's local part (or
+  from the service-token common name).
+- The principal — `email` for interactive SSO, `common_name` for
+  service tokens — keys the registry. Two browsers signed in as the
+  same principal share one Session and one IRC connection.
+
+## JWT validation rules
+
+For each authenticated request the lens:
+
+1. Reads the JWT from the `Cf-Access-Jwt-Assertion` header (preferred)
+   or the `CF_Authorization` cookie.
+2. Looks up the signing key by `kid` against an in-process JWKS cache.
+3. On `kid` miss: refreshes the cache once (rate-limited to once every
+   5 s) and retries; permanent miss → 401.
+4. Verifies signature, audience (`auth.cloudflare.aud`), and issuer
+   (`https://<auth.cloudflare.team_domain>`).
+5. Reads `email` (or `common_name`) and checks against
+   `auth.allowed_emails` / `auth.allowed_service_tokens`.
+6. Derives the nick and stashes the `Identity` on `request["identity"]`.
+
+## Dev mode
+
+In `auth.mode: dev`, the same middleware is installed but synthesizes
+`Identity(principal=auth.dev.email, nick=auth.dev.nick, ...)` on every
+request. Handlers see the same contract as in CF mode.
+
+## Failure modes
+
+| Status | Cause |
+| --- | --- |
+| 401 | missing or invalid JWT |
+| 403 | allowlist denied / Origin mismatch on POST /input |
+| 500 | nick derivation produced empty (server-config bug) |
+| 502 | JWKS unreachable on first fetch |
+| 503 | Session unhealthy / cannot reach AgentIRC |
+
+## Audit log
+
+Every authenticated request emits one structured line on stderr:
+
+    auth=ok principal=<email-or-common-name> nick=<derived> method=<verb> path=<path>
+
+Auth denials log:
+
+    auth=denied principal=<...> reason=<short-tag>
+
+When `--log-json` is passed, the same data goes through the
+`_JsonLineFormatter` and lands as one JSON object per line.
+
+## Service tokens
+
+Cloudflare Access supports service tokens for non-interactive callers
+(CI, scripts). They authenticate via `CF-Access-Client-Id` and
+`CF-Access-Client-Secret` headers; Cloudflare mints a JWT that carries
+`common_name` instead of `email`. List the allowed common-names under
+`auth.allowed_service_tokens`. Service tokens have no MFA and no SSO
+identity; treat them as long-lived secrets.
+```
+
+- [ ] **Step 2: Lint**
+
+Run: `markdownlint-cli2 docs/auth.md`
+Expected: no errors.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add docs/auth.md
+git commit -m "docs(auth): protocol-level reference for the lens auth model"
+```
+
+---
+
+### Task 5.2: Write `docs/security-checklist.md`
+
+**Files:**
+- Create: `docs/security-checklist.md`
+
+- [ ] **Step 1: Write the file**
+
+```markdown
+# Security Checklist — public-facing irc-lens
+
+Before opening your hostname to the internet, walk this list. Every
+item is a yes/no.
+
+## Network exposure
+
+- [ ] AgentIRC is bound to `127.0.0.1` (or a private mesh interface),
+      never `0.0.0.0`.
+- [ ] `irc-lens serve`'s `web.bind` is `127.0.0.1`. CF mode coerces
+      this automatically; verify with `ss -lntp | grep 8765`.
+- [ ] No firewall rule forwards an inbound port to either service.
+      cloudflared is the only reachable surface.
+
+## Cloudflare config
+
+- [ ] `auth.mode: cloudflare-access` in the active config file.
+- [ ] `auth.cloudflare.aud` matches the AUD shown in the Access app's
+      "Application Audience (AUD) Tag" field.
+- [ ] `auth.cloudflare.team_domain` matches your Cloudflare team
+      domain (`<team>.cloudflareaccess.com`).
+- [ ] `auth.allowed_emails` matches the Access policy's email list.
+      Both must say yes for a request to land — defense in depth.
+- [ ] The IdP (Google SSO, GitHub, etc.) enforces MFA on every
+      account in `auth.allowed_emails`.
+
+## cloudflared
+
+- [ ] cloudflared's tunnel `ingress` rule points to
+      `http://localhost:<web.port>`, not `http://0.0.0.0:<web.port>`.
+- [ ] cloudflared and irc-lens both run as a non-root user.
+- [ ] cloudflared's `tunnel-credentials` file is `chmod 600`.
+
+## Operational
+
+- [ ] Logs are persisted somewhere auditable (systemd journal is
+      fine). Review `auth=denied` lines after each test session.
+- [ ] `GET /healthz` returns `{"ok": true}` and nothing else; the
+      response does not reveal whether any user has a live session.
+- [ ] You have a way to rotate the IdP credentials and the CF API
+      token without downtime.
+
+## Things to revisit later
+
+These ship in v1 with a known floor; tighten as the deployment grows:
+
+- CSRF defense on `POST /input` is currently Origin/Referer only. See
+  [issue #27](https://github.com/agentculture/irc-lens/issues/27)
+  for the CSRF-token uplift.
+- The CF round-trip test runs only manually / via agent. Automation
+  on GitHub Actions is tracked in
+  [issue #28](https://github.com/agentculture/irc-lens/issues/28).
+- Group-based authorization (using the `groups` JWT claim) is not
+  consumed in v1.
+```
+
+- [ ] **Step 2: Lint**
+
+Run: `markdownlint-cli2 docs/security-checklist.md`
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add docs/security-checklist.md
+git commit -m "docs: pre-launch security checklist"
+```
+
+---
+
+### Task 5.3: Write `docs/deployment-cloudflare-access.md`
+
+**Files:**
+- Create: `docs/deployment-cloudflare-access.md`
+
+- [ ] **Step 1: Write the file** (domain-neutral; placeholders only)
+
+```markdown
+# Deploying irc-lens behind Cloudflare Access on your own domain
+
+This runbook walks you through hosting irc-lens at a public hostname
+on your own Cloudflare-managed zone, gated by Cloudflare Access. The
+result: anyone you allowlist can sign in via your IdP and reach a
+private AgentIRC mesh; nobody else can.
+
+## Prerequisites
+
+- A Cloudflare account with `<your-zone>` (e.g. `example.com`)
+  managed.
+- An IdP set up in Cloudflare Access (Google SSO, GitHub, etc.).
+  Cloudflare's dashboard has a wizard.
+- `cloudflared` installed on the host machine. See Cloudflare's docs
+  for current install instructions.
+- `irc-lens` and AgentIRC running (or about to run) on the same host.
+
+## 1. Pick a hostname
+
+Decide on `<your-hostname>` under `<your-zone>` (e.g.
+`lens.<your-zone>`). The runbook uses these placeholders below.
+
+## 2. Create the tunnel
+
+    cloudflared tunnel login                   # one-time, browser-based
+    cloudflared tunnel create irc-lens
+
+This writes a credentials JSON to `~/.cloudflared/<tunnel-uuid>.json`.
+
+## 3. Route DNS
+
+    cloudflared tunnel route dns irc-lens <your-hostname>
+
+Cloudflare creates a CNAME `<your-hostname>` → `<tunnel-uuid>.cfargotunnel.com`.
+
+## 4. Configure cloudflared
+
+Create `~/.cloudflared/config.yml`:
+
+    tunnel: <tunnel-uuid>
+    credentials-file: /home/<user>/.cloudflared/<tunnel-uuid>.json
+
+    ingress:
+      - hostname: <your-hostname>
+        service: http://localhost:8765
+      - service: http_status:404
+
+## 5. Run cloudflared as a service (systemd example)
+
+    sudo cloudflared service install
+    sudo systemctl start cloudflared
+    sudo systemctl enable cloudflared
+
+## 6. Create the Access application
+
+In the Cloudflare dashboard → Zero Trust → Access → Applications:
+
+- Application type: Self-hosted.
+- Application domain: `<your-hostname>`.
+- Identity providers: select your configured IdP.
+- Add policy: Allow + `Emails` → list the same emails you'll put in
+  `auth.allowed_emails`.
+
+Note the **Application Audience (AUD) Tag** — you need this for the
+lens config.
+
+## 7. Configure irc-lens
+
+    irc-lens config init
+
+Edit `~/.config/irc-lens/config.yaml`:
+
+    auth:
+      mode: cloudflare-access
+      cloudflare:
+        aud: <your-aud-tag>
+        team_domain: <your-team>.cloudflareaccess.com
+      allowed_emails:
+        - <your-email>
+    server:
+      name: <agentirc-server-name>
+      host: 127.0.0.1
+      port: 6667
+    web:
+      bind: 127.0.0.1
+      port: 8765
+
+## 8. Start in this order
+
+1. AgentIRC (so it's ready when the lens connects).
+2. `irc-lens serve` (validates JWKS, binds 127.0.0.1:8765).
+3. `cloudflared` (already running as systemd unit).
+
+Reverse on shutdown.
+
+## 9. Verify
+
+- Visit `https://<your-hostname>/healthz` → `{"ok": true}`.
+- Visit `https://<your-hostname>/` → SSO redirect → lens UI.
+- Send a slash-command — it dispatches into AgentIRC under the
+  derived nick `<agentirc-server-name>-<sanitized-email-local>`.
+
+## Troubleshooting
+
+- **401 at /** → JWT not reaching the lens. Check cloudflared logs;
+  `cloudflared tunnel info irc-lens` should show a healthy edge.
+- **403 not on allowlist** → email passed CF Access but is missing
+  from `auth.allowed_emails`. Add it and restart.
+- **502 on first request** → lens couldn't reach
+  `https://<team_domain>/cdn-cgi/access/certs` at startup. Verify
+  egress.
+- **503 on /input** → AgentIRC is unreachable. Check
+  `server.host`/`server.port` and the IRCd's status.
+
+## Security checklist
+
+Walk [security-checklist.md](security-checklist.md) before opening
+the hostname to the internet.
+```
+
+- [ ] **Step 2: Lint**
+
+Run: `markdownlint-cli2 docs/deployment-cloudflare-access.md`
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add docs/deployment-cloudflare-access.md
+git commit -m "docs: domain-neutral CF Access deployment runbook"
+```
+
+---
+
+### Task 5.4: Update `docs/architecture.md`
+
+**Files:**
+- Modify: `docs/architecture.md`
+
+- [ ] **Step 1: Add deployment-modes subsection**
+
+Append to `docs/architecture.md`:
+
+```markdown
+## Deployment modes
+
+irc-lens has two operational modes selected by `auth.mode` in the
+config:
+
+### `dev` mode
+
+A single `Session` opens at startup against the configured AgentIRC
+on `auth.dev.nick`. The identity middleware injects a synthetic
+`Identity` for every request. Existing tests run in this mode.
+
+### `cloudflare-access` mode
+
+Each authenticated user gets their own lazy-opened `Session` with a
+nick derived from their email's local part (sanitized to
+`[a-z0-9-]`). The identity middleware validates the
+Cloudflare-issued JWT against the team's JWKS, pins audience and
+issuer, and enforces the lens-side allowlist as a second line of
+defense behind the Cloudflare Access policy. JWKS is cached
+in-process with kid-miss-then-refresh semantics.
+
+The lens never opens an inbound port in CF mode; cloudflared
+terminates the tunnel locally and the lens listens on
+`127.0.0.1:<web.port>`.
+```
+
+- [ ] **Step 2: Lint and commit**
+
+```bash
+markdownlint-cli2 docs/architecture.md
+git add docs/architecture.md
+git commit -m "docs(arch): document dev vs cloudflare-access deployment modes"
+```
+
+---
+
+### Task 5.5: Round-trip scripts (`setup.sh`, `teardown.sh`)
+
+**Files:**
+- Create: `scripts/cf-roundtrip/setup.sh`
+- Create: `scripts/cf-roundtrip/teardown.sh`
+- Create: `scripts/cf-roundtrip/README.md`
+
+These scripts use the Cloudflare HTTP API directly (the `gh`-style approach via `curl`) to keep the dependency surface zero beyond `bash`, `curl`, and `jq`.
+
+- [ ] **Step 1: Write `setup.sh`**
+
+```bash
+#!/usr/bin/env bash
+# Idempotent CF round-trip setup. Re-runs are safe: existing resources
+# are reused, only missing ones are created. Prints / writes
+# `.cf-roundtrip.env` with values the test reads at runtime.
+set -euo pipefail
+
+: "${CF_API_TOKEN:?must be set}"
+: "${CF_ACCOUNT_ID:?must be set}"
+: "${CF_ZONE_ID:?must be set}"
+: "${CF_TEST_HOSTNAME:?must be set}"
+: "${CF_TEAM_DOMAIN:?must be set}"
+
+BASE="https://api.cloudflare.com/client/v4"
+HDR=(-H "Authorization: Bearer $CF_API_TOKEN" -H "Content-Type: application/json")
+TUNNEL_NAME="irc-lens-roundtrip"
+APP_NAME="irc-lens roundtrip"
+TOKEN_FILE="${HOME}/.config/irc-lens/cf-roundtrip-token.json"
+ENV_OUT="${ENV_OUT:-.cf-roundtrip.env}"
+
+cf_get() { curl -sS "${HDR[@]}" "$BASE$1"; }
+cf_post() { curl -sS "${HDR[@]}" -X POST "$BASE$1" -d "$2"; }
+
+echo "[1/5] tunnel" >&2
+TUNNEL_ID="$(cf_get "/accounts/$CF_ACCOUNT_ID/cfd_tunnel?name=$TUNNEL_NAME" \
+  | jq -r '.result[0].id // empty')"
+if [[ -z "$TUNNEL_ID" ]]; then
+  TUNNEL_SECRET="$(openssl rand -base64 32)"
+  TUNNEL_ID="$(cf_post "/accounts/$CF_ACCOUNT_ID/cfd_tunnel" \
+    "$(jq -n --arg n "$TUNNEL_NAME" --arg s "$TUNNEL_SECRET" \
+        '{name:$n, tunnel_secret:$s}')" \
+    | jq -r '.result.id')"
+fi
+echo "  tunnel_id=$TUNNEL_ID" >&2
+
+echo "[2/5] dns" >&2
+DNS_ID="$(cf_get "/zones/$CF_ZONE_ID/dns_records?name=$CF_TEST_HOSTNAME" \
+  | jq -r '.result[0].id // empty')"
+if [[ -z "$DNS_ID" ]]; then
+  cf_post "/zones/$CF_ZONE_ID/dns_records" \
+    "$(jq -n --arg n "$CF_TEST_HOSTNAME" --arg c "$TUNNEL_ID.cfargotunnel.com" \
+        '{type:"CNAME", name:$n, content:$c, proxied:true}')" >/dev/null
+fi
+
+echo "[3/5] access app" >&2
+APP_ID="$(cf_get "/accounts/$CF_ACCOUNT_ID/access/apps?name=$APP_NAME" \
+  | jq -r '.result[0].id // empty')"
+if [[ -z "$APP_ID" ]]; then
+  APP_ID="$(cf_post "/accounts/$CF_ACCOUNT_ID/access/apps" \
+    "$(jq -n --arg n "$APP_NAME" --arg d "$CF_TEST_HOSTNAME" \
+        '{name:$n, domain:$d, type:"self_hosted", session_duration:"24h"}')" \
+    | jq -r '.result.id')"
+fi
+echo "  app_id=$APP_ID" >&2
+
+AUD="$(cf_get "/accounts/$CF_ACCOUNT_ID/access/apps/$APP_ID" | jq -r '.result.aud')"
+
+echo "[4/5] service token" >&2
+if [[ -f "$TOKEN_FILE" ]]; then
+  CLIENT_ID="$(jq -r .client_id "$TOKEN_FILE")"
+  CLIENT_SECRET="$(jq -r .client_secret "$TOKEN_FILE")"
+else
+  TOKEN_JSON="$(cf_post "/accounts/$CF_ACCOUNT_ID/access/service_tokens" \
+    "$(jq -n '{name:"irc-lens-roundtrip"}')" | jq -r '.result')"
+  CLIENT_ID="$(echo "$TOKEN_JSON" | jq -r .client_id)"
+  CLIENT_SECRET="$(echo "$TOKEN_JSON" | jq -r .client_secret)"
+  mkdir -p "$(dirname "$TOKEN_FILE")"
+  echo "$TOKEN_JSON" >"$TOKEN_FILE"
+  chmod 600 "$TOKEN_FILE"
+fi
+
+echo "[5/5] policy" >&2
+EXISTING="$(cf_get "/accounts/$CF_ACCOUNT_ID/access/apps/$APP_ID/policies" \
+  | jq -r '.result[] | select(.name=="allow-svc-token") | .id' | head -1)"
+if [[ -z "$EXISTING" ]]; then
+  cf_post "/accounts/$CF_ACCOUNT_ID/access/apps/$APP_ID/policies" \
+    "$(jq -n --arg cid "$CLIENT_ID" \
+        '{name:"allow-svc-token", decision:"non_identity", precedence:1,
+          include:[{service_token:{token_id:$cid}}]}')" >/dev/null
+fi
+
+cat >"$ENV_OUT" <<EOF
+IRC_LENS_TEST_AUD=$AUD
+IRC_LENS_TEST_HOSTNAME=$CF_TEST_HOSTNAME
+IRC_LENS_TEST_TEAM_DOMAIN=$CF_TEAM_DOMAIN
+IRC_LENS_TEST_CLIENT_ID=$CLIENT_ID
+IRC_LENS_TEST_CLIENT_SECRET=$CLIENT_SECRET
+EOF
+echo "wrote $ENV_OUT" >&2
+```
+
+- [ ] **Step 2: Write `teardown.sh`**
+
+```bash
+#!/usr/bin/env bash
+# Remove every resource setup.sh creates. Idempotent (404s ignored).
+set -euo pipefail
+
+: "${CF_API_TOKEN:?}"
+: "${CF_ACCOUNT_ID:?}"
+: "${CF_ZONE_ID:?}"
+: "${CF_TEST_HOSTNAME:?}"
+
+BASE="https://api.cloudflare.com/client/v4"
+HDR=(-H "Authorization: Bearer $CF_API_TOKEN")
+
+cf_del() { curl -sS "${HDR[@]}" -X DELETE "$BASE$1" || true; }
+cf_get() { curl -sS "${HDR[@]}" "$BASE$1"; }
+
+# Service token
+TOK_ID="$(cf_get "/accounts/$CF_ACCOUNT_ID/access/service_tokens" \
+  | jq -r '.result[] | select(.name=="irc-lens-roundtrip") | .id' | head -1)"
+[[ -n "$TOK_ID" ]] && cf_del "/accounts/$CF_ACCOUNT_ID/access/service_tokens/$TOK_ID"
+
+# Access app
+APP_ID="$(cf_get "/accounts/$CF_ACCOUNT_ID/access/apps?name=irc-lens%20roundtrip" \
+  | jq -r '.result[0].id // empty')"
+[[ -n "$APP_ID" ]] && cf_del "/accounts/$CF_ACCOUNT_ID/access/apps/$APP_ID"
+
+# DNS
+DNS_ID="$(cf_get "/zones/$CF_ZONE_ID/dns_records?name=$CF_TEST_HOSTNAME" \
+  | jq -r '.result[0].id // empty')"
+[[ -n "$DNS_ID" ]] && cf_del "/zones/$CF_ZONE_ID/dns_records/$DNS_ID"
+
+# Tunnel
+TUN_ID="$(cf_get "/accounts/$CF_ACCOUNT_ID/cfd_tunnel?name=irc-lens-roundtrip" \
+  | jq -r '.result[0].id // empty')"
+[[ -n "$TUN_ID" ]] && cf_del "/accounts/$CF_ACCOUNT_ID/cfd_tunnel/$TUN_ID"
+
+rm -f "${HOME}/.config/irc-lens/cf-roundtrip-token.json"
+echo "teardown complete" >&2
+```
+
+- [ ] **Step 3: Make executable + add README**
+
+Run: `chmod +x scripts/cf-roundtrip/setup.sh scripts/cf-roundtrip/teardown.sh`
+
+Write `scripts/cf-roundtrip/README.md`:
+
+```markdown
+# CF round-trip helpers
+
+`setup.sh` provisions (or reuses) a Cloudflare Tunnel, DNS record,
+Access application, allow-policy, and service token for the
+`@pytest.mark.cloudflare` round-trip test.
+
+## Required env
+
+| Var | Purpose |
+| --- | --- |
+| `CF_API_TOKEN` | Cloudflare token with Account:Tunnel:Edit, Account:Access:Apps and Policies:Edit, Zone:DNS:Edit on `CF_ZONE_ID` |
+| `CF_ACCOUNT_ID` | your Cloudflare account ID |
+| `CF_ZONE_ID` | the zone hosting `CF_TEST_HOSTNAME` |
+| `CF_TEST_HOSTNAME` | the hostname the test will hit |
+| `CF_TEAM_DOMAIN` | `<team>.cloudflareaccess.com` |
+
+## Run
+
+    ./scripts/cf-roundtrip/setup.sh
+    set -a; source .cf-roundtrip.env; set +a
+    pytest -m cloudflare -v
+
+## Teardown
+
+    ./scripts/cf-roundtrip/teardown.sh
+```
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add scripts/cf-roundtrip/
+git commit -m "feat(scripts): idempotent CF round-trip setup/teardown"
+```
+
+---
+
+### Task 5.6: The CF round-trip test itself
+
+**Files:**
+- Create: `tests/test_cf_roundtrip.py`
+
+- [ ] **Step 1: Write the test**
+
+```python
+"""Real Cloudflare round-trip. Skipped unless setup.sh has run.
+
+Requires: AgentIRC running locally on 127.0.0.1:6667 (or a fixture),
+`cloudflared` installed, and the env vars in .cf-roundtrip.env loaded.
+"""
+from __future__ import annotations
+
+import asyncio
+import os
+import shutil
+import subprocess
+import time
+from pathlib import Path
+
+import aiohttp
+import pytest
+
+pytestmark = pytest.mark.cloudflare
+
+REQUIRED_ENV = (
+    "IRC_LENS_TEST_AUD",
+    "IRC_LENS_TEST_HOSTNAME",
+    "IRC_LENS_TEST_TEAM_DOMAIN",
+    "IRC_LENS_TEST_CLIENT_ID",
+    "IRC_LENS_TEST_CLIENT_SECRET",
+)
+
+
+def _missing_env() -> str | None:
+    for k in REQUIRED_ENV:
+        if not os.environ.get(k):
+            return k
+    return None
+
+
+@pytest.fixture(scope="module")
+def lens_subprocess(tmp_path_factory) -> subprocess.Popen:
+    if _missing_env():
+        pytest.skip(f"missing env: {_missing_env()}")
+    if not shutil.which("cloudflared"):
+        pytest.skip("cloudflared not on PATH")
+
+    cfg_dir = tmp_path_factory.mktemp("lens-cf")
+    cfg = cfg_dir / "config.yaml"
+    cfg.write_text(f"""
+auth:
+  mode: cloudflare-access
+  cloudflare:
+    aud: {os.environ['IRC_LENS_TEST_AUD']}
+    team_domain: {os.environ['IRC_LENS_TEST_TEAM_DOMAIN']}
+  allowed_emails: []
+  allowed_service_tokens:
+    - {os.environ['IRC_LENS_TEST_CLIENT_ID']}
+server:
+  name: roundtrip
+  host: 127.0.0.1
+  port: 6667
+web:
+  bind: 127.0.0.1
+  port: 8765
+""")
+    proc = subprocess.Popen(
+        ["uv", "run", "irc-lens", "serve", "--config", str(cfg)],
+        env={**os.environ, "IRC_LENS_TEST_HOOKS": "1"},
+    )
+    try:
+        # Wait for local /healthz before yielding.
+        for _ in range(30):
+            if _local_healthz():
+                break
+            time.sleep(1)
+        yield proc
+    finally:
+        proc.terminate()
+        proc.wait(timeout=10)
+
+
+def _local_healthz() -> bool:
+    import urllib.request
+    try:
+        with urllib.request.urlopen("http://127.0.0.1:8765/healthz", timeout=1) as r:
+            return r.status == 200
+    except Exception:
+        return False
+
+
+async def _get(url: str, headers: dict[str, str]) -> tuple[int, bytes]:
+    async with aiohttp.ClientSession() as s:
+        async with s.get(url, headers=headers, timeout=aiohttp.ClientTimeout(total=15)) as r:
+            return r.status, await r.read()
+
+
+async def _post(url: str, headers: dict[str, str], data: dict) -> int:
+    async with aiohttp.ClientSession() as s:
+        async with s.post(url, headers=headers, data=data,
+                          timeout=aiohttp.ClientTimeout(total=15)) as r:
+            return r.status
+
+
+@pytest.mark.asyncio
+async def test_cloudflare_round_trip(lens_subprocess) -> None:
+    host = os.environ["IRC_LENS_TEST_HOSTNAME"]
+    base = f"https://{host}"
+    auth_headers = {
+        "CF-Access-Client-Id": os.environ["IRC_LENS_TEST_CLIENT_ID"],
+        "CF-Access-Client-Secret": os.environ["IRC_LENS_TEST_CLIENT_SECRET"],
+    }
+
+    # Wait until the public hostname starts answering — DNS may need to
+    # settle on first run, and cloudflared takes a few seconds to come up.
+    deadline = time.time() + 60
+    while time.time() < deadline:
+        status, _ = await _get(f"{base}/healthz", headers=auth_headers)
+        if status == 200:
+            break
+        await asyncio.sleep(2)
+    else:
+        pytest.fail("public /healthz never came up")
+
+    # Unauthenticated request must be blocked at the CF edge.
+    status_unauth, _ = await _get(f"{base}/", headers={})
+    assert status_unauth in (401, 302)
+
+    # Service-token call lands on the lens.
+    status_auth, body = await _get(f"{base}/", headers=auth_headers)
+    assert status_auth == 200
+    assert b"<html" in body or b"<!DOCTYPE" in body
+
+    # POST /input via service token. With AgentIRC offline the response
+    # may be 503; that still proves the auth path landed in the handler.
+    status_post = await _post(
+        f"{base}/input",
+        headers={**auth_headers, "Origin": base},
+        data={"text": "/help"},
+    )
+    assert status_post in (204, 503)
+```
+
+- [ ] **Step 2: Smoke run (only if env is loaded)**
+
+If you've run `setup.sh` and have AgentIRC + cloudflared up:
+
+```bash
+set -a; source .cf-roundtrip.env; set +a
+uv run pytest -m cloudflare -v
+```
+
+Expected: 1 PASS in 30–60 s. If skipped, the env vars aren't loaded — that's fine; the test must skip cleanly outside the setup.
+
+- [ ] **Step 3: Run the default suite to confirm the test stays opt-in**
+
+Run: `uv run pytest -v`
+Expected: `test_cf_roundtrip` is deselected by default (per `addopts = "-m 'not playwright and not cloudflare'"`).
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add tests/test_cf_roundtrip.py
+git commit -m "test(cf): real Cloudflare round-trip via service token"
+```
+
+---
+
+## Final integration
+
+After all phases:
+
+- [ ] **Run the full test matrix**
+
+```bash
+uv run pytest -v                          # default
+uv run pytest -m playwright -v            # browser e2e
+uv run pytest -m slow -v                  # rotation test
+# CF round-trip is operator-driven:
+# uv run pytest -m cloudflare -v
+```
+
+- [ ] **Walk the security checklist** against your real deployment.
+
+- [ ] **PR opening**: each phase corresponds to one PR. Use the existing pr-review skill (`/pr-review`) if available; otherwise `gh pr create` per project conventions.
+
+---
+
+## Spec-coverage cross-check
+
+| Spec section | Tasks |
+| --- | --- |
+| Configuration surface | T1.1 (deps/marker), T1.2–T1.3 (loader), T1.4–T1.5 (init verb), T4.5 (cli docs) |
+| Auth and identity | T2.1–T2.2 (Identity/derive_nick), T3.1–T3.5 (middleware + JWT), T3.7 (audit log), T5.1 (auth.md) |
+| Per-user Session registry | T2.3–T2.4 (registry), T2.5 (make_app rewrite), T2.6 (serve wiring) |
+| Routes (`/`, `/input`, `/events`, `/healthz`) | T2.5 (registry use + /healthz), T4.2 (/healthz tests), T4.3 (Origin floor) |
+| Testing tiers | unit (T1.2, T2.1, T2.3, T3.5, T4.1), integration (T3.2, T3.4, T3.7, T4.2–T4.3), real-CF (T5.6) |
+| Documentation | T4.5 (cli.md, README), T5.1 (auth.md), T5.2 (security-checklist), T5.3 (deployment runbook), T5.4 (architecture.md) |
+| Round-trip scripts | T5.5 |
+| Rollout phases | Phase 1 → Phase 5 mapping at the top |
+| Compatibility notes | T2.5/T2.6 preserve dev-mode behavior; T4.4 documents the one breaking change (config file required) |

--- a/docs/superpowers/specs/2026-05-06-remote-connect-cloudflare-access-design.md
+++ b/docs/superpowers/specs/2026-05-06-remote-connect-cloudflare-access-design.md
@@ -1,0 +1,352 @@
+# Remote-connect via Cloudflare Access — design
+
+Status: draft, pending review.
+Issue: [agentculture/irc-lens#26](https://github.com/agentculture/irc-lens/issues/26).
+
+## Goal
+
+Make `irc-lens serve` deployable behind Cloudflare Tunnel + Cloudflare Access on the operator's own domain, so an authenticated user can browse to a public hostname and reach a private AgentIRC mesh without any inbound port being exposed. Local development must stay frictionless: no Cloudflare, no SSO, no JWT plumbing in the dev path.
+
+The design is mechanism-only. The spec and code never name a specific domain, hostname, or user. All such values live in the operator's local config file.
+
+## Non-goals
+
+- Multi-IdP support beyond Google SSO. CF Access supports more; the lens doesn't care which IdP issued the JWT it validates.
+- Self-registration / signup. The allowlist is config-driven; new users are added by editing `auth.allowed_emails` and the matching CF Access policy.
+- Group-based authorization. Only the `email` claim is consulted in v1; `groups` is a deferred enhancement.
+- Reconnect / liveness UX in the browser. SSE through CF Tunnel is already supported by today's lens; nothing changes here.
+
+## Configuration surface
+
+### Single config file, no env vars
+
+`~/.config/irc-lens/config.yaml` is the source of truth, location overridable with `--config <path>` and respecting `$XDG_CONFIG_HOME`. CLI flags override the file; the file overrides built-in defaults. There is no env-var layer in v1 — the goal is exactly one place to look for any setting.
+
+### Schema
+
+```yaml
+auth:
+  # "dev" | "cloudflare-access"
+  mode: cloudflare-access
+
+  # Required when mode == cloudflare-access:
+  cloudflare:
+    aud: <access-application-audience-tag>
+    team_domain: <team>.cloudflareaccess.com
+  allowed_emails:
+    - <your-email>
+  # Optional: service-token principals for CI / scripted access.
+  allowed_service_tokens:
+    - <client-id-or-common-name>
+
+  # Required when mode == dev:
+  dev:
+    nick: lens
+    email: dev@local
+
+server:
+  # AgentIRC server name — used to derive nicks in cloudflare-access mode.
+  name: <agentirc-server-name>
+  host: 127.0.0.1
+  port: 6667
+
+web:
+  bind: 127.0.0.1
+  port: 8765
+```
+
+### CLI changes
+
+`irc-lens serve`:
+
+- `--config <path>` — point at a non-default file.
+- `--server-host`, `--server-port`, `--web-port`, `--bind`, `--open`, `--seed`, `--log-json` — kept; override the file.
+- `--nick` — kept, but only honored when `auth.mode: dev`. Passing it under `cloudflare-access` is a hard error.
+- `--server-name` is *not* a CLI flag; it lives at `server.name`.
+
+New verb `irc-lens config init` writes a minimal commented template to the default path (or wherever `--config` points), in `dev` mode by default.
+
+### Asymmetric defaults
+
+| Setting | Dev mode | CF mode |
+| --- | --- | --- |
+| `web.bind` | accepts anything; `0.0.0.0` warns (existing) | non-loopback values are silently coerced to `127.0.0.1` with a one-line notice |
+| AgentIRC connect | opened at startup against `auth.dev` identity | not opened at startup; opened lazily per authenticated user |
+| `--nick` | required (overrides `auth.dev.nick`) | rejected |
+| Required env at startup | none | none beyond the file |
+
+CF mode binding to a public interface is always wrong: cloudflared terminates locally and only the local cloudflared is the legitimate caller. Coerce-with-notice is friendlier than hard-erroring on a recoverable mistake.
+
+## Auth and identity
+
+### Module shape
+
+```
+src/irc_lens/web/auth.py
+  Identity(NamedTuple): principal, nick, raw_jwt_subject
+  load_jwks(team_domain) -> JWK set            # cached, refreshed on kid miss
+  verify_cf_access_jwt(token, aud, team_domain) -> claims
+  derive_nick(server_name, email) -> str       # sanitize + prefix
+  build_middleware(config) -> aiohttp.middleware
+```
+
+### Middleware flow (CF mode)
+
+1. Skip auth for `/static/*` and the new `/healthz`. Both are unauthenticated and never expose IRC state.
+2. Pull JWT from `Cf-Access-Jwt-Assertion` header or `CF_Authorization` cookie. Header wins on conflict. Missing → 401 `{error, hint}`.
+3. Verify signature against JWKS; pin audience to `auth.cloudflare.aud` and issuer to `https://<team_domain>`. Failure → 401, hint differentiates expired / bad-signature / wrong-aud.
+4. Read identity claims:
+   - `email` if present (interactive SSO).
+   - Else `common_name` (service tokens), checked against `auth.allowed_service_tokens`.
+   - Else 401.
+5. If identity is from `email`, check membership in `auth.allowed_emails`. Not present → 403 `{error: "<email> not on allowlist", hint: "add to auth.allowed_emails in <config path>"}`. Defense-in-depth against a CF Access policy that drifted wider than intended.
+6. Build `Identity(principal=email_or_common_name, nick=derive_nick(server.name, principal), raw_jwt_subject=claims["sub"])` and stash on `request["identity"]`. The `principal` field holds an email under interactive SSO and a service-token client-id / common-name otherwise; downstream code never branches on which.
+
+### Dev mode
+
+Middleware is still installed, but it short-circuits to `Identity(principal=auth.dev.email, nick=auth.dev.nick, raw_jwt_subject="dev")` on every request. Same downstream contract; handlers always see `request["identity"]`.
+
+### Nick derivation
+
+```
+def derive_nick(server_name: str, principal: str) -> str:
+    local = principal.split("@", 1)[0].lower()
+    sanitized = "".join(c for c in local if c.isalnum() or c == "-")
+    if not sanitized:
+        raise AuthError("nick derivation produced empty result", ...)
+    return f"{server_name}-{sanitized}"
+```
+
+AgentIRC's existing `wait_for_welcome` handles the rare nick-collision (432/433) case.
+
+### JWKS caching
+
+Cache the JWK set in process. On a `kid` we don't recognize, refresh once and retry; permanent kid-miss after refresh → 401. Unconditional refresh would let a malformed-`kid` flood drive request-time fetches, so the kid-miss-then-refresh policy is the bound.
+
+### Error rendering
+
+Auth failures use the irc-lens HTTP error shape `{error, hint}`, not the AfiError CLI triple `{code, message, remediation}`. The CLI triple is for `serve` startup errors that exit the process; the HTTP shape is for in-flight requests. Status codes:
+
+| Status | Cause |
+| --- | --- |
+| 401 | missing or invalid JWT |
+| 403 | allowlist denied |
+| 500 | nick derivation produced empty result (server-config bug) |
+| 502 | JWKS unreachable on first fetch |
+
+### Audit logging
+
+Every authenticated request emits one structured log line on stderr: `auth=ok principal=… nick=… method=… path=… status=…`. Auth denials log `auth=denied principal=… reason=…`. The `principal` field is the email under interactive SSO and the client-id / common-name under service tokens. Logs flow through the existing logger so `--log-json` produces JSON-line output with no extra wiring.
+
+## Per-user Session registry
+
+### Shape change
+
+```
+app["sessions"]        : dict[principal, Session]
+app["session_locks"]   : dict[principal, asyncio.Lock]
+app["session_factory"] : Callable[[nick], Session]
+```
+
+The factory closes over `server.host`/`server.port` so handlers don't reach for transport config. The locks dict is populated lazily on first access for a principal.
+
+### Lazy open
+
+```python
+async def get_or_open_session(request) -> Session:
+    identity = request["identity"]
+    sessions = request.app["sessions"]
+    if identity.principal in sessions:
+        return sessions[identity.principal]
+    async with request.app["session_locks"][identity.principal]:
+        if identity.principal in sessions:            # double-check
+            return sessions[identity.principal]
+        s = request.app["session_factory"](identity.nick)
+        await s.connect()
+        await s.wait_for_welcome()
+        sessions[identity.principal] = s
+        return s
+```
+
+The double-check guards against two concurrent first requests from the same principal racing into Session creation.
+
+### Failure handling
+
+`LensConnectionLost` from the lazy-open path → handler renders 503 `{error: "cannot reach AgentIRC", hint: "verify AgentIRC is up at <host>:<port>"}`. The principal key is only inserted after `wait_for_welcome` returns clean; a failed open leaves no partial state.
+
+### Startup model
+
+- **Dev mode**: existing behavior — open one Session at boot, register under `auth.dev.email`. Preserves today's startup-time fail-fast for the dev workflow.
+- **CF mode**: validate config, fetch JWKS once (fail fast if Cloudflare is unreachable), bind aiohttp, return. First IRC connect happens on first authenticated request.
+
+### Shutdown
+
+```python
+await asyncio.gather(*(s.disconnect() for s in app["sessions"].values()),
+                     return_exceptions=True)
+```
+
+`return_exceptions=True` so a failed disconnect on one session doesn't strand the others.
+
+### Concurrency interactions
+
+PR #23's per-`Session` `execute()` lock is unchanged. Each per-user Session holds its own lock; users don't block each other. No new contention.
+
+### Idle TTL
+
+Skipped in v1. AgentIRC connections are cheap. Add a reaper if a teammate ever leaves a tab open for hours.
+
+## Routes
+
+### `GET /`
+
+Replace `request.app["session"]` with `await get_or_open_session(request)`. The first request from a new user blocks on Session connect + welcome (≤ ~10s typical, longer on a bad route). `LensConnectionLost` from the lazy-open renders a small `error.html.j2` page using the same `{error, hint}` text as the JSON path.
+
+### `POST /input`
+
+Same `get_or_open_session` swap. The 4 KiB body cap, JSON/form decode, empty-body, and 503-on-LensConnectionLost branches are unchanged in shape.
+
+New: an Origin/Referer floor for CSRF defense in depth. CF Access already requires the `CF_Authorization` cookie cross-site, but a same-origin XSS in the lens UI shouldn't be able to fire writes from a third-party tab. If `Origin` is present and doesn't match the configured public hostname (or `127.0.0.1:<web.port>` in dev), reject with 403. Absent `Origin` falls through (HTMX submits send Origin; cloudflared probes don't, and that's fine). CSRF-token uplift is tracked as a follow-up issue.
+
+### `GET /events`
+
+Per-user lazy open. JWT is validated at stream open; we don't re-validate per event. CF Access JWTs default to 24 h; a stream that crosses expiry stays open, but the next `POST /input` will 401 and the UI reconnects. Periodic SSE re-auth is not in v1.
+
+### `/static/*`
+
+Auth middleware skips. No change.
+
+### `/healthz` (new)
+
+Returns `{ok: true}`. No auth. No IRC state. Used by cloudflared / external uptime probes only. Opaque on purpose: it does not reveal whether any user has a live session, since that would leak the allowlist.
+
+## Testing
+
+Three tiers.
+
+### Unit
+
+- `tests/test_auth_middleware.py`: JWT verify happy-path, expired, wrong-aud, wrong-issuer, kid-miss-then-refresh, allowlist deny, dev-mode passthrough, service-token branch.
+- `tests/test_session_registry.py`: concurrent-first-request lock, double-check skip, connect-failure-clears-key, shutdown-disconnects-all.
+- `tests/test_serve_cf_mode.py`: `--nick` rejected; `--bind` non-loopback coerced.
+- `tests/test_config_loader.py`: schema validation, missing-required-field renders as the AfiError CLI triple.
+
+### Integration with fake JWKS
+
+A small aiohttp app on a random port serves a JWK we mint in-test. Sign a JWT with the matching private key, hit the lens, assert it lands. Same harness covers kid-miss-then-refresh end-to-end.
+
+### Real Cloudflare round-trip
+
+Marked `@pytest.mark.cloudflare`, gated on the secrets being present, **manual / agentic only** in v1. CI automation is a separate follow-up issue.
+
+Required secrets (loaded from env at test time, not committed):
+
+```
+CF_API_TOKEN          # scopes: Account:Cloudflare Tunnel:Edit,
+                      #         Account:Access: Apps and Policies:Edit,
+                      #         Zone:DNS:Edit on the chosen zone
+CF_ACCOUNT_ID
+CF_ZONE_ID
+CF_TEST_HOSTNAME
+CF_TEAM_DOMAIN
+```
+
+Two scripts under `scripts/cf-roundtrip/`:
+
+- `setup.sh` — idempotent. For each Cloudflare resource (tunnel `irc-lens-roundtrip`, DNS CNAME, Access app, Access policy, service token), creates if missing and reuses if present. The service-token credentials are cached at `~/.config/irc-lens/cf-roundtrip-token.json` (`chmod 600`, gitignored), since Cloudflare won't return the secret on a re-fetch. Outputs `IRC_LENS_TEST_AUD`, `IRC_LENS_TEST_HOSTNAME`, `IRC_LENS_TEST_CLIENT_ID`, `IRC_LENS_TEST_CLIENT_SECRET`, `IRC_LENS_TEST_TEAM_DOMAIN` to a gitignored `.cf-roundtrip.env`.
+- `teardown.sh` — removes the four CF resources and the local cred file.
+
+Round-trip test (`tests/test_cf_roundtrip.py`):
+
+1. Skip unless all required env vars are present.
+2. Boot `irc-lens serve --config <test-config>` as a subprocess on `127.0.0.1`.
+3. Boot `cloudflared tunnel run irc-lens-roundtrip` as a subprocess.
+4. Wait until `https://<CF_TEST_HOSTNAME>/healthz` returns 200 (poll up to ~30 s; DNS may need to settle on first run).
+5. Hit `GET /` without service-token headers → expect 401 from CF edge (proves the gate is on).
+6. Hit `GET /` with service-token headers → expect 200 (proves the gate accepts and the lens accepts).
+7. Hit `POST /input` with service-token headers and a slash-command payload → expect 204.
+8. Tear down subprocesses (CF resources stay).
+
+JWKS rotation coverage in the round-trip:
+
+- **Cold-start fetch.** Every test boot starts the lens with an empty JWKS cache; reaching `GET /` with a valid JWT exercises the real fetch from `https://<team_domain>/cdn-cgi/access/certs`. If CF rolled keys overnight, this catches it.
+- **Mid-process kid-miss refresh.** A test-only admin path `POST /__test/evict-jwks` drops the in-process JWK cache. Mounted only when `IRC_LENS_TEST_HOOKS=1`; production config never sets the env var, and the route isn't even registered without it.
+
+We can't force CF to rotate during the run, so we test both halves separately and accept that "actual rotation timing" is a property of CF, not of us.
+
+### Test-impact rule
+
+All existing tests run in `auth.mode: dev`. The `seeded_lens_client` fixture (phase 9c) is the canonical site to migrate; it constructs the dev-mode config and an app with a session-factory override. Phase 9b's AgentIRC fixture and Playwright e2e suites must keep passing without rewrite.
+
+## Documentation deliverables
+
+Three new documents under `docs/`. All are domain-neutral; no specific hostname or zone is named.
+
+### `docs/deployment-cloudflare-access.md`
+
+Runbook for "host irc-lens on your own domain". Sections:
+
+1. Prerequisites: a Cloudflare account on the same zone as your chosen host, an IdP (Google SSO, GitHub, etc.), `cloudflared` installed.
+2. DNS: add a CNAME under the tunnel.
+3. Tunnel: `cloudflared tunnel create`, route the hostname, run as a systemd unit (snippet provided).
+4. Access application: create the app, attach an IdP, set the allowlist policy by email (matching `auth.allowed_emails`).
+5. Wire the audience tag and team domain into `~/.config/irc-lens/config.yaml`.
+6. Boot order (AgentIRC → `irc-lens serve` → `cloudflared`); reverse on shutdown.
+7. Verifying: open the URL, confirm SSO redirect, confirm the lens renders, confirm `/healthz` returns `{ok: true}`.
+
+### `docs/auth.md`
+
+Protocol-level reference, so the runbook stays "do this" not "why".
+
+- Identity model (per-user Session, derived nick, allowlist).
+- JWT validation rules (header vs. cookie precedence, JWKS caching, kid-miss refresh).
+- Dev mode shim and how it parities prod.
+- Failure modes and HTTP status codes.
+
+### `docs/security-checklist.md`
+
+Pre-launch yes/no list:
+
+- AgentIRC bound to localhost only?
+- Lens bound to localhost only (CF mode auto-coerces; verify)?
+- `auth.mode: cloudflare-access` in the active config?
+- `auth.cloudflare.aud` matches the actual Access app's AUD?
+- `auth.allowed_emails` is the minimum needed?
+- IdP enforces MFA on the listed accounts?
+- Cloudflare Access policy mirrors the same email list?
+- Tunnel's origin URL is `http://localhost:<web.port>`, not `0.0.0.0`?
+- `cloudflared` and `irc-lens` run as non-root?
+- Logs are persisted somewhere auditable (systemd journal is fine)?
+- `/healthz` returns `{ok: true}` and nothing else?
+
+### Updates to existing docs
+
+- `docs/architecture.md`: deployment-modes subsection, updated session-registry diagram.
+- `docs/cli.md`: `--config`, `irc-lens config init`, the `--nick`-rejected-in-CF rule.
+- `README.md`: short pointer to the runbook.
+
+## Rollout
+
+Five PRs, in order. Each is independently reviewable.
+
+1. **Config loader + `irc-lens config init`** — no behavior change. CLI flags continue to work; the loader sees an empty/no config.
+2. **Per-user Session registry under dev mode** — `app["session"]` becomes a registry-of-one keyed by the dev principal. Identity middleware lands but synthesizes only the dev identity. Every existing test must keep passing.
+3. **Auth middleware + JWT verification** — `auth.mode: cloudflare-access` becomes selectable. New unit + fake-JWKS integration tests cover it. Dev tests untouched.
+4. **CLI/HTTP cleanups** — `--nick` rejection, `--bind` coercion, `/healthz`, Origin floor on `POST /input`.
+5. **Docs + security checklist + round-trip scripts** — written against the working code; round-trip test added under `@pytest.mark.cloudflare`.
+
+Steps 1, 3, 4, 5 are small. Step 2 is the largest. Manual verification on the operator's real domain happens after step 5.
+
+## Follow-up issues
+
+To be opened after this spec lands:
+
+1. **CSRF tokens for `POST /input`** — replace the v1 Origin/Referer floor with per-render CSRF tokens.
+2. **Automate CF round-trip on GitHub Actions** — track the open questions: secret-scope hygiene, rate limits, runner cost, cleanup-on-failure, and the workflow-edit-by-PR threat model.
+3. **Group-based authorization** — consume the `groups` claim when a teammate joins.
+
+## Compatibility notes
+
+- Existing memory: HTTP error shape stays `{error, hint}`, not the AfiError CLI triple. (PR #7 ratification preserved.)
+- Existing memory: AFI exit-code policy applies to `serve` startup errors, not in-flight HTTP responses. (Code 1 = user-supplied wrong; code 2 = environment failed to deliver.)
+- AgentIRC server-name nick prefix is enforced today via `wait_for_welcome` (`spark-foo` style). Derivation matches that contract.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,6 +27,7 @@ dependencies = [
     "aiohttp>=3.9",
     "jinja2>=3.1",
     "pyyaml>=6.0",
+    "pyjwt[crypto]>=2.8",
 ]
 
 [project.optional-dependencies]
@@ -56,7 +57,8 @@ asyncio_mode = "auto"
 # browser tests so local dev / the existing CI `test` job stays fast
 # (no chromium download, no per-test browser spin-up). The Playwright
 # CI job overrides via `pytest -m playwright`.
-addopts = "-m 'not playwright'"
+addopts = "-m 'not playwright and not cloudflare'"
 markers = [
     "playwright: opt-in browser end-to-end tests (requires `playwright install chromium`).",
+    "cloudflare: opt-in real-Cloudflare round-trip tests (requires CF_API_TOKEN and friends).",
 ]

--- a/src/irc_lens/cli/__init__.py
+++ b/src/irc_lens/cli/__init__.py
@@ -16,6 +16,7 @@ import argparse
 import sys
 
 from irc_lens import __version__
+from irc_lens.cli._commands import config_cmd as _config_cmd
 from irc_lens.cli._commands import explain as _explain_cmd
 from irc_lens.cli._commands import learn as _learn_cmd
 from irc_lens.cli._commands import overview as _overview_cmd
@@ -98,6 +99,8 @@ def _build_parser() -> argparse.ArgumentParser:
     # `irc-lens cli` with no verb prints the noun's own help instead of
     # raising AttributeError out of _dispatch.
     cli_noun.set_defaults(func=lambda _args: (cli_noun.print_help() or 0))
+
+    _config_cmd.register(sub)
 
     return parser
 

--- a/src/irc_lens/cli/_commands/config_cmd.py
+++ b/src/irc_lens/cli/_commands/config_cmd.py
@@ -1,0 +1,82 @@
+"""`irc-lens config` noun group: init + overview verbs."""
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+
+from irc_lens.cli._errors import EXIT_USER_ERROR, AfiError
+from irc_lens.cli._output import emit_diagnostic
+from irc_lens.config import default_config_path
+
+_STARTER = """\
+# irc-lens — local dev config
+# Written by `irc-lens config init`. See docs/cli.md for the full schema.
+
+auth:
+  mode: dev
+  dev:
+    nick: lens
+    email: dev@local
+
+server:
+  name: spark        # AgentIRC server name (used to derive nicks in CF mode)
+  host: 127.0.0.1
+  port: 6667
+
+web:
+  bind: 127.0.0.1
+  port: 8765
+"""
+
+
+def _resolve_target(args: argparse.Namespace) -> Path:
+    return Path(args.path) if args.path else default_config_path()
+
+
+def cmd_config_init(args: argparse.Namespace) -> int:
+    target = _resolve_target(args)
+    if target.exists() and not args.force:
+        raise AfiError(
+            code=EXIT_USER_ERROR,
+            message=f"config already exists at {target}",
+            remediation="pass --force to overwrite, or pick a different --path",
+        )
+    target.parent.mkdir(parents=True, exist_ok=True)
+    target.write_text(_STARTER)
+    emit_diagnostic(f"wrote starter config to {target}")
+    return 0
+
+
+def cmd_config_overview(_args: argparse.Namespace) -> int:
+    print(
+        "irc-lens config — manage the lens config file.\n"
+        "\n"
+        "verbs:\n"
+        "  init       write a starter dev-mode config\n"
+        "  overview   this help\n"
+        "\n"
+        "default path: ~/.config/irc-lens/config.yaml (XDG_CONFIG_HOME respected)\n"
+    )
+    return 0
+
+
+def register(sub: argparse._SubParsersAction) -> None:
+    cfg = sub.add_parser(
+        "config",
+        help="Manage the irc-lens config file.",
+    )
+    cfg_sub = cfg.add_subparsers(dest="config_command")
+
+    init = cfg_sub.add_parser("init", help="Write a starter dev-mode config.")
+    init.add_argument("--path", default=None, help="Override the default config path.")
+    init.add_argument(
+        "--force",
+        action="store_true",
+        help="Overwrite an existing file (default refuses).",
+    )
+    init.set_defaults(func=cmd_config_init)
+
+    overview = cfg_sub.add_parser("overview", help="Help for the config noun.")
+    overview.set_defaults(func=cmd_config_overview)
+
+    cfg.set_defaults(func=lambda _args: (cfg.print_help() or 0))

--- a/src/irc_lens/cli/_commands/config_cmd.py
+++ b/src/irc_lens/cli/_commands/config_cmd.py
@@ -10,7 +10,7 @@ from irc_lens.config import default_config_path
 
 _STARTER = """\
 # irc-lens — local dev config
-# Written by `irc-lens config init`. See docs/cli.md for the full schema.
+# Written by `irc-lens config init`. See the spec in docs/superpowers/specs/ for the full schema.
 
 auth:
   mode: dev

--- a/src/irc_lens/cli/_commands/config_cmd.py
+++ b/src/irc_lens/cli/_commands/config_cmd.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 import argparse
 from pathlib import Path
 
-from irc_lens.cli._errors import EXIT_USER_ERROR, AfiError
+from irc_lens.cli._errors import EXIT_ENV_ERROR, EXIT_USER_ERROR, AfiError
 from irc_lens.cli._output import emit_diagnostic
 from irc_lens.config import default_config_path
 
@@ -41,8 +41,15 @@ def cmd_config_init(args: argparse.Namespace) -> int:
             message=f"config already exists at {target}",
             remediation="pass --force to overwrite, or pick a different --path",
         )
-    target.parent.mkdir(parents=True, exist_ok=True)
-    target.write_text(_STARTER)
+    try:
+        target.parent.mkdir(parents=True, exist_ok=True)
+        target.write_text(_STARTER)
+    except OSError as exc:
+        raise AfiError(
+            code=EXIT_ENV_ERROR,
+            message=f"could not write config to {target}: {exc}",
+            remediation="check directory permissions or pick a different --path",
+        ) from exc
     emit_diagnostic(f"wrote starter config to {target}")
     return 0
 

--- a/src/irc_lens/cli/_commands/overview.py
+++ b/src/irc_lens/cli/_commands/overview.py
@@ -59,10 +59,13 @@ _SECTIONS: dict[str, list[dict[str, object]]] = {
             "heading": "Nouns",
             "body_md": (
                 "- `cli` — meta-introspection of the CLI surface itself; "
-                "exposes `overview`."
+                "exposes `overview`.\n"
+                "- `config` — manage the lens config file; exposes "
+                "`init` and `overview`."
             ),
             "findings": [
                 {"noun": "cli", "verbs": ["overview"]},
+                {"noun": "config", "verbs": ["init", "overview"]},
             ],
         },
     ],
@@ -76,6 +79,20 @@ _SECTIONS: dict[str, list[dict[str, object]]] = {
             ),
             "findings": [
                 {"verb": "overview", "summary": "Rollup of the CLI surface."},
+            ],
+        },
+    ],
+    "config": [
+        {
+            "heading": "irc-lens config",
+            "body_md": (
+                "The `config` noun manages the lens YAML config file at "
+                "`~/.config/irc-lens/config.yaml` (XDG_CONFIG_HOME respected). "
+                "`init` writes a starter dev-mode file; `overview` prints help."
+            ),
+            "findings": [
+                {"verb": "init", "summary": "Write a starter dev-mode config."},
+                {"verb": "overview", "summary": "Help for the config noun."},
             ],
         },
     ],

--- a/src/irc_lens/config.py
+++ b/src/irc_lens/config.py
@@ -92,6 +92,22 @@ def _require(d: dict, key: str, where: str) -> object:
     return d[key]
 
 
+def _require_str_list(value: object, where: str, hint: str) -> list[str]:
+    """Assert *value* is a list of strings; raise with a single shared message.
+
+    The two-step shape check (list, then per-element string) is needed for
+    SonarCloud S5864 (type narrowing) but produced duplicated message+hint
+    literals when each step had its own ``raise``. Centralizing here keeps
+    the narrowing while collapsing the duplication.
+    """
+    msg = f"{where} must be a list of strings"
+    if not isinstance(value, list):
+        raise _err(msg, hint)
+    if not all(isinstance(x, str) for x in value):
+        raise _err(msg, hint)
+    return value
+
+
 # ---------------------------------------------------------------------------
 # Section validators (extracted to keep load_config's cognitive complexity low)
 # ---------------------------------------------------------------------------
@@ -127,18 +143,11 @@ def _load_cf_fields(
     cf_aud = str(_require(cf, "aud", "auth.cloudflare"))
     cf_team_domain = str(_require(cf, "team_domain", "auth.cloudflare"))
 
-    emails_raw = _require(auth, "allowed_emails", "auth")
-    if not isinstance(emails_raw, list):
-        raise _err(
-            "auth.allowed_emails must be a list of strings",
-            "set `auth.allowed_emails: [you@example.com]`",
-        )
-    if not all(isinstance(x, str) for x in emails_raw):
-        raise _err(
-            "auth.allowed_emails must be a list of strings",
-            "set `auth.allowed_emails: [you@example.com]`",
-        )
-
+    emails_raw = _require_str_list(
+        _require(auth, "allowed_emails", "auth"),
+        "auth.allowed_emails",
+        "set `auth.allowed_emails: [you@example.com]`",
+    )
     if len(emails_raw) == 0 and not auth.get("allowed_service_tokens"):
         raise _err(
             "auth.allowed_emails is empty and no service tokens configured",
@@ -147,17 +156,11 @@ def _load_cf_fields(
         )
     allowed_emails = tuple(emails_raw)
 
-    ts_raw = auth.get("allowed_service_tokens", [])
-    if not isinstance(ts_raw, list):
-        raise _err(
-            "auth.allowed_service_tokens must be a list of strings",
-            "set `auth.allowed_service_tokens: []` or add client-ids",
-        )
-    if not all(isinstance(x, str) for x in ts_raw):
-        raise _err(
-            "auth.allowed_service_tokens must be a list of strings",
-            "set `auth.allowed_service_tokens: []` or add client-ids",
-        )
+    ts_raw = _require_str_list(
+        auth.get("allowed_service_tokens", []),
+        "auth.allowed_service_tokens",
+        "set `auth.allowed_service_tokens: []` or add client-ids",
+    )
     allowed_service_tokens = tuple(ts_raw)
 
     return cf_aud, cf_team_domain, allowed_emails, allowed_service_tokens

--- a/src/irc_lens/config.py
+++ b/src/irc_lens/config.py
@@ -43,6 +43,16 @@ def _err(message: str, hint: str) -> AfiError:
     return AfiError(code=EXIT_USER_ERROR, message=message, remediation=hint)
 
 
+def _coerce_port(value: object, where: str) -> int:
+    try:
+        return int(value)  # type: ignore[arg-type]
+    except (TypeError, ValueError):
+        raise _err(
+            f"{where} must be an integer, got {value!r}",
+            f"set `{where}:` to a port number like 6667 or 8765",
+        ) from None
+
+
 def _require(d: dict, key: str, where: str) -> object:
     if key not in d:
         raise _err(
@@ -129,13 +139,13 @@ def load_config(path: Path) -> LensConfig:
         raise _err("server: must be a mapping", "see docs/cli.md")
     server_name = str(_require(server, "name", "server"))
     server_host = str(server.get("host", "127.0.0.1"))
-    server_port = int(server.get("port", 6667))
+    server_port = _coerce_port(server.get("port", 6667), "server.port")
 
     web = raw.get("web", {}) or {}
     if not isinstance(web, dict):
         raise _err("web: must be a mapping", "see docs/cli.md")
     web_bind = str(web.get("bind", "127.0.0.1"))
-    web_port = int(web.get("port", 8765))
+    web_port = _coerce_port(web.get("port", 8765), "web.port")
 
     return LensConfig(
         auth_mode=mode,

--- a/src/irc_lens/config.py
+++ b/src/irc_lens/config.py
@@ -1,0 +1,153 @@
+"""YAML config loader and schema for irc-lens.
+
+One file, two top-level sections (`auth` and `server`), optional `web`.
+The loader returns a frozen :class:`LensConfig` dataclass; missing
+required keys raise :class:`AfiError` with an `error:`/`hint:` shape
+the dispatcher renders without leaking a traceback.
+"""
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass
+from pathlib import Path
+
+import yaml
+
+from irc_lens.cli._errors import EXIT_USER_ERROR, AfiError
+
+_AUTH_MODES = ("dev", "cloudflare-access")
+
+
+@dataclass(frozen=True)
+class LensConfig:
+    auth_mode: str
+    dev_nick: str | None
+    dev_email: str | None
+    cf_aud: str | None
+    cf_team_domain: str | None
+    allowed_emails: tuple[str, ...]
+    allowed_service_tokens: tuple[str, ...]
+    server_name: str
+    server_host: str
+    server_port: int
+    web_bind: str
+    web_port: int
+
+
+def default_config_path() -> Path:
+    base = os.environ.get("XDG_CONFIG_HOME") or str(Path.home() / ".config")
+    return Path(base) / "irc-lens" / "config.yaml"
+
+
+def _err(message: str, hint: str) -> AfiError:
+    return AfiError(code=EXIT_USER_ERROR, message=message, remediation=hint)
+
+
+def _require(d: dict, key: str, where: str) -> object:
+    if key not in d:
+        raise _err(
+            f"missing required key {where}.{key}" if where else f"missing required key {key}",
+            f"add `{key}:` under `{where}:` in the config file" if where else f"add `{key}:` to the config file",
+        )
+    return d[key]
+
+
+def load_config(path: Path) -> LensConfig:
+    if not path.exists():
+        raise _err(
+            f"no config at {path}",
+            "run 'irc-lens config init' to drop a starter, or pass --config <path>",
+        )
+    try:
+        raw = yaml.safe_load(path.read_text()) or {}
+    except yaml.YAMLError as exc:
+        raise _err(
+            f"could not parse YAML in {path}: {exc}",
+            "fix the YAML syntax; see docs/cli.md for a working example",
+        ) from exc
+    if not isinstance(raw, dict):
+        raise _err(
+            f"config at {path} must be a YAML mapping at the top level",
+            "wrap the file's contents in `auth:` and `server:` keys",
+        )
+
+    auth = _require(raw, "auth", "")
+    if not isinstance(auth, dict):
+        raise _err("auth: must be a mapping", "see docs/cli.md")
+    mode = _require(auth, "mode", "auth")
+    if mode not in _AUTH_MODES:
+        raise _err(
+            f"auth.mode must be one of {_AUTH_MODES}, got {mode!r}",
+            "set `auth.mode:` to either `dev` or `cloudflare-access`",
+        )
+
+    dev_nick = dev_email = None
+    cf_aud = cf_team_domain = None
+    allowed_emails: tuple[str, ...] = ()
+    allowed_service_tokens: tuple[str, ...] = ()
+
+    if mode == "dev":
+        dev = auth.get("dev")
+        if dev is None:
+            raise _err(
+                "missing required keys auth.dev.nick and auth.dev.email",
+                "add `dev:` section under `auth:` with `nick:` and `email:` fields",
+            )
+        if not isinstance(dev, dict):
+            raise _err("auth.dev must be a mapping", "see docs/cli.md")
+        dev_nick = str(_require(dev, "nick", "auth.dev"))
+        dev_email = str(_require(dev, "email", "auth.dev"))
+    else:
+        cf = _require(auth, "cloudflare", "auth")
+        if not isinstance(cf, dict):
+            raise _err("auth.cloudflare must be a mapping", "see docs/cli.md")
+        cf_aud = str(_require(cf, "aud", "auth.cloudflare"))
+        cf_team_domain = str(_require(cf, "team_domain", "auth.cloudflare"))
+        emails_raw = _require(auth, "allowed_emails", "auth")
+        if not isinstance(emails_raw, list) or not all(isinstance(x, str) for x in emails_raw):
+            raise _err(
+                "auth.allowed_emails must be a list of strings",
+                "set `auth.allowed_emails: [you@example.com]`",
+            )
+        if len(emails_raw) == 0 and not auth.get("allowed_service_tokens"):
+            raise _err(
+                "auth.allowed_emails is empty and no service tokens configured",
+                "add at least one email to auth.allowed_emails or one entry to "
+                "auth.allowed_service_tokens",
+            )
+        allowed_emails = tuple(emails_raw)
+        ts_raw = auth.get("allowed_service_tokens", [])
+        if not isinstance(ts_raw, list) or not all(isinstance(x, str) for x in ts_raw):
+            raise _err(
+                "auth.allowed_service_tokens must be a list of strings",
+                "set `auth.allowed_service_tokens: []` or add client-ids",
+            )
+        allowed_service_tokens = tuple(ts_raw)
+
+    server = _require(raw, "server", "")
+    if not isinstance(server, dict):
+        raise _err("server: must be a mapping", "see docs/cli.md")
+    server_name = str(_require(server, "name", "server"))
+    server_host = str(server.get("host", "127.0.0.1"))
+    server_port = int(server.get("port", 6667))
+
+    web = raw.get("web", {}) or {}
+    if not isinstance(web, dict):
+        raise _err("web: must be a mapping", "see docs/cli.md")
+    web_bind = str(web.get("bind", "127.0.0.1"))
+    web_port = int(web.get("port", 8765))
+
+    return LensConfig(
+        auth_mode=mode,
+        dev_nick=dev_nick,
+        dev_email=dev_email,
+        cf_aud=cf_aud,
+        cf_team_domain=cf_team_domain,
+        allowed_emails=allowed_emails,
+        allowed_service_tokens=allowed_service_tokens,
+        server_name=server_name,
+        server_host=server_host,
+        server_port=server_port,
+        web_bind=web_bind,
+        web_port=web_port,
+    )

--- a/src/irc_lens/config.py
+++ b/src/irc_lens/config.py
@@ -39,6 +39,11 @@ def default_config_path() -> Path:
     return Path(base) / "irc-lens" / "config.yaml"
 
 
+# Reused remediation hint — extracted so SonarCloud S1192 (duplicate-literal)
+# stays quiet and so the wording stays consistent across every shape error.
+_HINT_CONFIG_INIT = "run `irc-lens config init` to see a working example"
+
+
 def _err(message: str, hint: str) -> AfiError:
     return AfiError(code=EXIT_USER_ERROR, message=message, remediation=hint)
 
@@ -102,7 +107,7 @@ def _load_dev_fields(auth: dict) -> tuple[str, str]:
     if not isinstance(dev, dict):
         raise _err(
             "auth.dev must be a mapping",
-            "run `irc-lens config init` to see a working example",
+            _HINT_CONFIG_INIT,
         )
     dev_nick = str(_require(dev, "nick", "auth.dev"))
     dev_email = str(_require(dev, "email", "auth.dev"))
@@ -117,7 +122,7 @@ def _load_cf_fields(
     if not isinstance(cf, dict):
         raise _err(
             "auth.cloudflare must be a mapping",
-            "run `irc-lens config init` to see a working example",
+            _HINT_CONFIG_INIT,
         )
     cf_aud = str(_require(cf, "aud", "auth.cloudflare"))
     cf_team_domain = str(_require(cf, "team_domain", "auth.cloudflare"))
@@ -164,7 +169,7 @@ def _validate_auth_section(raw: dict) -> dict:
     if not isinstance(auth, dict):
         raise _err(
             "auth: must be a mapping",
-            "run `irc-lens config init` to see a working example",
+            _HINT_CONFIG_INIT,
         )
     mode = _require(auth, "mode", "auth")
     if mode not in _AUTH_MODES:
@@ -181,7 +186,7 @@ def _validate_server_section(raw: dict) -> tuple[str, str, int]:
     if not isinstance(server, dict):
         raise _err(
             "server: must be a mapping",
-            "run `irc-lens config init` to see a working example",
+            _HINT_CONFIG_INIT,
         )
     server_name = str(_require(server, "name", "server"))
     server_host = str(server.get("host", "127.0.0.1"))
@@ -197,7 +202,7 @@ def _validate_web_section(raw: dict) -> tuple[str, int]:
     elif not isinstance(web_raw, dict):
         raise _err(
             "web: must be a mapping",
-            "run `irc-lens config init` to see a working example",
+            _HINT_CONFIG_INIT,
         )
     else:
         web = web_raw
@@ -221,7 +226,7 @@ def load_config(path: Path) -> LensConfig:
     except yaml.YAMLError as exc:
         raise _err(
             f"could not parse YAML in {path}: {exc}",
-            "fix the YAML syntax; run `irc-lens config init` to see a working example",
+            f"fix the YAML syntax; {_HINT_CONFIG_INIT}",
         ) from exc
     except OSError as exc:
         raise _err_env(

--- a/src/irc_lens/config.py
+++ b/src/irc_lens/config.py
@@ -13,7 +13,7 @@ from pathlib import Path
 
 import yaml
 
-from irc_lens.cli._errors import EXIT_USER_ERROR, AfiError
+from irc_lens.cli._errors import EXIT_ENV_ERROR, EXIT_USER_ERROR, AfiError
 
 _AUTH_MODES = ("dev", "cloudflare-access")
 
@@ -43,14 +43,39 @@ def _err(message: str, hint: str) -> AfiError:
     return AfiError(code=EXIT_USER_ERROR, message=message, remediation=hint)
 
 
+def _err_env(message: str, hint: str) -> AfiError:
+    return AfiError(code=EXIT_ENV_ERROR, message=message, remediation=hint)
+
+
 def _coerce_port(value: object, where: str) -> int:
-    try:
-        return int(value)  # type: ignore[arg-type]
-    except (TypeError, ValueError):
-        raise _err(
-            f"{where} must be an integer, got {value!r}",
-            f"set `{where}:` to a port number like 6667 or 8765",
-        ) from None
+    """Coerce *value* to a valid TCP port integer (1..65535).
+
+    Accepts: int (non-bool), float only if it is a whole number, str
+    that parses as an integer.  Rejects bool, fractional floats, and
+    out-of-range values.
+    """
+    _bad = _err(
+        f"{where} must be an integer between 1 and 65535, got {value!r}",
+        f"set `{where}:` to a port number like 6667 or 8765",
+    )
+    if isinstance(value, bool):
+        raise _bad
+    if isinstance(value, int):
+        port = value
+    elif isinstance(value, float):
+        if not value.is_integer():
+            raise _bad
+        port = int(value)
+    elif isinstance(value, str):
+        try:
+            port = int(value.strip())
+        except ValueError:
+            raise _bad from None
+    else:
+        raise _bad
+    if not (1 <= port <= 65535):
+        raise _bad
+    return port
 
 
 def _require(d: dict, key: str, where: str) -> object:
@@ -61,6 +86,129 @@ def _require(d: dict, key: str, where: str) -> object:
         )
     return d[key]
 
+
+# ---------------------------------------------------------------------------
+# Section validators (extracted to keep load_config's cognitive complexity low)
+# ---------------------------------------------------------------------------
+
+def _load_dev_fields(auth: dict) -> tuple[str, str]:
+    """Return (dev_nick, dev_email) from the auth section in dev mode."""
+    dev = auth.get("dev")
+    if dev is None:
+        raise _err(
+            "missing required keys auth.dev.nick and auth.dev.email",
+            "add `dev:` section under `auth:` with `nick:` and `email:` fields",
+        )
+    if not isinstance(dev, dict):
+        raise _err(
+            "auth.dev must be a mapping",
+            "run `irc-lens config init` to see a working example",
+        )
+    dev_nick = str(_require(dev, "nick", "auth.dev"))
+    dev_email = str(_require(dev, "email", "auth.dev"))
+    return dev_nick, dev_email
+
+
+def _load_cf_fields(
+    auth: dict,
+) -> tuple[str, str, tuple[str, ...], tuple[str, ...]]:
+    """Return (cf_aud, cf_team_domain, allowed_emails, allowed_service_tokens)."""
+    cf = _require(auth, "cloudflare", "auth")
+    if not isinstance(cf, dict):
+        raise _err(
+            "auth.cloudflare must be a mapping",
+            "run `irc-lens config init` to see a working example",
+        )
+    cf_aud = str(_require(cf, "aud", "auth.cloudflare"))
+    cf_team_domain = str(_require(cf, "team_domain", "auth.cloudflare"))
+
+    emails_raw = _require(auth, "allowed_emails", "auth")
+    if not isinstance(emails_raw, list):
+        raise _err(
+            "auth.allowed_emails must be a list of strings",
+            "set `auth.allowed_emails: [you@example.com]`",
+        )
+    if not all(isinstance(x, str) for x in emails_raw):
+        raise _err(
+            "auth.allowed_emails must be a list of strings",
+            "set `auth.allowed_emails: [you@example.com]`",
+        )
+
+    if len(emails_raw) == 0 and not auth.get("allowed_service_tokens"):
+        raise _err(
+            "auth.allowed_emails is empty and no service tokens configured",
+            "add at least one email to auth.allowed_emails or one entry to "
+            "auth.allowed_service_tokens",
+        )
+    allowed_emails = tuple(emails_raw)
+
+    ts_raw = auth.get("allowed_service_tokens", [])
+    if not isinstance(ts_raw, list):
+        raise _err(
+            "auth.allowed_service_tokens must be a list of strings",
+            "set `auth.allowed_service_tokens: []` or add client-ids",
+        )
+    if not all(isinstance(x, str) for x in ts_raw):
+        raise _err(
+            "auth.allowed_service_tokens must be a list of strings",
+            "set `auth.allowed_service_tokens: []` or add client-ids",
+        )
+    allowed_service_tokens = tuple(ts_raw)
+
+    return cf_aud, cf_team_domain, allowed_emails, allowed_service_tokens
+
+
+def _validate_auth_section(raw: dict) -> dict:
+    """Validate the top-level `auth:` key and return it as a dict."""
+    auth = _require(raw, "auth", "")
+    if not isinstance(auth, dict):
+        raise _err(
+            "auth: must be a mapping",
+            "run `irc-lens config init` to see a working example",
+        )
+    mode = _require(auth, "mode", "auth")
+    if mode not in _AUTH_MODES:
+        raise _err(
+            f"auth.mode must be one of {_AUTH_MODES}, got {mode!r}",
+            "set `auth.mode:` to either `dev` or `cloudflare-access`",
+        )
+    return auth
+
+
+def _validate_server_section(raw: dict) -> tuple[str, str, int]:
+    """Return (server_name, server_host, server_port)."""
+    server = _require(raw, "server", "")
+    if not isinstance(server, dict):
+        raise _err(
+            "server: must be a mapping",
+            "run `irc-lens config init` to see a working example",
+        )
+    server_name = str(_require(server, "name", "server"))
+    server_host = str(server.get("host", "127.0.0.1"))
+    server_port = _coerce_port(server.get("port", 6667), "server.port")
+    return server_name, server_host, server_port
+
+
+def _validate_web_section(raw: dict) -> tuple[str, int]:
+    """Return (web_bind, web_port)."""
+    web_raw = raw.get("web")
+    if web_raw is None:
+        web: dict = {}
+    elif not isinstance(web_raw, dict):
+        raise _err(
+            "web: must be a mapping",
+            "run `irc-lens config init` to see a working example",
+        )
+    else:
+        web = web_raw
+    web_bind = str(web.get("bind", "127.0.0.1"))
+    web_port = _coerce_port(web.get("port", 8765), "web.port")
+    return web_bind, web_port
+
+
+# ---------------------------------------------------------------------------
+# Public loader — flat orchestrator, no nested conditionals beyond auth.mode
+# ---------------------------------------------------------------------------
 
 def load_config(path: Path) -> LensConfig:
     if not path.exists():
@@ -73,7 +221,12 @@ def load_config(path: Path) -> LensConfig:
     except yaml.YAMLError as exc:
         raise _err(
             f"could not parse YAML in {path}: {exc}",
-            "fix the YAML syntax; see docs/cli.md for a working example",
+            "fix the YAML syntax; run `irc-lens config init` to see a working example",
+        ) from exc
+    except OSError as exc:
+        raise _err_env(
+            f"could not read config at {path}: {exc}",
+            "check file permissions or pick a different --config <path>",
         ) from exc
     if not isinstance(raw, dict):
         raise _err(
@@ -81,71 +234,23 @@ def load_config(path: Path) -> LensConfig:
             "wrap the file's contents in `auth:` and `server:` keys",
         )
 
-    auth = _require(raw, "auth", "")
-    if not isinstance(auth, dict):
-        raise _err("auth: must be a mapping", "see docs/cli.md")
-    mode = _require(auth, "mode", "auth")
-    if mode not in _AUTH_MODES:
-        raise _err(
-            f"auth.mode must be one of {_AUTH_MODES}, got {mode!r}",
-            "set `auth.mode:` to either `dev` or `cloudflare-access`",
-        )
+    auth = _validate_auth_section(raw)
+    mode = auth["mode"]
 
-    dev_nick = dev_email = None
-    cf_aud = cf_team_domain = None
+    dev_nick: str | None = None
+    dev_email: str | None = None
+    cf_aud: str | None = None
+    cf_team_domain: str | None = None
     allowed_emails: tuple[str, ...] = ()
     allowed_service_tokens: tuple[str, ...] = ()
 
     if mode == "dev":
-        dev = auth.get("dev")
-        if dev is None:
-            raise _err(
-                "missing required keys auth.dev.nick and auth.dev.email",
-                "add `dev:` section under `auth:` with `nick:` and `email:` fields",
-            )
-        if not isinstance(dev, dict):
-            raise _err("auth.dev must be a mapping", "see docs/cli.md")
-        dev_nick = str(_require(dev, "nick", "auth.dev"))
-        dev_email = str(_require(dev, "email", "auth.dev"))
+        dev_nick, dev_email = _load_dev_fields(auth)
     else:
-        cf = _require(auth, "cloudflare", "auth")
-        if not isinstance(cf, dict):
-            raise _err("auth.cloudflare must be a mapping", "see docs/cli.md")
-        cf_aud = str(_require(cf, "aud", "auth.cloudflare"))
-        cf_team_domain = str(_require(cf, "team_domain", "auth.cloudflare"))
-        emails_raw = _require(auth, "allowed_emails", "auth")
-        if not isinstance(emails_raw, list) or not all(isinstance(x, str) for x in emails_raw):
-            raise _err(
-                "auth.allowed_emails must be a list of strings",
-                "set `auth.allowed_emails: [you@example.com]`",
-            )
-        if len(emails_raw) == 0 and not auth.get("allowed_service_tokens"):
-            raise _err(
-                "auth.allowed_emails is empty and no service tokens configured",
-                "add at least one email to auth.allowed_emails or one entry to "
-                "auth.allowed_service_tokens",
-            )
-        allowed_emails = tuple(emails_raw)
-        ts_raw = auth.get("allowed_service_tokens", [])
-        if not isinstance(ts_raw, list) or not all(isinstance(x, str) for x in ts_raw):
-            raise _err(
-                "auth.allowed_service_tokens must be a list of strings",
-                "set `auth.allowed_service_tokens: []` or add client-ids",
-            )
-        allowed_service_tokens = tuple(ts_raw)
+        cf_aud, cf_team_domain, allowed_emails, allowed_service_tokens = _load_cf_fields(auth)
 
-    server = _require(raw, "server", "")
-    if not isinstance(server, dict):
-        raise _err("server: must be a mapping", "see docs/cli.md")
-    server_name = str(_require(server, "name", "server"))
-    server_host = str(server.get("host", "127.0.0.1"))
-    server_port = _coerce_port(server.get("port", 6667), "server.port")
-
-    web = raw.get("web", {}) or {}
-    if not isinstance(web, dict):
-        raise _err("web: must be a mapping", "see docs/cli.md")
-    web_bind = str(web.get("bind", "127.0.0.1"))
-    web_port = _coerce_port(web.get("port", 8765), "web.port")
+    server_name, server_host, server_port = _validate_server_section(raw)
+    web_bind, web_port = _validate_web_section(raw)
 
     return LensConfig(
         auth_mode=mode,

--- a/tests/test_config_init.py
+++ b/tests/test_config_init.py
@@ -1,0 +1,46 @@
+"""`irc-lens config init` writes a starter dev-mode config."""
+from __future__ import annotations
+
+from pathlib import Path
+
+from irc_lens.cli import main
+
+
+def test_config_init_writes_default_path(tmp_path: Path, monkeypatch) -> None:
+    monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path))
+    rc = main(["config", "init"])
+    assert rc == 0
+    target = tmp_path / "irc-lens" / "config.yaml"
+    assert target.exists()
+    body = target.read_text()
+    assert "auth:" in body
+    assert "mode: dev" in body
+    assert "server:" in body
+
+
+def test_config_init_with_explicit_path(tmp_path: Path) -> None:
+    target = tmp_path / "custom.yaml"
+    rc = main(["config", "init", "--path", str(target)])
+    assert rc == 0
+    assert target.exists()
+
+
+def test_config_init_refuses_overwrite(tmp_path: Path) -> None:
+    target = tmp_path / "exists.yaml"
+    target.write_text("# pre-existing\n")
+    rc = main(["config", "init", "--path", str(target)])
+    assert rc == 1
+    assert target.read_text() == "# pre-existing\n"
+
+
+def test_config_init_force_overwrites(tmp_path: Path) -> None:
+    target = tmp_path / "exists.yaml"
+    target.write_text("# stale\n")
+    rc = main(["config", "init", "--path", str(target), "--force"])
+    assert rc == 0
+    assert "auth:" in target.read_text()
+
+
+def test_config_overview_works(tmp_path: Path) -> None:
+    rc = main(["config", "overview"])
+    assert rc == 0

--- a/tests/test_config_loader.py
+++ b/tests/test_config_loader.py
@@ -107,6 +107,39 @@ def test_malformed_yaml_errors(tmp_path: Path) -> None:
     assert "YAML" in exc.value.message or "parse" in exc.value.message
 
 
+def test_invalid_port_errors(tmp_path: Path) -> None:
+    with pytest.raises(AfiError) as exc:
+        load_config(_write(tmp_path, """
+auth:
+  mode: dev
+  dev:
+    nick: lens
+    email: dev@local
+server:
+  name: spark
+  port: not-a-number
+"""))
+    assert exc.value.code == EXIT_USER_ERROR
+    assert "server.port" in exc.value.message
+    assert "integer" in exc.value.message
+
+
+def test_invalid_web_port_errors(tmp_path: Path) -> None:
+    with pytest.raises(AfiError) as exc:
+        load_config(_write(tmp_path, """
+auth:
+  mode: dev
+  dev:
+    nick: lens
+    email: dev@local
+server:
+  name: spark
+web:
+  port: nope
+"""))
+    assert "web.port" in exc.value.message
+
+
 def test_empty_allowed_emails_errors_in_cf_mode(tmp_path: Path) -> None:
     with pytest.raises(AfiError) as exc:
         load_config(_write(tmp_path, """

--- a/tests/test_config_loader.py
+++ b/tests/test_config_loader.py
@@ -1,0 +1,123 @@
+"""Schema validation, defaults, and override semantics for LensConfig."""
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from irc_lens.cli._errors import EXIT_USER_ERROR, AfiError
+from irc_lens.config import LensConfig, load_config
+
+
+def _write(tmp_path: Path, body: str) -> Path:
+    p = tmp_path / "config.yaml"
+    p.write_text(body)
+    return p
+
+
+def test_dev_mode_minimal_loads(tmp_path: Path) -> None:
+    cfg = load_config(_write(tmp_path, """
+auth:
+  mode: dev
+  dev:
+    nick: lens
+    email: dev@local
+server:
+  name: spark
+"""))
+    assert cfg.auth_mode == "dev"
+    assert cfg.dev_nick == "lens"
+    assert cfg.dev_email == "dev@local"
+    assert cfg.server_name == "spark"
+    assert cfg.server_host == "127.0.0.1"
+    assert cfg.server_port == 6667
+    assert cfg.web_bind == "127.0.0.1"
+    assert cfg.web_port == 8765
+
+
+def test_cf_mode_minimal_loads(tmp_path: Path) -> None:
+    cfg = load_config(_write(tmp_path, """
+auth:
+  mode: cloudflare-access
+  cloudflare:
+    aud: aud-tag
+    team_domain: team.cloudflareaccess.com
+  allowed_emails:
+    - alice@example.com
+server:
+  name: spark
+"""))
+    assert cfg.auth_mode == "cloudflare-access"
+    assert cfg.cf_aud == "aud-tag"
+    assert cfg.cf_team_domain == "team.cloudflareaccess.com"
+    assert cfg.allowed_emails == ("alice@example.com",)
+    assert cfg.allowed_service_tokens == ()
+
+
+def test_cf_mode_missing_aud_errors(tmp_path: Path) -> None:
+    with pytest.raises(AfiError) as exc:
+        load_config(_write(tmp_path, """
+auth:
+  mode: cloudflare-access
+  cloudflare:
+    team_domain: team.cloudflareaccess.com
+  allowed_emails:
+    - alice@example.com
+server:
+  name: spark
+"""))
+    assert exc.value.code == EXIT_USER_ERROR
+    assert "auth.cloudflare.aud" in exc.value.message
+
+
+def test_dev_mode_missing_dev_section_errors(tmp_path: Path) -> None:
+    with pytest.raises(AfiError) as exc:
+        load_config(_write(tmp_path, """
+auth:
+  mode: dev
+server:
+  name: spark
+"""))
+    assert "auth.dev.nick" in exc.value.message
+
+
+def test_unknown_mode_errors(tmp_path: Path) -> None:
+    with pytest.raises(AfiError) as exc:
+        load_config(_write(tmp_path, """
+auth:
+  mode: oauth-passport
+server:
+  name: spark
+"""))
+    assert "auth.mode" in exc.value.message
+    assert "dev" in exc.value.remediation
+    assert "cloudflare-access" in exc.value.remediation
+
+
+def test_missing_file_errors(tmp_path: Path) -> None:
+    with pytest.raises(AfiError) as exc:
+        load_config(tmp_path / "nope.yaml")
+    assert exc.value.code == EXIT_USER_ERROR
+    assert "config init" in exc.value.remediation
+
+
+def test_malformed_yaml_errors(tmp_path: Path) -> None:
+    with pytest.raises(AfiError) as exc:
+        load_config(_write(tmp_path, "::: not: yaml :::"))
+    assert "YAML" in exc.value.message or "parse" in exc.value.message
+
+
+def test_empty_allowed_emails_errors_in_cf_mode(tmp_path: Path) -> None:
+    with pytest.raises(AfiError) as exc:
+        load_config(_write(tmp_path, """
+auth:
+  mode: cloudflare-access
+  cloudflare:
+    aud: aud-tag
+    team_domain: team.cloudflareaccess.com
+  allowed_emails: []
+server:
+  name: spark
+"""))
+    assert "allowed_emails" in exc.value.message
+    assert "empty" in exc.value.message.lower()

--- a/tests/test_config_loader.py
+++ b/tests/test_config_loader.py
@@ -5,7 +5,7 @@ from pathlib import Path
 
 import pytest
 
-from irc_lens.cli._errors import EXIT_USER_ERROR, AfiError
+from irc_lens.cli._errors import EXIT_ENV_ERROR, EXIT_USER_ERROR, AfiError
 from irc_lens.config import LensConfig, load_config
 
 
@@ -121,7 +121,7 @@ server:
 """))
     assert exc.value.code == EXIT_USER_ERROR
     assert "server.port" in exc.value.message
-    assert "integer" in exc.value.message
+    assert "between 1 and 65535" in exc.value.message
 
 
 def test_invalid_web_port_errors(tmp_path: Path) -> None:
@@ -138,6 +138,7 @@ web:
   port: nope
 """))
     assert "web.port" in exc.value.message
+    assert "between 1 and 65535" in exc.value.message
 
 
 def test_empty_allowed_emails_errors_in_cf_mode(tmp_path: Path) -> None:
@@ -154,3 +155,59 @@ server:
 """))
     assert "allowed_emails" in exc.value.message
     assert "empty" in exc.value.message.lower()
+
+
+@pytest.mark.parametrize("port_value,expected_substring", [
+    ("8765.9", "must be an integer between 1 and 65535"),
+    ("true", "must be an integer between 1 and 65535"),
+    ("0", "must be an integer between 1 and 65535"),
+    ("70000", "must be an integer between 1 and 65535"),
+    ("-1", "must be an integer between 1 and 65535"),
+])
+def test_port_validation_rejects_bad_values(
+    tmp_path: Path, port_value: str, expected_substring: str
+) -> None:
+    yaml_body = f"""
+auth:
+  mode: dev
+  dev:
+    nick: lens
+    email: dev@local
+server:
+  name: spark
+  port: {port_value}
+"""
+    with pytest.raises(AfiError) as exc:
+        load_config(_write(tmp_path, yaml_body))
+    assert expected_substring in exc.value.message
+
+
+def test_falsy_web_section_rejected(tmp_path: Path) -> None:
+    """web: [] (or 0, or false) must NOT silently become {}."""
+    with pytest.raises(AfiError) as exc:
+        load_config(_write(tmp_path, """
+auth:
+  mode: dev
+  dev:
+    nick: lens
+    email: dev@local
+server:
+  name: spark
+web: []
+"""))
+    assert "web" in exc.value.message
+    assert "mapping" in exc.value.message
+
+
+def test_unreadable_config_raises_env_error(tmp_path: Path) -> None:
+    """A path that exists but can't be read fails with EXIT_ENV_ERROR."""
+    p = tmp_path / "config.yaml"
+    p.write_text("auth: {}")
+    p.chmod(0o000)
+    try:
+        with pytest.raises(AfiError) as exc:
+            load_config(p)
+        assert exc.value.code == EXIT_ENV_ERROR
+        assert "could not read" in exc.value.message
+    finally:
+        p.chmod(0o600)  # so cleanup works

--- a/uv.lock
+++ b/uv.lock
@@ -145,6 +145,76 @@ wheels = [
 ]
 
 [[package]]
+name = "cffi"
+version = "2.0.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pycparser", marker = "implementation_name != 'PyPy'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/eb/56/b1ba7935a17738ae8453301356628e8147c79dbb825bcbc73dc7401f9846/cffi-2.0.0.tar.gz", hash = "sha256:44d1b5909021139fe36001ae048dbdde8214afa20200eda0f64c068cac5d5529", size = 523588, upload-time = "2025-09-08T23:24:04.541Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/12/4a/3dfd5f7850cbf0d06dc84ba9aa00db766b52ca38d8b86e3a38314d52498c/cffi-2.0.0-cp311-cp311-macosx_10_13_x86_64.whl", hash = "sha256:b4c854ef3adc177950a8dfc81a86f5115d2abd545751a304c5bcf2c2c7283cfe", size = 184344, upload-time = "2025-09-08T23:22:26.456Z" },
+    { url = "https://files.pythonhosted.org/packages/4f/8b/f0e4c441227ba756aafbe78f117485b25bb26b1c059d01f137fa6d14896b/cffi-2.0.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:2de9a304e27f7596cd03d16f1b7c72219bd944e99cc52b84d0145aefb07cbd3c", size = 180560, upload-time = "2025-09-08T23:22:28.197Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/b7/1200d354378ef52ec227395d95c2576330fd22a869f7a70e88e1447eb234/cffi-2.0.0-cp311-cp311-manylinux1_i686.manylinux2014_i686.manylinux_2_17_i686.manylinux_2_5_i686.whl", hash = "sha256:baf5215e0ab74c16e2dd324e8ec067ef59e41125d3eade2b863d294fd5035c92", size = 209613, upload-time = "2025-09-08T23:22:29.475Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/56/6033f5e86e8cc9bb629f0077ba71679508bdf54a9a5e112a3c0b91870332/cffi-2.0.0-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:730cacb21e1bdff3ce90babf007d0a0917cc3e6492f336c2f0134101e0944f93", size = 216476, upload-time = "2025-09-08T23:22:31.063Z" },
+    { url = "https://files.pythonhosted.org/packages/dc/7f/55fecd70f7ece178db2f26128ec41430d8720f2d12ca97bf8f0a628207d5/cffi-2.0.0-cp311-cp311-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:6824f87845e3396029f3820c206e459ccc91760e8fa24422f8b0c3d1731cbec5", size = 203374, upload-time = "2025-09-08T23:22:32.507Z" },
+    { url = "https://files.pythonhosted.org/packages/84/ef/a7b77c8bdc0f77adc3b46888f1ad54be8f3b7821697a7b89126e829e676a/cffi-2.0.0-cp311-cp311-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:9de40a7b0323d889cf8d23d1ef214f565ab154443c42737dfe52ff82cf857664", size = 202597, upload-time = "2025-09-08T23:22:34.132Z" },
+    { url = "https://files.pythonhosted.org/packages/d7/91/500d892b2bf36529a75b77958edfcd5ad8e2ce4064ce2ecfeab2125d72d1/cffi-2.0.0-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:8941aaadaf67246224cee8c3803777eed332a19d909b47e29c9842ef1e79ac26", size = 215574, upload-time = "2025-09-08T23:22:35.443Z" },
+    { url = "https://files.pythonhosted.org/packages/44/64/58f6255b62b101093d5df22dcb752596066c7e89dd725e0afaed242a61be/cffi-2.0.0-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:a05d0c237b3349096d3981b727493e22147f934b20f6f125a3eba8f994bec4a9", size = 218971, upload-time = "2025-09-08T23:22:36.805Z" },
+    { url = "https://files.pythonhosted.org/packages/ab/49/fa72cebe2fd8a55fbe14956f9970fe8eb1ac59e5df042f603ef7c8ba0adc/cffi-2.0.0-cp311-cp311-musllinux_1_2_i686.whl", hash = "sha256:94698a9c5f91f9d138526b48fe26a199609544591f859c870d477351dc7b2414", size = 211972, upload-time = "2025-09-08T23:22:38.436Z" },
+    { url = "https://files.pythonhosted.org/packages/0b/28/dd0967a76aab36731b6ebfe64dec4e981aff7e0608f60c2d46b46982607d/cffi-2.0.0-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:5fed36fccc0612a53f1d4d9a816b50a36702c28a2aa880cb8a122b3466638743", size = 217078, upload-time = "2025-09-08T23:22:39.776Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/c0/015b25184413d7ab0a410775fdb4a50fca20f5589b5dab1dbbfa3baad8ce/cffi-2.0.0-cp311-cp311-win32.whl", hash = "sha256:c649e3a33450ec82378822b3dad03cc228b8f5963c0c12fc3b1e0ab940f768a5", size = 172076, upload-time = "2025-09-08T23:22:40.95Z" },
+    { url = "https://files.pythonhosted.org/packages/ae/8f/dc5531155e7070361eb1b7e4c1a9d896d0cb21c49f807a6c03fd63fc877e/cffi-2.0.0-cp311-cp311-win_amd64.whl", hash = "sha256:66f011380d0e49ed280c789fbd08ff0d40968ee7b665575489afa95c98196ab5", size = 182820, upload-time = "2025-09-08T23:22:42.463Z" },
+    { url = "https://files.pythonhosted.org/packages/95/5c/1b493356429f9aecfd56bc171285a4c4ac8697f76e9bbbbb105e537853a1/cffi-2.0.0-cp311-cp311-win_arm64.whl", hash = "sha256:c6638687455baf640e37344fe26d37c404db8b80d037c3d29f58fe8d1c3b194d", size = 177635, upload-time = "2025-09-08T23:22:43.623Z" },
+    { url = "https://files.pythonhosted.org/packages/ea/47/4f61023ea636104d4f16ab488e268b93008c3d0bb76893b1b31db1f96802/cffi-2.0.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:6d02d6655b0e54f54c4ef0b94eb6be0607b70853c45ce98bd278dc7de718be5d", size = 185271, upload-time = "2025-09-08T23:22:44.795Z" },
+    { url = "https://files.pythonhosted.org/packages/df/a2/781b623f57358e360d62cdd7a8c681f074a71d445418a776eef0aadb4ab4/cffi-2.0.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:8eca2a813c1cb7ad4fb74d368c2ffbbb4789d377ee5bb8df98373c2cc0dee76c", size = 181048, upload-time = "2025-09-08T23:22:45.938Z" },
+    { url = "https://files.pythonhosted.org/packages/ff/df/a4f0fbd47331ceeba3d37c2e51e9dfc9722498becbeec2bd8bc856c9538a/cffi-2.0.0-cp312-cp312-manylinux1_i686.manylinux2014_i686.manylinux_2_17_i686.manylinux_2_5_i686.whl", hash = "sha256:21d1152871b019407d8ac3985f6775c079416c282e431a4da6afe7aefd2bccbe", size = 212529, upload-time = "2025-09-08T23:22:47.349Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/72/12b5f8d3865bf0f87cf1404d8c374e7487dcf097a1c91c436e72e6badd83/cffi-2.0.0-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:b21e08af67b8a103c71a250401c78d5e0893beff75e28c53c98f4de42f774062", size = 220097, upload-time = "2025-09-08T23:22:48.677Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/95/7a135d52a50dfa7c882ab0ac17e8dc11cec9d55d2c18dda414c051c5e69e/cffi-2.0.0-cp312-cp312-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:1e3a615586f05fc4065a8b22b8152f0c1b00cdbc60596d187c2a74f9e3036e4e", size = 207983, upload-time = "2025-09-08T23:22:50.06Z" },
+    { url = "https://files.pythonhosted.org/packages/3a/c8/15cb9ada8895957ea171c62dc78ff3e99159ee7adb13c0123c001a2546c1/cffi-2.0.0-cp312-cp312-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:81afed14892743bbe14dacb9e36d9e0e504cd204e0b165062c488942b9718037", size = 206519, upload-time = "2025-09-08T23:22:51.364Z" },
+    { url = "https://files.pythonhosted.org/packages/78/2d/7fa73dfa841b5ac06c7b8855cfc18622132e365f5b81d02230333ff26e9e/cffi-2.0.0-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:3e17ed538242334bf70832644a32a7aae3d83b57567f9fd60a26257e992b79ba", size = 219572, upload-time = "2025-09-08T23:22:52.902Z" },
+    { url = "https://files.pythonhosted.org/packages/07/e0/267e57e387b4ca276b90f0434ff88b2c2241ad72b16d31836adddfd6031b/cffi-2.0.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:3925dd22fa2b7699ed2617149842d2e6adde22b262fcbfada50e3d195e4b3a94", size = 222963, upload-time = "2025-09-08T23:22:54.518Z" },
+    { url = "https://files.pythonhosted.org/packages/b6/75/1f2747525e06f53efbd878f4d03bac5b859cbc11c633d0fb81432d98a795/cffi-2.0.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:2c8f814d84194c9ea681642fd164267891702542f028a15fc97d4674b6206187", size = 221361, upload-time = "2025-09-08T23:22:55.867Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/2b/2b6435f76bfeb6bbf055596976da087377ede68df465419d192acf00c437/cffi-2.0.0-cp312-cp312-win32.whl", hash = "sha256:da902562c3e9c550df360bfa53c035b2f241fed6d9aef119048073680ace4a18", size = 172932, upload-time = "2025-09-08T23:22:57.188Z" },
+    { url = "https://files.pythonhosted.org/packages/f8/ed/13bd4418627013bec4ed6e54283b1959cf6db888048c7cf4b4c3b5b36002/cffi-2.0.0-cp312-cp312-win_amd64.whl", hash = "sha256:da68248800ad6320861f129cd9c1bf96ca849a2771a59e0344e88681905916f5", size = 183557, upload-time = "2025-09-08T23:22:58.351Z" },
+    { url = "https://files.pythonhosted.org/packages/95/31/9f7f93ad2f8eff1dbc1c3656d7ca5bfd8fb52c9d786b4dcf19b2d02217fa/cffi-2.0.0-cp312-cp312-win_arm64.whl", hash = "sha256:4671d9dd5ec934cb9a73e7ee9676f9362aba54f7f34910956b84d727b0d73fb6", size = 177762, upload-time = "2025-09-08T23:22:59.668Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/8d/a0a47a0c9e413a658623d014e91e74a50cdd2c423f7ccfd44086ef767f90/cffi-2.0.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:00bdf7acc5f795150faa6957054fbbca2439db2f775ce831222b66f192f03beb", size = 185230, upload-time = "2025-09-08T23:23:00.879Z" },
+    { url = "https://files.pythonhosted.org/packages/4a/d2/a6c0296814556c68ee32009d9c2ad4f85f2707cdecfd7727951ec228005d/cffi-2.0.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:45d5e886156860dc35862657e1494b9bae8dfa63bf56796f2fb56e1679fc0bca", size = 181043, upload-time = "2025-09-08T23:23:02.231Z" },
+    { url = "https://files.pythonhosted.org/packages/b0/1e/d22cc63332bd59b06481ceaac49d6c507598642e2230f201649058a7e704/cffi-2.0.0-cp313-cp313-manylinux1_i686.manylinux2014_i686.manylinux_2_17_i686.manylinux_2_5_i686.whl", hash = "sha256:07b271772c100085dd28b74fa0cd81c8fb1a3ba18b21e03d7c27f3436a10606b", size = 212446, upload-time = "2025-09-08T23:23:03.472Z" },
+    { url = "https://files.pythonhosted.org/packages/a9/f5/a2c23eb03b61a0b8747f211eb716446c826ad66818ddc7810cc2cc19b3f2/cffi-2.0.0-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:d48a880098c96020b02d5a1f7d9251308510ce8858940e6fa99ece33f610838b", size = 220101, upload-time = "2025-09-08T23:23:04.792Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/7f/e6647792fc5850d634695bc0e6ab4111ae88e89981d35ac269956605feba/cffi-2.0.0-cp313-cp313-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:f93fd8e5c8c0a4aa1f424d6173f14a892044054871c771f8566e4008eaa359d2", size = 207948, upload-time = "2025-09-08T23:23:06.127Z" },
+    { url = "https://files.pythonhosted.org/packages/cb/1e/a5a1bd6f1fb30f22573f76533de12a00bf274abcdc55c8edab639078abb6/cffi-2.0.0-cp313-cp313-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:dd4f05f54a52fb558f1ba9f528228066954fee3ebe629fc1660d874d040ae5a3", size = 206422, upload-time = "2025-09-08T23:23:07.753Z" },
+    { url = "https://files.pythonhosted.org/packages/98/df/0a1755e750013a2081e863e7cd37e0cdd02664372c754e5560099eb7aa44/cffi-2.0.0-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:c8d3b5532fc71b7a77c09192b4a5a200ea992702734a2e9279a37f2478236f26", size = 219499, upload-time = "2025-09-08T23:23:09.648Z" },
+    { url = "https://files.pythonhosted.org/packages/50/e1/a969e687fcf9ea58e6e2a928ad5e2dd88cc12f6f0ab477e9971f2309b57c/cffi-2.0.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:d9b29c1f0ae438d5ee9acb31cadee00a58c46cc9c0b2f9038c6b0b3470877a8c", size = 222928, upload-time = "2025-09-08T23:23:10.928Z" },
+    { url = "https://files.pythonhosted.org/packages/36/54/0362578dd2c9e557a28ac77698ed67323ed5b9775ca9d3fe73fe191bb5d8/cffi-2.0.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:6d50360be4546678fc1b79ffe7a66265e28667840010348dd69a314145807a1b", size = 221302, upload-time = "2025-09-08T23:23:12.42Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/6d/bf9bda840d5f1dfdbf0feca87fbdb64a918a69bca42cfa0ba7b137c48cb8/cffi-2.0.0-cp313-cp313-win32.whl", hash = "sha256:74a03b9698e198d47562765773b4a8309919089150a0bb17d829ad7b44b60d27", size = 172909, upload-time = "2025-09-08T23:23:14.32Z" },
+    { url = "https://files.pythonhosted.org/packages/37/18/6519e1ee6f5a1e579e04b9ddb6f1676c17368a7aba48299c3759bbc3c8b3/cffi-2.0.0-cp313-cp313-win_amd64.whl", hash = "sha256:19f705ada2530c1167abacb171925dd886168931e0a7b78f5bffcae5c6b5be75", size = 183402, upload-time = "2025-09-08T23:23:15.535Z" },
+    { url = "https://files.pythonhosted.org/packages/cb/0e/02ceeec9a7d6ee63bb596121c2c8e9b3a9e150936f4fbef6ca1943e6137c/cffi-2.0.0-cp313-cp313-win_arm64.whl", hash = "sha256:256f80b80ca3853f90c21b23ee78cd008713787b1b1e93eae9f3d6a7134abd91", size = 177780, upload-time = "2025-09-08T23:23:16.761Z" },
+    { url = "https://files.pythonhosted.org/packages/92/c4/3ce07396253a83250ee98564f8d7e9789fab8e58858f35d07a9a2c78de9f/cffi-2.0.0-cp314-cp314-macosx_10_13_x86_64.whl", hash = "sha256:fc33c5141b55ed366cfaad382df24fe7dcbc686de5be719b207bb248e3053dc5", size = 185320, upload-time = "2025-09-08T23:23:18.087Z" },
+    { url = "https://files.pythonhosted.org/packages/59/dd/27e9fa567a23931c838c6b02d0764611c62290062a6d4e8ff7863daf9730/cffi-2.0.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:c654de545946e0db659b3400168c9ad31b5d29593291482c43e3564effbcee13", size = 181487, upload-time = "2025-09-08T23:23:19.622Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/43/0e822876f87ea8a4ef95442c3d766a06a51fc5298823f884ef87aaad168c/cffi-2.0.0-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:24b6f81f1983e6df8db3adc38562c83f7d4a0c36162885ec7f7b77c7dcbec97b", size = 220049, upload-time = "2025-09-08T23:23:20.853Z" },
+    { url = "https://files.pythonhosted.org/packages/b4/89/76799151d9c2d2d1ead63c2429da9ea9d7aac304603de0c6e8764e6e8e70/cffi-2.0.0-cp314-cp314-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:12873ca6cb9b0f0d3a0da705d6086fe911591737a59f28b7936bdfed27c0d47c", size = 207793, upload-time = "2025-09-08T23:23:22.08Z" },
+    { url = "https://files.pythonhosted.org/packages/bb/dd/3465b14bb9e24ee24cb88c9e3730f6de63111fffe513492bf8c808a3547e/cffi-2.0.0-cp314-cp314-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:d9b97165e8aed9272a6bb17c01e3cc5871a594a446ebedc996e2397a1c1ea8ef", size = 206300, upload-time = "2025-09-08T23:23:23.314Z" },
+    { url = "https://files.pythonhosted.org/packages/47/d9/d83e293854571c877a92da46fdec39158f8d7e68da75bf73581225d28e90/cffi-2.0.0-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:afb8db5439b81cf9c9d0c80404b60c3cc9c3add93e114dcae767f1477cb53775", size = 219244, upload-time = "2025-09-08T23:23:24.541Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/0f/1f177e3683aead2bb00f7679a16451d302c436b5cbf2505f0ea8146ef59e/cffi-2.0.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:737fe7d37e1a1bffe70bd5754ea763a62a066dc5913ca57e957824b72a85e205", size = 222828, upload-time = "2025-09-08T23:23:26.143Z" },
+    { url = "https://files.pythonhosted.org/packages/c6/0f/cafacebd4b040e3119dcb32fed8bdef8dfe94da653155f9d0b9dc660166e/cffi-2.0.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:38100abb9d1b1435bc4cc340bb4489635dc2f0da7456590877030c9b3d40b0c1", size = 220926, upload-time = "2025-09-08T23:23:27.873Z" },
+    { url = "https://files.pythonhosted.org/packages/3e/aa/df335faa45b395396fcbc03de2dfcab242cd61a9900e914fe682a59170b1/cffi-2.0.0-cp314-cp314-win32.whl", hash = "sha256:087067fa8953339c723661eda6b54bc98c5625757ea62e95eb4898ad5e776e9f", size = 175328, upload-time = "2025-09-08T23:23:44.61Z" },
+    { url = "https://files.pythonhosted.org/packages/bb/92/882c2d30831744296ce713f0feb4c1cd30f346ef747b530b5318715cc367/cffi-2.0.0-cp314-cp314-win_amd64.whl", hash = "sha256:203a48d1fb583fc7d78a4c6655692963b860a417c0528492a6bc21f1aaefab25", size = 185650, upload-time = "2025-09-08T23:23:45.848Z" },
+    { url = "https://files.pythonhosted.org/packages/9f/2c/98ece204b9d35a7366b5b2c6539c350313ca13932143e79dc133ba757104/cffi-2.0.0-cp314-cp314-win_arm64.whl", hash = "sha256:dbd5c7a25a7cb98f5ca55d258b103a2054f859a46ae11aaf23134f9cc0d356ad", size = 180687, upload-time = "2025-09-08T23:23:47.105Z" },
+    { url = "https://files.pythonhosted.org/packages/3e/61/c768e4d548bfa607abcda77423448df8c471f25dbe64fb2ef6d555eae006/cffi-2.0.0-cp314-cp314t-macosx_10_13_x86_64.whl", hash = "sha256:9a67fc9e8eb39039280526379fb3a70023d77caec1852002b4da7e8b270c4dd9", size = 188773, upload-time = "2025-09-08T23:23:29.347Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/ea/5f76bce7cf6fcd0ab1a1058b5af899bfbef198bea4d5686da88471ea0336/cffi-2.0.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:7a66c7204d8869299919db4d5069a82f1561581af12b11b3c9f48c584eb8743d", size = 185013, upload-time = "2025-09-08T23:23:30.63Z" },
+    { url = "https://files.pythonhosted.org/packages/be/b4/c56878d0d1755cf9caa54ba71e5d049479c52f9e4afc230f06822162ab2f/cffi-2.0.0-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:7cc09976e8b56f8cebd752f7113ad07752461f48a58cbba644139015ac24954c", size = 221593, upload-time = "2025-09-08T23:23:31.91Z" },
+    { url = "https://files.pythonhosted.org/packages/e0/0d/eb704606dfe8033e7128df5e90fee946bbcb64a04fcdaa97321309004000/cffi-2.0.0-cp314-cp314t-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:92b68146a71df78564e4ef48af17551a5ddd142e5190cdf2c5624d0c3ff5b2e8", size = 209354, upload-time = "2025-09-08T23:23:33.214Z" },
+    { url = "https://files.pythonhosted.org/packages/d8/19/3c435d727b368ca475fb8742ab97c9cb13a0de600ce86f62eab7fa3eea60/cffi-2.0.0-cp314-cp314t-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:b1e74d11748e7e98e2f426ab176d4ed720a64412b6a15054378afdb71e0f37dc", size = 208480, upload-time = "2025-09-08T23:23:34.495Z" },
+    { url = "https://files.pythonhosted.org/packages/d0/44/681604464ed9541673e486521497406fadcc15b5217c3e326b061696899a/cffi-2.0.0-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:28a3a209b96630bca57cce802da70c266eb08c6e97e5afd61a75611ee6c64592", size = 221584, upload-time = "2025-09-08T23:23:36.096Z" },
+    { url = "https://files.pythonhosted.org/packages/25/8e/342a504ff018a2825d395d44d63a767dd8ebc927ebda557fecdaca3ac33a/cffi-2.0.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:7553fb2090d71822f02c629afe6042c299edf91ba1bf94951165613553984512", size = 224443, upload-time = "2025-09-08T23:23:37.328Z" },
+    { url = "https://files.pythonhosted.org/packages/e1/5e/b666bacbbc60fbf415ba9988324a132c9a7a0448a9a8f125074671c0f2c3/cffi-2.0.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:6c6c373cfc5c83a975506110d17457138c8c63016b563cc9ed6e056a82f13ce4", size = 223437, upload-time = "2025-09-08T23:23:38.945Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/1d/ec1a60bd1a10daa292d3cd6bb0b359a81607154fb8165f3ec95fe003b85c/cffi-2.0.0-cp314-cp314t-win32.whl", hash = "sha256:1fc9ea04857caf665289b7a75923f2c6ed559b8298a1b8c49e59f7dd95c8481e", size = 180487, upload-time = "2025-09-08T23:23:40.423Z" },
+    { url = "https://files.pythonhosted.org/packages/bf/41/4c1168c74fac325c0c8156f04b6749c8b6a8f405bbf91413ba088359f60d/cffi-2.0.0-cp314-cp314t-win_amd64.whl", hash = "sha256:d68b6cef7827e8641e8ef16f4494edda8b36104d79773a334beaa1e3521430f6", size = 191726, upload-time = "2025-09-08T23:23:41.742Z" },
+    { url = "https://files.pythonhosted.org/packages/ae/3a/dbeec9d1ee0844c679f6bb5d6ad4e9f198b1224f4e7a32825f47f6192b0c/cffi-2.0.0-cp314-cp314t-win_arm64.whl", hash = "sha256:0a1527a803f0a659de1af2e1fd700213caba79377e27e4693648c2923da066f9", size = 184195, upload-time = "2025-09-08T23:23:43.004Z" },
+]
+
+[[package]]
 name = "charset-normalizer"
 version = "3.4.7"
 source = { registry = "https://pypi.org/simple" }
@@ -347,6 +417,65 @@ toml = [
 ]
 
 [[package]]
+name = "cryptography"
+version = "48.0.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "cffi", marker = "platform_python_implementation != 'PyPy'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/9f/a9/db8f313fdcd85d767d4973515e1db101f9c71f95fced83233de224673757/cryptography-48.0.0.tar.gz", hash = "sha256:5c3932f4436d1cccb036cb0eaef46e6e2db91035166f1ad6505c3c9d5a635920", size = 832984, upload-time = "2026-05-04T22:59:38.133Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/df/3d/01f6dd9190170a5a241e0e98c2d04be3664a9e6f5b9b872cde63aff1c3dd/cryptography-48.0.0-cp311-abi3-macosx_10_9_universal2.whl", hash = "sha256:0c558d2cdffd8f4bbb30fc7134c74d2ca9a476f830bb053074498fbc86f41ed6", size = 8001587, upload-time = "2026-05-04T22:57:36.803Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/6e/e90527eef33f309beb811cf7c982c3aeffcce8e3edb178baa4ca3ae4a6fa/cryptography-48.0.0-cp311-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:f5333311663ea94f75dd408665686aaf426563556bb5283554a3539177e03b8c", size = 4690433, upload-time = "2026-05-04T22:57:40.373Z" },
+    { url = "https://files.pythonhosted.org/packages/90/04/673510ed51ddff56575f306cf1617d80411ee76831ccd3097599140efdfe/cryptography-48.0.0-cp311-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:7995ef305d7165c3f11ae07f2517e5a4f1d5c18da1376a0a9ed496336b69e5f3", size = 4710620, upload-time = "2026-05-04T22:57:42.935Z" },
+    { url = "https://files.pythonhosted.org/packages/14/d5/e9c4ef932c8d800490c34d8bd589d64a31d5890e27ec9e9ad532be893294/cryptography-48.0.0-cp311-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:40ba1f85eaa6959837b1d51c9767e230e14612eea4ef110ee8854ada22da1bf5", size = 4696283, upload-time = "2026-05-04T22:57:45.294Z" },
+    { url = "https://files.pythonhosted.org/packages/0c/29/174b9dfb60b12d59ecfc6cfa04bc88c21b42a54f01b8aae09bb6e51e4c7f/cryptography-48.0.0-cp311-abi3-manylinux_2_28_ppc64le.whl", hash = "sha256:369a6348999f94bbd53435c894377b20ab95f25a9065c283570e70150d8abc3c", size = 5296573, upload-time = "2026-05-04T22:57:47.933Z" },
+    { url = "https://files.pythonhosted.org/packages/95/38/0d29a6fd7d0d1373f0c0c88a04ba20e359b257753ac497564cd660fc1d55/cryptography-48.0.0-cp311-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:a0e692c683f4df67815a2d258b324e66f4738bd7a96a218c826dce4f4bd05d8f", size = 4743677, upload-time = "2026-05-04T22:57:50.067Z" },
+    { url = "https://files.pythonhosted.org/packages/30/be/eef653013d5c63b6a490529e0316f9ac14a37602965d4903efed1399f32b/cryptography-48.0.0-cp311-abi3-manylinux_2_31_armv7l.whl", hash = "sha256:18349bbc56f4743c8b12dc32e2bccb2cf83ee8b69a3bba74ef8ae857e26b3d25", size = 4330808, upload-time = "2026-05-04T22:57:52.301Z" },
+    { url = "https://files.pythonhosted.org/packages/84/9e/500463e87abb7a0a0f9f256ec21123ecde0a7b5541a15e840ea54551fd81/cryptography-48.0.0-cp311-abi3-manylinux_2_34_aarch64.whl", hash = "sha256:7e8eac43dfca5c4cccc6dad9a80504436fca53bb9bc3100a2386d730fbe6b602", size = 4695941, upload-time = "2026-05-04T22:57:54.603Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/dc/7303087450c2ec9e7fbb750e17c2abfbc658f23cbd0e54009509b7cc4091/cryptography-48.0.0-cp311-abi3-manylinux_2_34_ppc64le.whl", hash = "sha256:9ccdac7d40688ecb5a3b4a604b8a88c8002e3442d6c60aead1db2a89a041560c", size = 5252579, upload-time = "2026-05-04T22:57:57.207Z" },
+    { url = "https://files.pythonhosted.org/packages/d0/c0/7101d3b7215edcdc90c45da544961fd8ed2d6448f77577460fa75a8443f7/cryptography-48.0.0-cp311-abi3-manylinux_2_34_x86_64.whl", hash = "sha256:bd72e68b06bb1e96913f97dd4901119bc17f39d4586a5adf2d3e47bc2b9d58b5", size = 4743326, upload-time = "2026-05-04T22:57:59.535Z" },
+    { url = "https://files.pythonhosted.org/packages/ac/d8/5b833bad13016f562ab9d063d68199a4bd121d18458e439515601d3357ec/cryptography-48.0.0-cp311-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:59baa2cb386c4f0b9905bd6eb4c2a79a69a128408fd31d32ca4d7102d4156321", size = 4826672, upload-time = "2026-05-04T22:58:01.996Z" },
+    { url = "https://files.pythonhosted.org/packages/98/e1/7074eb8bf3c135558c73fc2bcf0f5633f912e6fb87e868a55c454080ef09/cryptography-48.0.0-cp311-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:9249e3cd978541d665967ac2cb2787fd6a62bddf1e75b3e347a594d7dacf4f74", size = 4972574, upload-time = "2026-05-04T22:58:03.968Z" },
+    { url = "https://files.pythonhosted.org/packages/04/70/e5a1b41d325f797f39427aa44ef8baf0be500065ab6d8e10369d850d4a4f/cryptography-48.0.0-cp311-abi3-win32.whl", hash = "sha256:9c459db21422be75e2809370b829a87eb37f74cd785fc4aa9ea1e5f43b47cda4", size = 3294868, upload-time = "2026-05-04T22:58:06.467Z" },
+    { url = "https://files.pythonhosted.org/packages/f4/ac/8ac51b4a5fc5932eb7ee5c517ba7dc8cd834f0048962b6b352f00f41ebf9/cryptography-48.0.0-cp311-abi3-win_amd64.whl", hash = "sha256:5b012212e08b8dd5edc78ef54da83dd9892fd9105323b3993eff6bea65dc21d7", size = 3817107, upload-time = "2026-05-04T22:58:08.845Z" },
+    { url = "https://files.pythonhosted.org/packages/6b/84/70e3feea9feea87fd7cbe77efb2712ae1e3e6edf10749dc6e95f4e60e455/cryptography-48.0.0-cp314-cp314t-macosx_10_9_universal2.whl", hash = "sha256:3cb07a3ed6431663cd321ea8a000a1314c74211f823e4177fefa2255e057d1ec", size = 7986556, upload-time = "2026-05-04T22:58:11.172Z" },
+    { url = "https://files.pythonhosted.org/packages/89/6e/18e07a618bb5442ba10cf4df16e99c071365528aa570dfcb8c02e25a303b/cryptography-48.0.0-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:8c7378637d7d88016fa6791c159f698b3d3eed28ebf844ac36b9dc04a14dae18", size = 4684776, upload-time = "2026-05-04T22:58:13.712Z" },
+    { url = "https://files.pythonhosted.org/packages/be/6a/4ea3b4c6c6759794d5ee2103c304a5076dc4b19ae1f9fe47dba439e159e9/cryptography-48.0.0-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:cc90c0b39b2e3c65ef52c804b72e3c58f8a04ab2a1871272798e5f9572c17d20", size = 4698121, upload-time = "2026-05-04T22:58:16.448Z" },
+    { url = "https://files.pythonhosted.org/packages/2f/59/6ff6ad6cae03bb887da2a5860b2c9805f8dac969ef01ce563336c49bd1d1/cryptography-48.0.0-cp314-cp314t-manylinux_2_28_aarch64.whl", hash = "sha256:76341972e1eff8b4bea859f09c0d3e64b96ce931b084f9b9b7db8ef364c30eff", size = 4690042, upload-time = "2026-05-04T22:58:18.544Z" },
+    { url = "https://files.pythonhosted.org/packages/ca/b4/fc334ed8cfd705aca282fe4d8f5ae64a8e0f74932e9feecb344610cf6e4d/cryptography-48.0.0-cp314-cp314t-manylinux_2_28_ppc64le.whl", hash = "sha256:55b7718303bf06a5753dcdccf2f3945cf18ad7bffde41b61226e4db31ab89a9c", size = 5282526, upload-time = "2026-05-04T22:58:20.75Z" },
+    { url = "https://files.pythonhosted.org/packages/11/08/9f8c5386cc4cd90d8255c7cdd0f5baf459a08502a09de30dc51f553d38dc/cryptography-48.0.0-cp314-cp314t-manylinux_2_28_x86_64.whl", hash = "sha256:a64697c641c7b1b2178e573cbc31c7c6684cd56883a478d75143dbb7118036db", size = 4733116, upload-time = "2026-05-04T22:58:23.627Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/77/99307d7574045699f8805aa500fa0fb83422d115b5400a064ddd306d7750/cryptography-48.0.0-cp314-cp314t-manylinux_2_31_armv7l.whl", hash = "sha256:561215ea3879cb1cbbf272867e2efda62476f240fb58c64de6b393ae19246741", size = 4316030, upload-time = "2026-05-04T22:58:25.581Z" },
+    { url = "https://files.pythonhosted.org/packages/fd/36/a608b98337af3cb2aff4818e406649d30572b7031918b04c87d979495348/cryptography-48.0.0-cp314-cp314t-manylinux_2_34_aarch64.whl", hash = "sha256:ad64688338ed4bc1a6618076ba75fd7194a5f1797ac60b47afe926285adb3166", size = 4689640, upload-time = "2026-05-04T22:58:27.747Z" },
+    { url = "https://files.pythonhosted.org/packages/dd/a6/825010a291b4438aecc1f568bc428189fc1175515223632477c07dc0a6df/cryptography-48.0.0-cp314-cp314t-manylinux_2_34_ppc64le.whl", hash = "sha256:906cbf0670286c6e0044156bc7d4af9cbb0ef6db9f73e52c3ec56ba6bdde5336", size = 5237657, upload-time = "2026-05-04T22:58:29.848Z" },
+    { url = "https://files.pythonhosted.org/packages/b9/09/4e76a09b4caa29aad535ddc806f5d4c5d01885bd978bd984fbc6ca032cae/cryptography-48.0.0-cp314-cp314t-manylinux_2_34_x86_64.whl", hash = "sha256:ea8990436d914540a40ab24b6a77c0969695ed52f4a4874c5137ccf7045a7057", size = 4732362, upload-time = "2026-05-04T22:58:32.009Z" },
+    { url = "https://files.pythonhosted.org/packages/18/78/444fa04a77d0cb95f417dda20d450e13c56ba8e5220fc892a1658f44f882/cryptography-48.0.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:c18684a7f0cc9a3cb60328f496b8e3372def7c5d2df39ac267878b05565aaaae", size = 4819580, upload-time = "2026-05-04T22:58:34.254Z" },
+    { url = "https://files.pythonhosted.org/packages/38/85/ea67067c70a1fd4be2c63d35eeed82658023021affccc7b17705f8527dd2/cryptography-48.0.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:9be5aafa5736574f8f15f262adc81b2a9869e2cfe9014d52a44633905b40d52c", size = 4963283, upload-time = "2026-05-04T22:58:36.376Z" },
+    { url = "https://files.pythonhosted.org/packages/75/54/cc6d0f3deac3e81c7f847e8a189a12b6cdd65059b43dad25d4316abd849a/cryptography-48.0.0-cp314-cp314t-win32.whl", hash = "sha256:c17dfe85494deaeddc5ce251aebd1d60bbe6afc8b62071bb0b469431a000124f", size = 3270954, upload-time = "2026-05-04T22:58:38.791Z" },
+    { url = "https://files.pythonhosted.org/packages/49/67/cc947e288c0758a4e5473d1dcb743037ab7785541265a969240b8885441a/cryptography-48.0.0-cp314-cp314t-win_amd64.whl", hash = "sha256:27241b1dc9962e056062a8eef1991d02c3a24569c95975bd2322a8a52c6e5e12", size = 3797313, upload-time = "2026-05-04T22:58:40.746Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/63/61d4a4e1c6b6bab6ce1e213cd36a24c415d90e76d78c5eb8577c5541d2e8/cryptography-48.0.0-cp39-abi3-macosx_10_9_universal2.whl", hash = "sha256:58d00498e8933e4a194f3076aee1b4a97dfec1a6da444535755822fe5d8b0b86", size = 7983482, upload-time = "2026-05-04T22:58:43.769Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/ac/f5b5995b87770c693e2596559ffafe195b4033a57f14a82268a2842953f3/cryptography-48.0.0-cp39-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:614d0949f4790582d2cc25553abd09dd723025f0c0e7c67376a1d77196743d6e", size = 4683266, upload-time = "2026-05-04T22:58:46.064Z" },
+    { url = "https://files.pythonhosted.org/packages/ec/c6/8b14f67e18338fbc4adb76f66c001f5c3610b3e2d1837f268f47a347dbbb/cryptography-48.0.0-cp39-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:7ce4bfae76319a532a2dc68f82cc32f5676ee792a983187dac07183690e5c66f", size = 4696228, upload-time = "2026-05-04T22:58:48.22Z" },
+    { url = "https://files.pythonhosted.org/packages/ea/73/f808fbae9514bd91b47875b003f13e284c8c6bdfd904b7944e803937eec1/cryptography-48.0.0-cp39-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:2eb992bbd4661238c5a397594c83f5b4dc2bc5b848c365c8f991b6780efcc5c7", size = 4689097, upload-time = "2026-05-04T22:58:50.9Z" },
+    { url = "https://files.pythonhosted.org/packages/93/01/d86632d7d28db8ae83221995752eeb6639ffb374c2d22955648cf8d52797/cryptography-48.0.0-cp39-abi3-manylinux_2_28_ppc64le.whl", hash = "sha256:22a5cb272895dce158b2cacdfdc3debd299019659f42947dbdac6f32d68fe832", size = 5283582, upload-time = "2026-05-04T22:58:53.017Z" },
+    { url = "https://files.pythonhosted.org/packages/02/e1/50edc7a50334807cc4791fc4a0ce7468b4a1416d9138eab358bfc9a3d70b/cryptography-48.0.0-cp39-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:2b4d59804e8408e2fea7d1fbaf218e5ec984325221db76e6a241a9abd6cdd95c", size = 4730479, upload-time = "2026-05-04T22:58:55.611Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/af/99a582b1b1641ff5911ac559beb45097cf79efd4ead4657f578ef1af2d47/cryptography-48.0.0-cp39-abi3-manylinux_2_31_armv7l.whl", hash = "sha256:984a20b0f62a26f48a3396c72e4bc34c66e356d356bf370053066b3b6d54634a", size = 4326481, upload-time = "2026-05-04T22:58:57.607Z" },
+    { url = "https://files.pythonhosted.org/packages/90/ee/89aa26a06ef0a7d7611788ffd571a7c50e368cc6a4d5eef8b4884e866edb/cryptography-48.0.0-cp39-abi3-manylinux_2_34_aarch64.whl", hash = "sha256:5a5ed8fde7a1d09376ca0b40e68cd59c69fe23b1f9768bd5824f54681626032a", size = 4688713, upload-time = "2026-05-04T22:59:00.077Z" },
+    { url = "https://files.pythonhosted.org/packages/70/ba/bcb1b0bb7a33d4c7c0c4d4c7874b4a62ae4f56113a5f4baefa362dfb1f0f/cryptography-48.0.0-cp39-abi3-manylinux_2_34_ppc64le.whl", hash = "sha256:8cd666227ef7af430aa5914a9910e0ddd703e75f039cef0825cd0da71b6b711a", size = 5238165, upload-time = "2026-05-04T22:59:02.317Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/70/ca4003b1ce5ca3dc3186ada51908c8a9b9ff7d5cab83cc0d43ee14ec144f/cryptography-48.0.0-cp39-abi3-manylinux_2_34_x86_64.whl", hash = "sha256:9071196d81abc88b3516ac8cdfad32e2b66dd4a5393a8e68a961e9161ddc6239", size = 4729947, upload-time = "2026-05-04T22:59:05.255Z" },
+    { url = "https://files.pythonhosted.org/packages/44/a0/4ec7cf774207905aef1a8d11c3750d5a1db805eb380ee4e16df317870128/cryptography-48.0.0-cp39-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:1e2d54c8be6152856a36f0882ab231e70f8ec7f14e93cf87db8a2ed056bf160c", size = 4822059, upload-time = "2026-05-04T22:59:07.802Z" },
+    { url = "https://files.pythonhosted.org/packages/1e/75/a2e55f99c16fcac7b5d6c1eb19ad8e00799854d6be5ca845f9259eae1681/cryptography-48.0.0-cp39-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:a5da777e32ffed6f85a7b2b3f7c5cbc88c146bfcd0a1d7baf5fcc6c52ee35dd4", size = 4960575, upload-time = "2026-05-04T22:59:09.851Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/23/6e6f32143ab5d8b36ca848a502c4bcd477ae75b9e1677e3530d669062578/cryptography-48.0.0-cp39-abi3-win32.whl", hash = "sha256:77a2ccbbe917f6710e05ba9adaa25fb5075620bf3ea6fb751997875aff4ae4bd", size = 3279117, upload-time = "2026-05-04T22:59:12.019Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/9a/0fea98a70cf1749d41d738836f6349d97945f7c89433a259a6c2642eefeb/cryptography-48.0.0-cp39-abi3-win_amd64.whl", hash = "sha256:16cd65b9330583e4619939b3a3843eec1e6e789744bb01e7c7e2e62e33c239c8", size = 3792100, upload-time = "2026-05-04T22:59:14.884Z" },
+    { url = "https://files.pythonhosted.org/packages/be/d2/024b5e06be9d44cb021fb0e1a03d34d63989cf56a0fe62f3dfbab695b9b4/cryptography-48.0.0-pp311-pypy311_pp73-macosx_11_0_arm64.whl", hash = "sha256:84cf79f0dc8b36ac5da873481716e87aef31fcfa0444f9e1d8b4b2cece142855", size = 3950391, upload-time = "2026-05-04T22:59:17.415Z" },
+    { url = "https://files.pythonhosted.org/packages/bc/17/3861e17c56fa0fd37491a14a8673fdb77c57fc5693cafe745ea8b06dba75/cryptography-48.0.0-pp311-pypy311_pp73-manylinux_2_28_aarch64.whl", hash = "sha256:fdfef35d751d510fcef5252703621574364fec16418c4a1e5e1055248401054b", size = 4637126, upload-time = "2026-05-04T22:59:20.197Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/0a/7e226dbff530f21480727eb764973a7bff2b912f8e15cd4f129e71b56d1d/cryptography-48.0.0-pp311-pypy311_pp73-manylinux_2_28_x86_64.whl", hash = "sha256:0890f502ddf7d9c6426129c3f49f5c0a39278ed7cd6322c8755ffca6ee675a13", size = 4667270, upload-time = "2026-05-04T22:59:22.647Z" },
+    { url = "https://files.pythonhosted.org/packages/3b/f2/5a72274ca9f1b2a8b44a662ee0bf1b435909deb473d6f97bcd035bcdbc71/cryptography-48.0.0-pp311-pypy311_pp73-manylinux_2_34_aarch64.whl", hash = "sha256:ecde28a596bead48b0cfd2a1b4416c3d43074c2d785e3a398d7ec1fc4d0f7fbb", size = 4636797, upload-time = "2026-05-04T22:59:24.912Z" },
+    { url = "https://files.pythonhosted.org/packages/b4/e1/48cedb2fe63626e91ded1edad159e2a4fb8b6906c4425eb7749673077ce7/cryptography-48.0.0-pp311-pypy311_pp73-manylinux_2_34_x86_64.whl", hash = "sha256:4defde8685ae324a9eb9d818717e93b4638ef67070ac9bc15b8ca85f63048355", size = 4666800, upload-time = "2026-05-04T22:59:27.474Z" },
+    { url = "https://files.pythonhosted.org/packages/a2/ca/7e8365deec19afb2b2c7be7c1c0aa8f99633b54e90c570999acda93260fc/cryptography-48.0.0-pp311-pypy311_pp73-win_amd64.whl", hash = "sha256:db63bf618e5dea46c07de12e900fe1cdd2541e6dc9dbae772a70b7d4d4765f6a", size = 3739536, upload-time = "2026-05-04T22:59:29.61Z" },
+]
+
+[[package]]
 name = "frozenlist"
 version = "1.8.0"
 source = { registry = "https://pypi.org/simple" }
@@ -533,6 +662,7 @@ source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },
     { name = "jinja2" },
+    { name = "pyjwt", extra = ["crypto"] },
     { name = "pyyaml" },
 ]
 
@@ -551,6 +681,7 @@ requires-dist = [
     { name = "aiohttp", specifier = ">=3.9" },
     { name = "jinja2", specifier = ">=3.1" },
     { name = "playwright", marker = "extra == 'dev'", specifier = ">=1.40" },
+    { name = "pyjwt", extras = ["crypto"], specifier = ">=2.8" },
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=8.0" },
     { name = "pytest-aiohttp", marker = "extra == 'dev'", specifier = ">=1.0" },
     { name = "pytest-asyncio", marker = "extra == 'dev'", specifier = ">=0.23" },
@@ -900,6 +1031,15 @@ wheels = [
 ]
 
 [[package]]
+name = "pycparser"
+version = "3.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/1b/7d/92392ff7815c21062bea51aa7b87d45576f649f16458d78b7cf94b9ab2e6/pycparser-3.0.tar.gz", hash = "sha256:600f49d217304a5902ac3c37e1281c9fe94e4d0489de643a9504c5cdfdfc6b29", size = 103492, upload-time = "2026-01-21T14:26:51.89Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0c/c3/44f3fbbfa403ea2a7c779186dc20772604442dde72947e7d01069cbe98e3/pycparser-3.0-py3-none-any.whl", hash = "sha256:b727414169a36b7d524c1c3e31839a521725078d7b2ff038656844266160a992", size = 48172, upload-time = "2026-01-21T14:26:50.693Z" },
+]
+
+[[package]]
 name = "pyee"
 version = "13.0.1"
 source = { registry = "https://pypi.org/simple" }
@@ -918,6 +1058,20 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/c3/b2/bc9c9196916376152d655522fdcebac55e66de6603a76a02bca1b6414f6c/pygments-2.20.0.tar.gz", hash = "sha256:6757cd03768053ff99f3039c1a36d6c0aa0b263438fcab17520b30a303a82b5f", size = 4955991, upload-time = "2026-03-29T13:29:33.898Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/f4/7e/a72dd26f3b0f4f2bf1dd8923c85f7ceb43172af56d63c7383eb62b332364/pygments-2.20.0-py3-none-any.whl", hash = "sha256:81a9e26dd42fd28a23a2d169d86d7ac03b46e2f8b59ed4698fb4785f946d0176", size = 1231151, upload-time = "2026-03-29T13:29:30.038Z" },
+]
+
+[[package]]
+name = "pyjwt"
+version = "2.12.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/c2/27/a3b6e5bf6ff856d2509292e95c8f57f0df7017cf5394921fc4e4ef40308a/pyjwt-2.12.1.tar.gz", hash = "sha256:c74a7a2adf861c04d002db713dd85f84beb242228e671280bf709d765b03672b", size = 102564, upload-time = "2026-03-13T19:27:37.25Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e5/7a/8dd906bd22e79e47397a61742927f6747fe93242ef86645ee9092e610244/pyjwt-2.12.1-py3-none-any.whl", hash = "sha256:28ca37c070cad8ba8cd9790cd940535d40274d22f80ab87f3ac6a713e6e8454c", size = 29726, upload-time = "2026-03-13T19:27:35.677Z" },
+]
+
+[package.optional-dependencies]
+crypto = [
+    { name = "cryptography" },
 ]
 
 [[package]]


### PR DESCRIPTION
First PR in the [Cloudflare Access deployment plan](docs/superpowers/plans/2026-05-07-remote-connect-cloudflare-access.md) (issue #26). **No behavior change to `serve` in this PR — pure foundation.**

## Summary

- Adds `pyjwt[crypto]` dependency (used in Phase 3) and a `cloudflare` pytest marker (excluded by default).
- Adds `irc_lens.config.LensConfig` (frozen dataclass) and `load_config()` — YAML loader with schema validation that raises `AfiError` with proper `error:`/`hint:` shape; ports are coerced via `_coerce_port` with a useful error on garbage input.
- Adds `irc-lens config init` and `irc-lens config overview` verbs. `init` writes a starter dev-mode config to `~/.config/irc-lens/config.yaml` (XDG_CONFIG_HOME respected); `--force` overwrites; `OSError`s are wrapped as `EXIT_ENV_ERROR`.
- Wires the `config` noun into the existing `irc-lens overview` rubric.

## Spec / plan reference

- Spec: `docs/superpowers/specs/2026-05-06-remote-connect-cloudflare-access-design.md`
- Plan: `docs/superpowers/plans/2026-05-07-remote-connect-cloudflare-access.md` (Phase 1 = T1.1–T1.6)

## Test plan

- [x] `uv run pytest -x` — 257 passed, 4 deselected (playwright/cloudflare).
- [x] `uv run irc-lens config init --path /tmp/x.yaml` — writes starter; `--force` overwrites; missing-permission case fails closed with code 2 + hint.
- [x] `uv run irc-lens config init` (existing file, no `--force`) — exits 1 with `error: config already exists at <path>` + `hint: pass --force to overwrite, or pick a different --path`.
- [x] `uv run irc-lens overview` lists both `cli` and `config` nouns.
- [x] `uv run irc-lens overview --json | python -m json.tool` — parseable.
- [x] `uv run irc-lens overview config` — drills into config noun's section.
- [x] Code-quality review by sonnet on full Phase 1 diff — flagged two error-path gaps (port coercion, mkdir/write_text), both fixed in commit 2bf850c.

## Follow-ups

Phases 2–5 of the plan, each as their own PR:
- Phase 2: per-user Session registry under dev mode
- Phase 3: CF auth middleware + JWT verification
- Phase 4: CLI/HTTP cleanups (\`--nick\`/\`--bind\`/\`/healthz\`/Origin floor)
- Phase 5: docs + CF round-trip scripts + real round-trip test

🤖 Generated with [Claude Code](https://claude.com/claude-code)