### PR TITLE
ci: SonarCloud GitHub Action (replace broken auto-analysis)

### DIFF
--- a/.github/workflows/sonar.yml
+++ b/.github/workflows/sonar.yml
@@ -37,7 +37,7 @@ jobs:
           fetch-depth: 0
 
       - name: SonarCloud Scan
-        uses: SonarSource/sonarcloud-github-action@v3
+        uses: SonarSource/sonarcloud-github-action@ffc3010689be73b8e5ae0c57ce35968afd7909e8  # v5.0.0
         env:
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/sonar.yml
+++ b/.github/workflows/sonar.yml
@@ -1,0 +1,43 @@
+# SonarCloud Code Analysis — CI-based.
+#
+# Replaces SonarCloud's automatic-analysis path, which silently stopped
+# decorating PRs after #29 (only main-branch refresh tasks fire,
+# tagged "Anonymous", ~2-3s; PR diffs are skipped). CI-based scanning
+# is the SonarCloud-recommended fallback when auto-analysis breaks.
+#
+# Required repo secret:
+#   SONAR_TOKEN  — generated at sonarcloud.io → My Account → Security.
+#
+# Job is gated on the secret being present so contributor PRs without
+# access to the secret skip cleanly instead of hard-failing the check.
+
+name: SonarCloud
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+    types: [opened, synchronize, reopened]
+
+jobs:
+  sonarcloud:
+    name: SonarCloud Code Analysis
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: read
+    if: ${{ github.event.pull_request.head.repo.full_name == github.repository || github.event_name == 'push' }}
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
+        with:
+          # Full history is required for accurate blame and PR-diff
+          # baselines. The default shallow clone makes Sonar miss
+          # most "new code" attribution.
+          fetch-depth: 0
+
+      - name: SonarCloud Scan
+        uses: SonarSource/sonarcloud-github-action@v3
+        env:
+          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,0 +1,26 @@
+# SonarCloud project configuration.
+#
+# Project key + organization are also set in the SonarCloud dashboard;
+# these properties make the scanner discover them locally without an
+# extra CLI flag.
+#
+# Auto-analysis stopped firing on PRs after PR #29 (project switched to
+# CI-based scanning silently). The CI workflow at
+# .github/workflows/sonar.yml replaces auto-analysis as the canonical
+# trigger; this file declares what the scanner sees.
+
+sonar.projectKey=agentculture_irc-lens
+sonar.organization=agentculture
+
+sonar.sources=src
+sonar.tests=tests
+
+# Match what we ship in pyproject.toml (Python 3.11, 3.12, 3.13).
+sonar.python.version=3.11,3.12,3.13
+
+# Generated/cached/asset paths the scanner should ignore.
+sonar.exclusions=**/__pycache__/**,uv.lock,**/*.j2,**/*.html,docs/**,.afi/**,src/irc_lens/static/vendor/**
+
+# Test fixtures aren't production code; keep them out of the test
+# coverage / duplication baselines.
+sonar.test.exclusions=tests/fixtures/**,tests/_agentirc_server.py


### PR DESCRIPTION
SonarCloud's automatic-analysis path silently stopped decorating PRs after #29 — only main-branch refresh tasks fire ("By Anonymous", ~2–3 s, PR diffs skipped). The project page on sonarcloud.io still recognises new PRs, but \`measures\` for them are always empty. Auto-analysis was likely auto-disabled when SonarCloud detected (or thought it detected) a CI scan attempt, and the lockout doesn't surface in the UI.

CI-based scanning is the SonarCloud-recommended fallback when auto-analysis breaks at the project level. This PR replaces it.

## Changes

- \`.github/workflows/sonar.yml\` — runs on PRs and main pushes via the official \`SonarSource/sonarcloud-github-action@v3\`. Uses \`fetch-depth: 0\` so blame and PR-diff attribution work. Gated on same-repo PR origin so fork PRs skip cleanly.
- \`sonar-project.properties\` — declares \`projectKey\` (\`agentculture_irc-lens\`), \`organization\` (\`agentculture\`), source roots (\`src/\` and \`tests/\`), Python 3.11–3.13, plus exclusions for \`__pycache__\`, \`uv.lock\`, Jinja2 templates, docs, \`.afi/\`, and vendored static assets.

## Required action before this PR's CI passes

Add a repo secret \`SONAR_TOKEN\`:
1. sonarcloud.io → top-right avatar → **My Account** → **Security**.
2. Generate a token (any name; pick "User Token" type).
3. GitHub → repo **Settings** → **Secrets and variables** → **Actions** → **New repository secret** → name \`SONAR_TOKEN\`, paste the value.

Once the secret is in place, push any commit to retrigger CI. The Sonar job should turn green and a quality-gate comment should appear on every future PR (including, after rebase, #31 — the Phase 2 PR).

## Test plan

- [ ] \`SONAR_TOKEN\` added on GitHub.
- [ ] CI on this PR shows a green \`SonarCloud Code Analysis\` check.
- [ ] SonarCloud comment lands on the PR with \`new_lines\` populated (proves PR decoration works again).
- [ ] After merge, rebase #31 on top of main; confirm Sonar runs and decorates that PR.
- [ ] Existing checks (\`test\`, \`playwright\`, \`test-publish\`, GitGuardian) keep passing.

## Follow-ups

- Phase 2 PR (#31) gets Sonar coverage on next rebase.
- Once stable, consider pinning \`SonarSource/sonarcloud-github-action\` to a SHA (matching the convention in \`ci.yml\`'s \`actions/checkout\` and \`astral-sh/setup-uv\` pins).
- If contributor PRs from forks ever become a thing, revisit the same-repo gating and Sonar's recommended fork-handling pattern.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

- Claude