### PR TITLE
Phase 3: Cloudflare Access JWT middleware + JWKS cache

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -61,4 +61,5 @@ addopts = "-m 'not playwright and not cloudflare'"
 markers = [
     "playwright: opt-in browser end-to-end tests (requires `playwright install chromium`).",
     "cloudflare: opt-in real-Cloudflare round-trip tests (requires CF_API_TOKEN and friends).",
+    "slow: tests with intentional sleeps (kept in default suite — labels only).",
 ]

--- a/src/irc_lens/cli/_commands/serve.py
+++ b/src/irc_lens/cli/_commands/serve.py
@@ -144,10 +144,28 @@ def _resolve_config(args: argparse.Namespace) -> LensConfig:
     to the synthetic dev config from CLI args.
 
     Phase 4 (T4.4) removes the fallback so the file becomes required.
+
+    If the user *explicitly* passes ``--config <path>``, the path must
+    exist — silently dropping to the synthetic dev config on a missed
+    typo would risk starting an unauthenticated server when the user
+    intended a CF-mode deploy. The fallback only applies when no
+    ``--config`` was passed AND the default location is empty.
     """
-    config_path = Path(args.config) if args.config else default_config_path()
-    if config_path.exists():
-        return load_config(config_path)
+    if args.config:
+        explicit = Path(args.config)
+        if not explicit.exists():
+            raise AfiError(
+                code=EXIT_USER_ERROR,
+                message=f"--config {args.config!r} does not exist",
+                remediation=(
+                    "fix the path, or run `irc-lens config init "
+                    f"--path {args.config}` to drop a starter config there"
+                ),
+            )
+        return load_config(explicit)
+    default = default_config_path()
+    if default.exists():
+        return load_config(default)
     return _build_dev_config_from_args(args)
 
 
@@ -243,16 +261,29 @@ async def _build_app(
         # (config.dev_email) resolves immediately without re-connecting.
         app["registry"].register(config.dev_email, session)
         return app, session
-    # cloudflare-access mode — no session at startup.
-    await _warm_cf_or_raise(config)
+    if config.auth_mode == "cloudflare-access":
+        # No session at startup — per-user sessions open lazily on
+        # first authenticated request.
+        await _warm_cf_or_raise(config)
 
-    def cf_factory(nick: str) -> Session:
-        return Session(host=config.server_host, port=config.server_port, nick=nick)
+        def cf_factory(nick: str) -> Session:
+            return Session(
+                host=config.server_host, port=config.server_port, nick=nick
+            )
 
-    app = make_app(config, cf_factory)
-    # No pre-seed; --nick / --seed / --icon are ignored (Phase 4
-    # T4.1 will reject --nick with a hard error in CF mode).
-    return app, None
+        app = make_app(config, cf_factory)
+        # No pre-seed; --nick / --seed / --icon are ignored (Phase 4
+        # T4.1 will reject --nick with a hard error in CF mode).
+        return app, None
+    # Future-mode guard: load_config only allows "dev" or
+    # "cloudflare-access", but a caller bypassing load_config (or a
+    # future mode added without updating this branch) lands here. Fail
+    # loud rather than silently routing through the CF path.
+    raise AfiError(
+        code=EXIT_USER_ERROR,
+        message=f"unsupported auth.mode={config.auth_mode!r}",
+        remediation="set `auth.mode:` to either `dev` or `cloudflare-access`",
+    )
 
 
 async def _bind_site_or_raise(

--- a/src/irc_lens/cli/_commands/serve.py
+++ b/src/irc_lens/cli/_commands/serve.py
@@ -46,7 +46,7 @@ from irc_lens.config import LensConfig, default_config_path, load_config
 from irc_lens.session import LensConnectionLost, Session
 from irc_lens.web import make_app
 from irc_lens.web.auth import warm_jwks
-from irc_lens.web.sessions import disconnect_all
+from irc_lens.web.sessions import SessionFactory, disconnect_all
 
 # `irc_lens.seed` is imported function-locally inside `_serve_async`
 # to avoid a real-but-latent module-load cycle:
@@ -139,126 +139,137 @@ def _build_dev_config_from_args(args: argparse.Namespace) -> LensConfig:
     )
 
 
-async def _serve_async(args: argparse.Namespace) -> None:
-    """Run connect → bind → forever inside one event loop.
+def _resolve_config(args: argparse.Namespace) -> LensConfig:
+    """Load a LensConfig from `--config` / default path, or fall back
+    to the synthetic dev config from CLI args.
 
-    Doing the IRC connect in a separate ``asyncio.run`` would create
-    background read tasks tied to a loop that exits before
-    ``aiohttp.web.run_app`` starts — the IRC connection would die
-    before the web UI ever serves a request. This coroutine keeps
-    everything on one loop until shutdown.
+    Phase 4 (T4.4) removes the fallback so the file becomes required.
     """
-    # ------------------------------------------------------------------
-    # 1. Determine the config
-    # ------------------------------------------------------------------
     config_path = Path(args.config) if args.config else default_config_path()
     if config_path.exists():
-        config = load_config(config_path)
-    else:
-        # Backward-compat: build synthetic dev config from CLI args.
-        # Phase 4 (T4.4) will remove this fallback.
-        config = _build_dev_config_from_args(args)
+        return load_config(config_path)
+    return _build_dev_config_from_args(args)
 
-    # ------------------------------------------------------------------
-    # 2. Branch on auth.mode
-    # ------------------------------------------------------------------
-    if config.auth_mode == "dev":
-        session = Session(
-            host=config.server_host,
-            port=config.server_port,
-            nick=config.dev_nick,
-            icon=args.icon,
-        )
+
+async def _connect_dev_session(args: argparse.Namespace, config: LensConfig) -> Session:
+    """Open the dev-mode IRC session: connect → wait_for_welcome → seed.
+
+    Translates `LensConnectionLost` into the canonical `AfiError`
+    pair (host/port unreachable vs. nick rejected) and propagates
+    `apply_seed`'s errors after disconnecting cleanly.
+    """
+    session = Session(
+        host=config.server_host,
+        port=config.server_port,
+        nick=config.dev_nick,
+        icon=args.icon,
+    )
+    try:
+        await session.connect()
+    except LensConnectionLost as exc:
+        raise AfiError(
+            code=EXIT_USER_ERROR,
+            message=f"cannot reach AgentIRC at {config.server_host}:{config.server_port}: {exc}",
+            remediation=(
+                "verify the AgentIRC server is running and reachable, then "
+                "retry. e.g. `culture server start --name local && culture "
+                "server status local`"
+            ),
+        ) from exc
+    # Block until 001 RPL_WELCOME (or 432/433 rejection). AgentIRC
+    # enforces a server-name prefix on nicks (e.g. `spark-`); without
+    # this gate a rejected nick produces a silently broken session
+    # where every query times out at 10 s and the chat pane stays empty.
+    try:
+        await session.wait_for_welcome()
+    except LensConnectionLost as exc:
+        await session.disconnect()
+        raise AfiError(
+            code=EXIT_USER_ERROR,
+            message=f"AgentIRC registration failed: {exc}",
+            remediation=(
+                "AgentIRC enforces a server-name prefix on nicks (e.g. "
+                "`spark-foo` for a server named `spark`). Pass a nick "
+                "matching that prefix via --nick, or check the server's "
+                "config for the expected prefix."
+            ),
+        ) from exc
+    if args.seed:
+        # apply_seed raises AfiError on shape errors which the dispatcher
+        # renders as `error:` + `hint:`. Broad except so connection
+        # cleanup runs on every failure path — leaking a connected IRC
+        # session past process exit would orphan state in the AgentIRC
+        # server. BaseException (KeyboardInterrupt, SystemExit) still
+        # propagates untouched. Function-local import to keep the same
+        # cycle break documented at the module top.
         try:
-            await session.connect()
-        except LensConnectionLost as exc:
-            raise AfiError(
-                code=EXIT_USER_ERROR,
-                message=f"cannot reach AgentIRC at {config.server_host}:{config.server_port}: {exc}",
-                remediation=(
-                    "verify the AgentIRC server is running and reachable, then "
-                    "retry. e.g. `culture server start --name local && culture "
-                    "server status local`"
-                ),
-            ) from exc
-        # Block until 001 RPL_WELCOME (or 432/433 rejection). AgentIRC
-        # enforces a server-name prefix on nicks (e.g. `spark-`); without
-        # this gate a rejected nick produces a silently broken session
-        # where every query times out at 10s and the chat pane stays empty.
-        try:
-            await session.wait_for_welcome()
-        except LensConnectionLost as exc:
+            from irc_lens.seed import apply_seed
+            apply_seed(session, Path(args.seed))
+        except Exception:
             await session.disconnect()
-            raise AfiError(
-                code=EXIT_USER_ERROR,
-                message=f"AgentIRC registration failed: {exc}",
-                remediation=(
-                    "AgentIRC enforces a server-name prefix on nicks (e.g. "
-                    "`spark-foo` for a server named `spark`). Pass a nick "
-                    "matching that prefix via --nick, or check the server's "
-                    "config for the expected prefix."
-                ),
-            ) from exc
+            raise
+    return session
 
-        if args.seed:
-            # Spec line 261: connection is real; seed only overlays UI
-            # state. apply_seed raises AfiError on shape errors which the
-            # dispatcher renders as `error:` + `hint:`. Broad except so
-            # connection cleanup runs on every failure path — leaking a
-            # connected IRC session past process exit would orphan state
-            # in the AgentIRC server. BaseException (KeyboardInterrupt,
-            # SystemExit) still propagates untouched. The function-local
-            # import lives INSIDE the try so an import-time failure on
-            # `irc_lens.seed` (or any module it loads) also triggers the
-            # disconnect cleanup branch.
-            try:
-                from irc_lens.seed import apply_seed  # see module top comment
 
-                apply_seed(session, Path(args.seed))
-            except Exception:
-                await session.disconnect()
-                raise
+async def _warm_cf_or_raise(config: LensConfig) -> None:
+    """Pre-flight the Cloudflare JWKS endpoint. Fail-fast at startup
+    so a misconfigured CF deploy can't bind a port that returns 502
+    on every request."""
+    try:
+        await warm_jwks(config)
+    except Exception as exc:
+        raise AfiError(
+            code=EXIT_ENV_ERROR,
+            message=f"could not reach Cloudflare JWKS at {config.cf_team_domain}: {exc}",
+            remediation="verify network egress and team_domain spelling",
+        ) from exc
 
-        # Factory creates sessions for new principals; the already-connected
-        # CLI session is pre-seeded into the registry below (avoids re-connecting).
-        factory = lambda _nick: session  # noqa: E731
+
+async def _build_app(
+    args: argparse.Namespace, config: LensConfig
+) -> tuple[web.Application, Session | None]:
+    """Construct the aiohttp Application for the active auth mode.
+
+    Returns the app plus, in dev mode, the pre-seeded `Session` (so
+    the bind-failure path can clean it up). CF mode returns `None`
+    for the session: per-user sessions open lazily on first
+    authenticated request.
+    """
+    if config.auth_mode == "dev":
+        session = await _connect_dev_session(args, config)
+        factory: SessionFactory = lambda _nick: session  # noqa: E731
         app = make_app(config, factory)
-        # Pre-seed the registry with the already-connected session so the
-        # dev-mode middleware's fixed identity (dev_email) resolves it
-        # immediately on the first request without calling connect() twice.
+        # Pre-seed so the dev-mode middleware's fixed identity
+        # (config.dev_email) resolves immediately without re-connecting.
         app["registry"].register(config.dev_email, session)
-    else:
-        # cloudflare-access mode: do NOT open an IRC session at startup.
-        # Warm the JWKS endpoint; fail-fast with EXIT_ENV_ERROR if unreachable.
-        try:
-            await warm_jwks(config)
-        except Exception as exc:
-            raise AfiError(
-                code=EXIT_ENV_ERROR,
-                message=f"could not reach Cloudflare JWKS at {config.cf_team_domain}: {exc}",
-                remediation="verify network egress and team_domain spelling",
-            ) from exc
+        return app, session
+    # cloudflare-access mode — no session at startup.
+    await _warm_cf_or_raise(config)
 
-        def factory(nick: str) -> Session:
-            return Session(host=config.server_host, port=config.server_port, nick=nick)
+    def cf_factory(nick: str) -> Session:
+        return Session(host=config.server_host, port=config.server_port, nick=nick)
 
-        app = make_app(config, factory)
-        # Do NOT pre-seed the registry — first authenticated request per
-        # principal triggers the per-user get_or_open lazily.
-        # --nick / --seed / --icon are ignored in CF mode (Phase 4 T4.1
-        # will reject --nick with a hard error).
+    app = make_app(config, cf_factory)
+    # No pre-seed; --nick / --seed / --icon are ignored (Phase 4
+    # T4.1 will reject --nick with a hard error in CF mode).
+    return app, None
 
-    # ------------------------------------------------------------------
-    # 3. AppRunner setup, site bind, sleep, cleanup (shared by both modes)
-    # ------------------------------------------------------------------
-    runner = web.AppRunner(app, handle_signals=True)
-    await runner.setup()
+
+async def _bind_site_or_raise(
+    runner: web.AppRunner, config: LensConfig, dev_session: Session | None
+) -> None:
+    """Start the TCPSite or raise `AfiError(EXIT_ENV_ERROR)`.
+
+    On `OSError` (port in use, etc.), tear down the runner AND any
+    dev-mode session that's already connected, so the process doesn't
+    exit holding open fds.
+    """
     site = web.TCPSite(runner, host=config.web_bind, port=config.web_port)
     try:
         await site.start()
     except OSError as exc:
-        if config.auth_mode == "dev":
-            await session.disconnect()
+        if dev_session is not None:
+            await dev_session.disconnect()
         await runner.cleanup()
         raise AfiError(
             code=EXIT_ENV_ERROR,
@@ -269,22 +280,41 @@ async def _serve_async(args: argparse.Namespace) -> None:
             ),
         ) from exc
 
+
+def _maybe_open_browser(args: argparse.Namespace, url: str) -> None:
+    if not args.open:
+        return
+    try:
+        webbrowser.open(url)
+    except webbrowser.Error as exc:
+        emit_diagnostic(f"warning: --open failed: {exc}")
+
+
+async def _serve_async(args: argparse.Namespace) -> None:
+    """Run connect → bind → forever inside one event loop.
+
+    Doing the IRC connect in a separate ``asyncio.run`` would create
+    background read tasks tied to a loop that exits before
+    ``aiohttp.web.run_app`` starts — the IRC connection would die
+    before the web UI ever serves a request. This coroutine keeps
+    everything on one loop until shutdown.
+    """
+    config = _resolve_config(args)
+    app, dev_session = await _build_app(args, config)
+    runner = web.AppRunner(app, handle_signals=True)
+    await runner.setup()
+    await _bind_site_or_raise(runner, config, dev_session)
     url = _display_url(config.web_bind, config.web_port)
     emit_diagnostic(f"irc-lens serving on {url}")
-    if args.open:
-        try:
-            webbrowser.open(url)
-        except webbrowser.Error as exc:
-            emit_diagnostic(f"warning: --open failed: {exc}")
-
+    _maybe_open_browser(args, url)
     # Sleep forever until the runtime cancels us (SIGINT / SIGTERM via
-    # AppRunner.handle_signals=True, or the test harness cancelling the
-    # task).
+    # AppRunner.handle_signals=True, or the test harness cancelling
+    # the task).
     try:
         await asyncio.Event().wait()
     finally:
-        # Disconnect every registered Session (covers dev pre-seeded session
-        # and any lazily-opened per-user CF sessions alike).
+        # Disconnect every registered Session (covers dev pre-seeded
+        # session and any lazily-opened per-user CF sessions alike).
         # return_exceptions=True so one failure doesn't strand the others.
         await disconnect_all(app["registry"])
         await runner.cleanup()

--- a/src/irc_lens/cli/_commands/serve.py
+++ b/src/irc_lens/cli/_commands/serve.py
@@ -1,9 +1,16 @@
 """``irc-lens serve`` — launch the aiohttp web console.
 
-Phase 4 ships the skeleton: parse flags, construct ``Session``,
-fail-fast on connect, then ``aiohttp.web.run_app``. The Phase 5 wiring
-(SSE bus, parser dispatch on POST /input) is invisible from here —
-``make_app`` just gets a richer Session.
+Loads a ``LensConfig`` from ``--config`` (or ``default_config_path()`` if
+it exists). When no config file is found, falls back to building a synthetic
+dev ``LensConfig`` from the CLI args — this preserves backward compatibility
+with the existing ``irc-lens serve --nick lens`` invocation. Phase 4 (T4.4)
+makes the config file required.
+
+In ``auth.mode: dev``, opens one Session at startup against the configured
+AgentIRC and pre-seeds the registry. In ``auth.mode: cloudflare-access``,
+warms the JWKS endpoint at startup (fail-fast on unreachable Cloudflare →
+``EXIT_ENV_ERROR``) and lazy-opens per-user Sessions on first authenticated
+request.
 
 Spec contract enforced:
 
@@ -35,9 +42,10 @@ from aiohttp import web
 
 from irc_lens.cli._errors import EXIT_ENV_ERROR, EXIT_USER_ERROR, AfiError
 from irc_lens.cli._output import emit_diagnostic
-from irc_lens.config import LensConfig
+from irc_lens.config import LensConfig, default_config_path, load_config
 from irc_lens.session import LensConnectionLost, Session
 from irc_lens.web import make_app
+from irc_lens.web.auth import warm_jwks
 from irc_lens.web.sessions import disconnect_all
 
 # `irc_lens.seed` is imported function-locally inside `_serve_async`
@@ -103,72 +111,19 @@ def _display_url(bind: str, port: int) -> str:
     return f"http://{host}:{port}/"
 
 
-async def _serve_async(args: argparse.Namespace) -> None:
-    """Run connect → bind → forever inside one event loop.
+def _build_dev_config_from_args(args: argparse.Namespace) -> LensConfig:
+    """Build a synthetic dev-mode ``LensConfig`` from the CLI arguments.
 
-    Doing the IRC connect in a separate ``asyncio.run`` would create
-    background read tasks tied to a loop that exits before
-    ``aiohttp.web.run_app`` starts — the IRC connection would die
-    before the web UI ever serves a request. This coroutine keeps
-    everything on one loop until shutdown.
+    This is the Phase-3 backward-compatibility fallback: when no config file
+    is found at ``--config`` (or ``default_config_path()``), the serve command
+    constructs a minimal ``LensConfig`` from the legacy ``--host``, ``--port``,
+    ``--nick``, ``--bind``, and ``--web-port`` flags so that the existing
+    ``irc-lens serve --nick lens`` invocation keeps working without a config
+    file. Phase 4 (T4.4) removes this fallback and makes ``--config`` (or the
+    default path) required.
     """
-    session = Session(host=args.host, port=args.port, nick=args.nick, icon=args.icon)
-    try:
-        await session.connect()
-    except LensConnectionLost as exc:
-        raise AfiError(
-            code=EXIT_USER_ERROR,
-            message=f"cannot reach AgentIRC at {args.host}:{args.port}: {exc}",
-            remediation=(
-                "verify the AgentIRC server is running and reachable, then "
-                "retry. e.g. `culture server start --name local && culture "
-                "server status local`"
-            ),
-        ) from exc
-    # Block until 001 RPL_WELCOME (or 432/433 rejection). AgentIRC
-    # enforces a server-name prefix on nicks (e.g. `spark-`); without
-    # this gate a rejected nick produces a silently broken session
-    # where every query times out at 10s and the chat pane stays empty.
-    try:
-        await session.wait_for_welcome()
-    except LensConnectionLost as exc:
-        await session.disconnect()
-        raise AfiError(
-            code=EXIT_USER_ERROR,
-            message=f"AgentIRC registration failed: {exc}",
-            remediation=(
-                "AgentIRC enforces a server-name prefix on nicks (e.g. "
-                "`spark-foo` for a server named `spark`). Pass a nick "
-                "matching that prefix via --nick, or check the server's "
-                "config for the expected prefix."
-            ),
-        ) from exc
-
-    if args.seed:
-        # Spec line 261: connection is real; seed only overlays UI
-        # state. apply_seed raises AfiError on shape errors which the
-        # dispatcher renders as `error:` + `hint:`. Broad except so
-        # connection cleanup runs on every failure path — leaking a
-        # connected IRC session past process exit would orphan state
-        # in the AgentIRC server. BaseException (KeyboardInterrupt,
-        # SystemExit) still propagates untouched. The function-local
-        # import lives INSIDE the try so an import-time failure on
-        # `irc_lens.seed` (or any module it loads) also triggers the
-        # disconnect cleanup branch.
-        try:
-            from irc_lens.seed import apply_seed  # see module top comment
-
-            apply_seed(session, Path(args.seed))
-        except Exception:
-            await session.disconnect()
-            raise
-
-    # Build a dev-mode LensConfig from the CLI args so make_app gets
-    # the full Phase 2 signature. serve.py doesn't load a config file
-    # yet (Phase 4/5 will add --config support); construct the minimum
-    # viable LensConfig here so the factory wiring works today.
     dev_email = f"{args.nick}@local"
-    config = LensConfig(
+    return LensConfig(
         auth_mode="dev",
         dev_nick=args.nick,
         dev_email=dev_email,
@@ -182,31 +137,139 @@ async def _serve_async(args: argparse.Namespace) -> None:
         web_bind=args.bind,
         web_port=args.web_port,
     )
-    # Factory creates sessions for new principals; the already-connected
-    # CLI session is pre-seeded into the registry below (avoids re-connecting).
-    app = make_app(config, lambda nick: Session(host=args.host, port=args.port, nick=nick))
-    # Pre-seed the registry with the already-connected session so the
-    # dev-mode middleware's fixed identity (dev_email) resolves it
-    # immediately on the first request without calling connect() twice.
-    app["registry"].register(dev_email, session)
+
+
+async def _serve_async(args: argparse.Namespace) -> None:
+    """Run connect → bind → forever inside one event loop.
+
+    Doing the IRC connect in a separate ``asyncio.run`` would create
+    background read tasks tied to a loop that exits before
+    ``aiohttp.web.run_app`` starts — the IRC connection would die
+    before the web UI ever serves a request. This coroutine keeps
+    everything on one loop until shutdown.
+    """
+    # ------------------------------------------------------------------
+    # 1. Determine the config
+    # ------------------------------------------------------------------
+    config_path = Path(args.config) if args.config else default_config_path()
+    if config_path.exists():
+        config = load_config(config_path)
+    else:
+        # Backward-compat: build synthetic dev config from CLI args.
+        # Phase 4 (T4.4) will remove this fallback.
+        config = _build_dev_config_from_args(args)
+
+    # ------------------------------------------------------------------
+    # 2. Branch on auth.mode
+    # ------------------------------------------------------------------
+    if config.auth_mode == "dev":
+        session = Session(
+            host=config.server_host,
+            port=config.server_port,
+            nick=config.dev_nick,
+            icon=args.icon,
+        )
+        try:
+            await session.connect()
+        except LensConnectionLost as exc:
+            raise AfiError(
+                code=EXIT_USER_ERROR,
+                message=f"cannot reach AgentIRC at {config.server_host}:{config.server_port}: {exc}",
+                remediation=(
+                    "verify the AgentIRC server is running and reachable, then "
+                    "retry. e.g. `culture server start --name local && culture "
+                    "server status local`"
+                ),
+            ) from exc
+        # Block until 001 RPL_WELCOME (or 432/433 rejection). AgentIRC
+        # enforces a server-name prefix on nicks (e.g. `spark-`); without
+        # this gate a rejected nick produces a silently broken session
+        # where every query times out at 10s and the chat pane stays empty.
+        try:
+            await session.wait_for_welcome()
+        except LensConnectionLost as exc:
+            await session.disconnect()
+            raise AfiError(
+                code=EXIT_USER_ERROR,
+                message=f"AgentIRC registration failed: {exc}",
+                remediation=(
+                    "AgentIRC enforces a server-name prefix on nicks (e.g. "
+                    "`spark-foo` for a server named `spark`). Pass a nick "
+                    "matching that prefix via --nick, or check the server's "
+                    "config for the expected prefix."
+                ),
+            ) from exc
+
+        if args.seed:
+            # Spec line 261: connection is real; seed only overlays UI
+            # state. apply_seed raises AfiError on shape errors which the
+            # dispatcher renders as `error:` + `hint:`. Broad except so
+            # connection cleanup runs on every failure path — leaking a
+            # connected IRC session past process exit would orphan state
+            # in the AgentIRC server. BaseException (KeyboardInterrupt,
+            # SystemExit) still propagates untouched. The function-local
+            # import lives INSIDE the try so an import-time failure on
+            # `irc_lens.seed` (or any module it loads) also triggers the
+            # disconnect cleanup branch.
+            try:
+                from irc_lens.seed import apply_seed  # see module top comment
+
+                apply_seed(session, Path(args.seed))
+            except Exception:
+                await session.disconnect()
+                raise
+
+        # Factory creates sessions for new principals; the already-connected
+        # CLI session is pre-seeded into the registry below (avoids re-connecting).
+        factory = lambda _nick: session  # noqa: E731
+        app = make_app(config, factory)
+        # Pre-seed the registry with the already-connected session so the
+        # dev-mode middleware's fixed identity (dev_email) resolves it
+        # immediately on the first request without calling connect() twice.
+        app["registry"].register(config.dev_email, session)
+    else:
+        # cloudflare-access mode: do NOT open an IRC session at startup.
+        # Warm the JWKS endpoint; fail-fast with EXIT_ENV_ERROR if unreachable.
+        try:
+            await warm_jwks(config)
+        except Exception as exc:
+            raise AfiError(
+                code=EXIT_ENV_ERROR,
+                message=f"could not reach Cloudflare JWKS at {config.cf_team_domain}: {exc}",
+                remediation="verify network egress and team_domain spelling",
+            ) from exc
+
+        def factory(nick: str) -> Session:
+            return Session(host=config.server_host, port=config.server_port, nick=nick)
+
+        app = make_app(config, factory)
+        # Do NOT pre-seed the registry — first authenticated request per
+        # principal triggers the per-user get_or_open lazily.
+        # --nick / --seed / --icon are ignored in CF mode (Phase 4 T4.1
+        # will reject --nick with a hard error).
+
+    # ------------------------------------------------------------------
+    # 3. AppRunner setup, site bind, sleep, cleanup (shared by both modes)
+    # ------------------------------------------------------------------
     runner = web.AppRunner(app, handle_signals=True)
     await runner.setup()
-    site = web.TCPSite(runner, host=args.bind, port=args.web_port)
+    site = web.TCPSite(runner, host=config.web_bind, port=config.web_port)
     try:
         await site.start()
     except OSError as exc:
-        await session.disconnect()
+        if config.auth_mode == "dev":
+            await session.disconnect()
         await runner.cleanup()
         raise AfiError(
             code=EXIT_ENV_ERROR,
-            message=f"cannot bind web port {args.bind}:{args.web_port}: {exc}",
+            message=f"cannot bind web port {config.web_bind}:{config.web_port}: {exc}",
             remediation=(
                 "pick a different --web-port, or stop whatever is already "
                 "bound to this port"
             ),
         ) from exc
 
-    url = _display_url(args.bind, args.web_port)
+    url = _display_url(config.web_bind, config.web_port)
     emit_diagnostic(f"irc-lens serving on {url}")
     if args.open:
         try:
@@ -220,10 +283,9 @@ async def _serve_async(args: argparse.Namespace) -> None:
     try:
         await asyncio.Event().wait()
     finally:
-        # Disconnect every registered Session, not just the pre-seeded one;
-        # Phase 3 will add lazily-opened per-user sessions, and this single
-        # call covers them too (return_exceptions=True so one failure doesn't
-        # strand the others).
+        # Disconnect every registered Session (covers dev pre-seeded session
+        # and any lazily-opened per-user CF sessions alike).
+        # return_exceptions=True so one failure doesn't strand the others.
         await disconnect_all(app["registry"])
         await runner.cleanup()
 
@@ -266,6 +328,14 @@ def register(sub: argparse._SubParsersAction) -> None:
             "      Point at a remote AgentIRC server.\n"
         ),
         formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    p.add_argument(
+        "--config",
+        default=None,
+        help=(
+            "Path to irc-lens config.yaml (default: ~/.config/irc-lens/config.yaml). "
+            "When absent, builds a synthetic dev config from the other CLI flags."
+        ),
     )
     # `%(default)s` lets argparse render the actual default at help-time,
     # so the rendered "(default: …)" string can never drift from the

--- a/src/irc_lens/web/app.py
+++ b/src/irc_lens/web/app.py
@@ -1,11 +1,10 @@
 """aiohttp ``Application`` factory for irc-lens.
 
-Phase 2: takes a :class:`LensConfig` and a session factory rather than
-a single connected Session. Builds the per-principal
-:class:`SessionRegistry`, mounts the dev-mode identity middleware, and
-exposes a `/healthz` endpoint.
-
-CF-mode middleware lands in Phase 3.
+Phase 3: dev-mode and cloudflare-access modes both wired. Takes a
+:class:`LensConfig` and a session factory rather than a single connected
+Session. Builds the per-principal :class:`SessionRegistry`, mounts the
+appropriate identity middleware for the configured auth mode, and exposes
+a ``/healthz`` endpoint.
 """
 from __future__ import annotations
 
@@ -16,6 +15,7 @@ from aiohttp import web
 from irc_lens._errors import EXIT_USER_ERROR, AfiError
 from irc_lens.config import LensConfig
 from irc_lens.web import routes
+from irc_lens.web.auth import build_cloudflare_middleware
 from irc_lens.web.identity import Identity
 from irc_lens.web.routes import _MAX_INPUT_BODY
 from irc_lens.web.sessions import SessionFactory, SessionRegistry
@@ -56,21 +56,17 @@ def _dev_identity_middleware(config: LensConfig):
 
 
 def make_app(config: LensConfig, session_factory: SessionFactory) -> web.Application:
-    if config.auth_mode != "dev":
-        # Intentional failure path → AfiError (the dispatcher renders this
-        # as `error:` + `hint:` and exits with code 1, instead of falling
-        # into the catch-all "file a bug" path that RuntimeError produces).
-        # Phase 3 will replace this branch with the CF-mode middleware.
+    if config.auth_mode == "dev":
+        middleware = _dev_identity_middleware(config)
+    elif config.auth_mode == "cloudflare-access":
+        middleware = build_cloudflare_middleware(config)
+    else:
         raise AfiError(
             code=EXIT_USER_ERROR,
-            message=f"auth.mode={config.auth_mode!r} is not yet supported",
-            remediation=(
-                "set `auth.mode: dev` in your config; "
-                "cloudflare-access support lands in a later phase"
-            ),
+            message=f"auth.mode={config.auth_mode!r} is not supported",
+            remediation="set `auth.mode:` to either `dev` or `cloudflare-access`",
         )
 
-    middleware = _dev_identity_middleware(config)
     app = web.Application(client_max_size=_MAX_INPUT_BODY, middlewares=[middleware])
 
     registry = SessionRegistry(factory=session_factory)

--- a/src/irc_lens/web/auth.py
+++ b/src/irc_lens/web/auth.py
@@ -105,6 +105,139 @@ def _principal_from_claims(claims: dict[str, Any]) -> tuple[str | None, bool]:
     return None, False
 
 
+class _AuthDenied(Exception):
+    """Internal control-flow exception carrying the HTTP response.
+
+    Lets the verification + authorization helpers surface rich
+    ``web.Response`` objects upward without forcing the middleware to
+    branch on union return types (which Sonar S3776 counts as
+    cognitive complexity). Internal to this module — never propagates
+    past ``build_cloudflare_middleware``'s closure.
+    """
+
+    __slots__ = ("response",)
+
+    def __init__(self, response: web.Response) -> None:
+        super().__init__()
+        self.response = response
+
+
+def _extract_token(request: web.Request) -> str | None:
+    """Pull the JWT from the header (preferred) or the cookie.
+
+    Returns ``None`` only when neither carrier holds a token.
+    """
+    token = request.headers.get("Cf-Access-Jwt-Assertion")
+    if token:
+        return token
+    return request.cookies.get("CF_Authorization") or None
+
+
+async def _decode_and_verify_jwt(
+    cache: _JWKSCache,
+    token: str,
+    aud: str,
+    issuer: str,
+    team_domain: str,
+) -> dict[str, Any]:
+    """Verify signature + audience + issuer; return the claims dict.
+
+    Pinned to ``RS256``. Raises :class:`_AuthDenied` carrying the
+    appropriate HTTP response on every failure path so the middleware
+    body stays linear.
+    """
+    try:
+        unverified_header = jwt.get_unverified_header(token)
+        kid = unverified_header.get("kid")
+        if not kid:
+            raise jwt.InvalidTokenError("missing kid in JWT header")
+        jwk_data = await cache.get_key(kid)
+        public_key = RSAAlgorithm.from_jwk(jwk_data)
+        return jwt.decode(
+            token,
+            public_key,
+            algorithms=["RS256"],
+            audience=aud,
+            issuer=issuer,
+        )
+    except jwt.ExpiredSignatureError as exc:
+        raise _AuthDenied(_http_error(
+            401, "Cloudflare Access JWT expired", "sign in again"
+        )) from exc
+    except jwt.InvalidAudienceError as exc:
+        raise _AuthDenied(_http_error(
+            401,
+            _ERR_JWT_VERIFICATION,
+            "audience mismatch — verify auth.cloudflare.aud in the lens config",
+        )) from exc
+    except jwt.InvalidIssuerError as exc:
+        raise _AuthDenied(_http_error(
+            401,
+            _ERR_JWT_VERIFICATION,
+            "issuer mismatch — verify auth.cloudflare.team_domain in the lens config",
+        )) from exc
+    except (KeyError, jwt.InvalidTokenError) as exc:
+        raise _AuthDenied(_http_error(
+            401,
+            _ERR_JWT_VERIFICATION,
+            f"verify the request came through cloudflared ({type(exc).__name__})",
+        )) from exc
+    except aiohttp.ClientError as exc:
+        raise _AuthDenied(_http_error(
+            502,
+            "could not reach Cloudflare JWKS",
+            f"check connectivity to {team_domain} ({exc})",
+        )) from exc
+
+
+def _authorize_principal(
+    claims: dict[str, Any],
+    allowed_emails: set[str],
+    allowed_tokens: set[str],
+    server_name: str,
+) -> Identity:
+    """Extract the principal, enforce the allowlist, derive the nick.
+
+    Emails and service tokens are sibling lists. The ``is_email`` flag
+    prevents a service-token JWT from accidentally matching an entry
+    in ``allowed_emails`` (or vice versa) just because the strings
+    happen to match. Raises :class:`_AuthDenied` on every deny path.
+    """
+    principal, is_email = _principal_from_claims(claims)
+    if not principal:
+        raise _AuthDenied(_http_error(
+            401,
+            "JWT carried neither email nor common_name",
+            "verify the Access policy issues an email or service-token JWT",
+        ))
+    if is_email and principal not in allowed_emails:
+        raise _AuthDenied(_http_error(
+            403,
+            f"{principal} not on allowlist",
+            "add to auth.allowed_emails in the lens config",
+        ))
+    if (not is_email) and principal not in allowed_tokens:
+        raise _AuthDenied(_http_error(
+            403,
+            f"service token {principal} not on allowlist",
+            "add to auth.allowed_service_tokens in the lens config",
+        ))
+    try:
+        nick = derive_nick(server_name, principal)
+    except ValueError as exc:
+        logger.error("nick derivation failed: %s", exc)
+        raise _AuthDenied(_http_error(
+            500,
+            "nick derivation failed",
+            "principal sanitizes to empty; pick a different identity",
+        )) from exc
+    return Identity(
+        principal=principal,
+        nick=nick,
+        raw_jwt_subject=str(claims.get("sub", "")),
+    )
+
+
 def build_cloudflare_middleware(config: LensConfig):
     """Build the @web.middleware coroutine for cloudflare-access mode.
 
@@ -124,115 +257,41 @@ def build_cloudflare_middleware(config: LensConfig):
     cache = _JWKSCache(config.cf_team_domain)
     issuer = _build_issuer(config.cf_team_domain)
     aud = config.cf_aud
+    team_domain = config.cf_team_domain
     allowed_emails = set(config.allowed_emails)
     allowed_tokens = set(config.allowed_service_tokens)
     server_name = config.server_name
 
     @web.middleware
     async def middleware(request: web.Request, handler):
-        # Static assets never require identity (browser fetches them before
-        # the SSO redirect lands on every page load). `/healthz` is also
-        # unauthenticated by spec — cloudflared and external uptime
-        # probes hit it without a JWT, and the response is opaque
+        # Static assets never require identity (browser fetches them
+        # before the SSO redirect lands on every page load). `/healthz`
+        # is also unauthenticated by spec — cloudflared and external
+        # uptime probes hit it without a JWT, and the response is opaque
         # (`{"ok": true}`) so it doesn't leak any allowlist state.
         if request.path.startswith("/static/") or request.path == "/healthz":
             return await handler(request)
-
-        token = request.headers.get("Cf-Access-Jwt-Assertion")
-        if not token:
-            token = request.cookies.get("CF_Authorization")
+        token = _extract_token(request)
         if not token:
             return _http_error(
                 401,
                 "missing Cloudflare Access identity",
                 "ensure this request is reaching the lens through cloudflared",
             )
-
         try:
-            unverified_header = jwt.get_unverified_header(token)
-            kid = unverified_header.get("kid")
-            if not kid:
-                raise jwt.InvalidTokenError("missing kid in JWT header")
-            jwk_data = await cache.get_key(kid)
-            public_key = RSAAlgorithm.from_jwk(jwk_data)
-            claims = jwt.decode(
-                token,
-                public_key,
-                algorithms=["RS256"],
-                audience=aud,
-                issuer=issuer,
+            claims = await _decode_and_verify_jwt(
+                cache, token, aud, issuer, team_domain
             )
-        except jwt.ExpiredSignatureError:
-            return _http_error(401, "Cloudflare Access JWT expired", "sign in again")
-        except jwt.InvalidAudienceError:
-            return _http_error(
-                401,
-                _ERR_JWT_VERIFICATION,
-                "audience mismatch — verify auth.cloudflare.aud in the lens config",
+            identity = _authorize_principal(
+                claims, allowed_emails, allowed_tokens, server_name
             )
-        except jwt.InvalidIssuerError:
-            return _http_error(
-                401,
-                _ERR_JWT_VERIFICATION,
-                "issuer mismatch — verify auth.cloudflare.team_domain in the lens config",
-            )
-        except (KeyError, jwt.InvalidTokenError) as exc:
-            return _http_error(
-                401,
-                _ERR_JWT_VERIFICATION,
-                f"verify the request came through cloudflared ({type(exc).__name__})",
-            )
-        except aiohttp.ClientError as exc:
-            return _http_error(
-                502,
-                "could not reach Cloudflare JWKS",
-                f"check connectivity to {config.cf_team_domain} ({exc})",
-            )
-
-        principal, is_email = _principal_from_claims(claims)
-        if not principal:
-            return _http_error(
-                401,
-                "JWT carried neither email nor common_name",
-                "verify the Access policy issues an email or service-token JWT",
-            )
-
-        # Allowlist enforcement — emails and service tokens are sibling
-        # lists.  The ``is_email`` flag prevents a service-token JWT from
-        # accidentally matching an entry in ``allowed_emails`` (or vice
-        # versa) just because both happen to be string-identical.
-        if is_email and principal not in allowed_emails:
-            return _http_error(
-                403,
-                f"{principal} not on allowlist",
-                "add to auth.allowed_emails in the lens config",
-            )
-        if (not is_email) and principal not in allowed_tokens:
-            return _http_error(
-                403,
-                f"service token {principal} not on allowlist",
-                "add to auth.allowed_service_tokens in the lens config",
-            )
-
-        try:
-            nick = derive_nick(server_name, principal)
-        except ValueError as exc:
-            logger.error("nick derivation failed: %s", exc)
-            return _http_error(
-                500,
-                "nick derivation failed",
-                "principal sanitizes to empty; pick a different identity",
-            )
-
-        request["identity"] = Identity(
-            principal=principal,
-            nick=nick,
-            raw_jwt_subject=str(claims.get("sub", "")),
-        )
+        except _AuthDenied as denied:
+            return denied.response
+        request["identity"] = identity
         logger.info(
             "auth=ok principal=%s nick=%s method=%s path=%s",
-            principal,
-            nick,
+            identity.principal,
+            identity.nick,
             request.method,
             request.path,
         )

--- a/src/irc_lens/web/auth.py
+++ b/src/irc_lens/web/auth.py
@@ -16,6 +16,7 @@ from typing import Any
 import aiohttp
 import jwt
 from aiohttp import web
+from jwt.algorithms import RSAAlgorithm
 
 from irc_lens.config import LensConfig
 from irc_lens.web.identity import Identity, derive_nick
@@ -33,6 +34,12 @@ def _http_error(status: int, error: str, hint: str) -> web.Response:
 def _scheme_for(team_domain: str) -> str:
     """HTTP for tests (FakeJWKS uses host:port), HTTPS otherwise."""
     return "http" if ":" in team_domain else "https"
+
+
+# Reused error message — extracted so SonarCloud S1192 (duplicate-literal,
+# default threshold 3) stays quiet and so the wording can't drift across
+# the three jwt-decode failure arms below.
+_ERR_JWT_VERIFICATION = "Cloudflare Access JWT failed verification"
 
 
 def _build_jwks_url(team_domain: str) -> str:
@@ -147,7 +154,6 @@ def build_cloudflare_middleware(config: LensConfig):
             if not kid:
                 raise jwt.InvalidTokenError("missing kid in JWT header")
             jwk_data = await cache.get_key(kid)
-            from jwt.algorithms import RSAAlgorithm
             public_key = RSAAlgorithm.from_jwk(jwk_data)
             claims = jwt.decode(
                 token,
@@ -161,19 +167,19 @@ def build_cloudflare_middleware(config: LensConfig):
         except jwt.InvalidAudienceError:
             return _http_error(
                 401,
-                "Cloudflare Access JWT failed verification",
+                _ERR_JWT_VERIFICATION,
                 "audience mismatch — verify auth.cloudflare.aud in the lens config",
             )
         except jwt.InvalidIssuerError:
             return _http_error(
                 401,
-                "Cloudflare Access JWT failed verification",
+                _ERR_JWT_VERIFICATION,
                 "issuer mismatch — verify auth.cloudflare.team_domain in the lens config",
             )
         except (KeyError, jwt.InvalidTokenError) as exc:
             return _http_error(
                 401,
-                "Cloudflare Access JWT failed verification",
+                _ERR_JWT_VERIFICATION,
                 f"verify the request came through cloudflared ({type(exc).__name__})",
             )
         except aiohttp.ClientError as exc:

--- a/src/irc_lens/web/auth.py
+++ b/src/irc_lens/web/auth.py
@@ -9,6 +9,7 @@ deny → 403.
 """
 from __future__ import annotations
 
+import asyncio
 import logging
 import time
 from typing import Any
@@ -18,6 +19,7 @@ import jwt
 from aiohttp import web
 from jwt.algorithms import RSAAlgorithm
 
+from irc_lens._errors import EXIT_USER_ERROR, AfiError
 from irc_lens.config import LensConfig
 from irc_lens.web.identity import Identity, derive_nick
 
@@ -56,7 +58,16 @@ class _JWKSCache:
     def __init__(self, team_domain: str) -> None:
         self._url = _build_jwks_url(team_domain)
         self._keys: dict[str, Any] = {}
+        # Use ``time.monotonic()`` rather than ``time.time()`` for the
+        # flood-window arithmetic — wall-clock adjustments (NTP, leap
+        # seconds, manual time changes) can otherwise produce negative
+        # or huge deltas that collapse or extend the window unexpectedly.
         self._last_fetch: float = 0.0
+        # Single-flight: a thundering herd of requests with an unknown
+        # ``kid`` would otherwise each kick off their own JWKS refetch.
+        # The lock serialises refreshes; the post-lock cache check
+        # short-circuits everyone after the first.
+        self._refresh_lock: asyncio.Lock = asyncio.Lock()
 
     async def _refresh(self) -> None:
         async with aiohttp.ClientSession() as session:
@@ -66,24 +77,30 @@ class _JWKSCache:
                 r.raise_for_status()
                 payload = await r.json()
         self._keys = {k["kid"]: k for k in payload.get("keys", [])}
-        self._last_fetch = time.time()
+        self._last_fetch = time.monotonic()
 
     async def get_key(self, kid: str) -> Any:
         if kid in self._keys:
             return self._keys[kid]
-        # Anti-flood: only refresh if cache is empty OR the last fetch
-        # was longer ago than the flood window.  A malformed-kid storm
-        # would otherwise drive request-time fetches every request.
-        within_flood_window = (
-            self._keys
-            and (time.time() - self._last_fetch) < _KID_MISS_FLOOD_WINDOW_SECONDS
-        )
-        if within_flood_window:
-            raise KeyError(kid)
-        await self._refresh()
-        if kid not in self._keys:
-            raise KeyError(kid)
-        return self._keys[kid]
+        # Anti-flood + single-flight: only one coroutine refreshes per
+        # window. A malformed-kid storm would otherwise drive
+        # request-time fetches every request.
+        async with self._refresh_lock:
+            # Double-check inside the lock: another coroutine may have
+            # just refreshed and populated the kid we want.
+            if kid in self._keys:
+                return self._keys[kid]
+            within_flood_window = (
+                self._keys
+                and (time.monotonic() - self._last_fetch)
+                < _KID_MISS_FLOOD_WINDOW_SECONDS
+            )
+            if within_flood_window:
+                raise KeyError(kid)
+            await self._refresh()
+            if kid not in self._keys:
+                raise KeyError(kid)
+            return self._keys[kid]
 
     async def warm(self) -> None:
         await self._refresh()
@@ -182,11 +199,15 @@ async def _decode_and_verify_jwt(
             _ERR_JWT_VERIFICATION,
             f"verify the request came through cloudflared ({type(exc).__name__})",
         )) from exc
-    except aiohttp.ClientError as exc:
+    except (aiohttp.ClientError, asyncio.TimeoutError) as exc:
+        # ``aiohttp.ClientTimeout`` raises ``asyncio.TimeoutError``,
+        # which is NOT a subclass of ``aiohttp.ClientError`` — without
+        # the explicit catch it would bubble to a 500. Both surface
+        # the same operator-facing 502.
         raise _AuthDenied(_http_error(
             502,
             "could not reach Cloudflare JWKS",
-            f"check connectivity to {team_domain} ({exc})",
+            f"check connectivity to {team_domain} ({type(exc).__name__}: {exc})",
         )) from exc
 
 
@@ -246,13 +267,27 @@ def build_cloudflare_middleware(config: LensConfig):
     ``request['identity']`` so downstream handlers stay mode-agnostic.
     """
     if config.auth_mode != "cloudflare-access":
-        raise ValueError(
-            f"build_cloudflare_middleware called with auth_mode={config.auth_mode!r}"
+        # AfiError (not ValueError) so the dispatcher renders an
+        # `error:`/`hint:` pair and exits with code 1 instead of
+        # falling into the catch-all "file a bug" path. Reachable
+        # only if a caller bypasses load_config's auth_mode check;
+        # belt-and-suspenders for that case.
+        raise AfiError(
+            code=EXIT_USER_ERROR,
+            message=f"build_cloudflare_middleware called with auth_mode={config.auth_mode!r}",
+            remediation="set `auth.mode: cloudflare-access` in the lens config",
         )
     if not config.cf_aud or not config.cf_team_domain:
-        raise ValueError(
-            "auth.mode='cloudflare-access' requires both "
-            "auth.cloudflare.aud and auth.cloudflare.team_domain"
+        raise AfiError(
+            code=EXIT_USER_ERROR,
+            message=(
+                "auth.mode='cloudflare-access' requires both "
+                "auth.cloudflare.aud and auth.cloudflare.team_domain"
+            ),
+            remediation=(
+                "fill in both `auth.cloudflare.aud` and "
+                "`auth.cloudflare.team_domain` in the lens config"
+            ),
         )
     cache = _JWKSCache(config.cf_team_domain)
     issuer = _build_issuer(config.cf_team_domain)

--- a/src/irc_lens/web/auth.py
+++ b/src/irc_lens/web/auth.py
@@ -1,0 +1,245 @@
+"""Cloudflare Access JWT verification and middleware.
+
+Validates the JWT against the Cloudflare-published JWKS, pinning
+audience and issuer. Caches the JWK set in process; on a ``kid`` we
+don't recognize, refresh once and retry — but never on every request
+(anti-flood window). Identity (email or service-token common-name)
+becomes ``request['identity']``; missing/invalid → 401, allowlist
+deny → 403.
+"""
+from __future__ import annotations
+
+import logging
+import time
+from typing import Any
+
+import aiohttp
+import jwt
+from aiohttp import web
+
+from irc_lens.config import LensConfig
+from irc_lens.web.identity import Identity, derive_nick
+
+logger = logging.getLogger(__name__)
+
+_JWKS_PATH = "/cdn-cgi/access/certs"
+_KID_MISS_FLOOD_WINDOW_SECONDS = 5.0
+
+
+def _http_error(status: int, error: str, hint: str) -> web.Response:
+    return web.json_response({"error": error, "hint": hint}, status=status)
+
+
+def _scheme_for(team_domain: str) -> str:
+    """HTTP for tests (FakeJWKS uses host:port), HTTPS otherwise."""
+    return "http" if ":" in team_domain else "https"
+
+
+def _build_jwks_url(team_domain: str) -> str:
+    return f"{_scheme_for(team_domain)}://{team_domain}{_JWKS_PATH}"
+
+
+def _build_issuer(team_domain: str) -> str:
+    return f"{_scheme_for(team_domain)}://{team_domain}"
+
+
+class _JWKSCache:
+    """In-process JWK set cache with kid-miss-then-refresh semantics."""
+
+    def __init__(self, team_domain: str) -> None:
+        self._url = _build_jwks_url(team_domain)
+        self._keys: dict[str, Any] = {}
+        self._last_fetch: float = 0.0
+
+    async def _refresh(self) -> None:
+        async with aiohttp.ClientSession() as session:
+            async with session.get(
+                self._url, timeout=aiohttp.ClientTimeout(total=5)
+            ) as r:
+                r.raise_for_status()
+                payload = await r.json()
+        self._keys = {k["kid"]: k for k in payload.get("keys", [])}
+        self._last_fetch = time.time()
+
+    async def get_key(self, kid: str) -> Any:
+        if kid in self._keys:
+            return self._keys[kid]
+        # Anti-flood: only refresh if cache is empty OR the last fetch
+        # was longer ago than the flood window.  A malformed-kid storm
+        # would otherwise drive request-time fetches every request.
+        within_flood_window = (
+            self._keys
+            and (time.time() - self._last_fetch) < _KID_MISS_FLOOD_WINDOW_SECONDS
+        )
+        if within_flood_window:
+            raise KeyError(kid)
+        await self._refresh()
+        if kid not in self._keys:
+            raise KeyError(kid)
+        return self._keys[kid]
+
+    async def warm(self) -> None:
+        await self._refresh()
+
+
+def _principal_from_claims(claims: dict[str, Any]) -> tuple[str | None, bool]:
+    """Return (principal, is_email).
+
+    Email under interactive SSO; common_name under service tokens.
+    ``is_email`` lets the caller pick which allowlist to consult so the
+    two principal types can't accidentally cross-authorize each other.
+    """
+    email = claims.get("email")
+    if isinstance(email, str) and email:
+        return email, True
+    cn = claims.get("common_name")
+    if isinstance(cn, str) and cn:
+        return cn, False
+    return None, False
+
+
+def build_cloudflare_middleware(config: LensConfig):
+    """Build the @web.middleware coroutine for cloudflare-access mode.
+
+    Pins audience to ``config.cf_aud`` and issuer to
+    ``<scheme>://<config.cf_team_domain>``.  Identity is stashed on
+    ``request['identity']`` so downstream handlers stay mode-agnostic.
+    """
+    if config.auth_mode != "cloudflare-access":
+        raise ValueError(
+            f"build_cloudflare_middleware called with auth_mode={config.auth_mode!r}"
+        )
+    if not config.cf_aud or not config.cf_team_domain:
+        raise ValueError(
+            "auth.mode='cloudflare-access' requires both "
+            "auth.cloudflare.aud and auth.cloudflare.team_domain"
+        )
+    cache = _JWKSCache(config.cf_team_domain)
+    issuer = _build_issuer(config.cf_team_domain)
+    aud = config.cf_aud
+    allowed_emails = set(config.allowed_emails)
+    allowed_tokens = set(config.allowed_service_tokens)
+    server_name = config.server_name
+
+    @web.middleware
+    async def middleware(request: web.Request, handler):
+        # Static assets never require identity (browser fetches them before
+        # the SSO redirect lands on every page load).
+        if request.path.startswith("/static/"):
+            return await handler(request)
+
+        token = request.headers.get("Cf-Access-Jwt-Assertion")
+        if not token:
+            token = request.cookies.get("CF_Authorization")
+        if not token:
+            return _http_error(
+                401,
+                "missing Cloudflare Access identity",
+                "ensure this request is reaching the lens through cloudflared",
+            )
+
+        try:
+            unverified_header = jwt.get_unverified_header(token)
+            kid = unverified_header.get("kid")
+            if not kid:
+                raise jwt.InvalidTokenError("missing kid in JWT header")
+            jwk_data = await cache.get_key(kid)
+            from jwt.algorithms import RSAAlgorithm
+            public_key = RSAAlgorithm.from_jwk(jwk_data)
+            claims = jwt.decode(
+                token,
+                public_key,
+                algorithms=["RS256"],
+                audience=aud,
+                issuer=issuer,
+            )
+        except jwt.ExpiredSignatureError:
+            return _http_error(401, "Cloudflare Access JWT expired", "sign in again")
+        except jwt.InvalidAudienceError:
+            return _http_error(
+                401,
+                "Cloudflare Access JWT failed verification",
+                "audience mismatch — verify auth.cloudflare.aud in the lens config",
+            )
+        except jwt.InvalidIssuerError:
+            return _http_error(
+                401,
+                "Cloudflare Access JWT failed verification",
+                "issuer mismatch — verify auth.cloudflare.team_domain in the lens config",
+            )
+        except (KeyError, jwt.InvalidTokenError) as exc:
+            return _http_error(
+                401,
+                "Cloudflare Access JWT failed verification",
+                f"verify the request came through cloudflared ({type(exc).__name__})",
+            )
+        except aiohttp.ClientError as exc:
+            return _http_error(
+                502,
+                "could not reach Cloudflare JWKS",
+                f"check connectivity to {config.cf_team_domain} ({exc})",
+            )
+
+        principal, is_email = _principal_from_claims(claims)
+        if not principal:
+            return _http_error(
+                401,
+                "JWT carried neither email nor common_name",
+                "verify the Access policy issues an email or service-token JWT",
+            )
+
+        # Allowlist enforcement — emails and service tokens are sibling
+        # lists.  The ``is_email`` flag prevents a service-token JWT from
+        # accidentally matching an entry in ``allowed_emails`` (or vice
+        # versa) just because both happen to be string-identical.
+        if is_email and principal not in allowed_emails:
+            return _http_error(
+                403,
+                f"{principal} not on allowlist",
+                "add to auth.allowed_emails in the lens config",
+            )
+        if (not is_email) and principal not in allowed_tokens:
+            return _http_error(
+                403,
+                f"service token {principal} not on allowlist",
+                "add to auth.allowed_service_tokens in the lens config",
+            )
+
+        try:
+            nick = derive_nick(server_name, principal)
+        except ValueError as exc:
+            logger.error("nick derivation failed: %s", exc)
+            return _http_error(
+                500,
+                "nick derivation failed",
+                "principal sanitizes to empty; pick a different identity",
+            )
+
+        request["identity"] = Identity(
+            principal=principal,
+            nick=nick,
+            raw_jwt_subject=str(claims.get("sub", "")),
+        )
+        logger.info(
+            "auth=ok principal=%s nick=%s method=%s path=%s",
+            principal,
+            nick,
+            request.method,
+            request.path,
+        )
+        return await handler(request)
+
+    return middleware
+
+
+async def warm_jwks(config: LensConfig) -> None:
+    """Fail fast at startup if Cloudflare's JWKS is unreachable.
+
+    No-op for non-CF auth modes.  Raises whatever ``aiohttp.ClientError``
+    or ``KeyError`` the cache surfaces; the caller (``serve.py``)
+    wraps that as ``AfiError(EXIT_ENV_ERROR, ...)``.
+    """
+    if config.auth_mode != "cloudflare-access" or not config.cf_team_domain:
+        return
+    cache = _JWKSCache(config.cf_team_domain)
+    await cache.warm()

--- a/src/irc_lens/web/auth.py
+++ b/src/irc_lens/web/auth.py
@@ -124,8 +124,11 @@ def build_cloudflare_middleware(config: LensConfig):
     @web.middleware
     async def middleware(request: web.Request, handler):
         # Static assets never require identity (browser fetches them before
-        # the SSO redirect lands on every page load).
-        if request.path.startswith("/static/"):
+        # the SSO redirect lands on every page load). `/healthz` is also
+        # unauthenticated by spec — cloudflared and external uptime
+        # probes hit it without a JWT, and the response is opaque
+        # (`{"ok": true}`) so it doesn't leak any allowlist state.
+        if request.path.startswith("/static/") or request.path == "/healthz":
             return await handler(request)
 
         token = request.headers.get("Cf-Access-Jwt-Assertion")

--- a/tests/_jwks_server.py
+++ b/tests/_jwks_server.py
@@ -1,0 +1,91 @@
+"""Tiny aiohttp app that mimics Cloudflare's JWKS endpoint for tests.
+
+Tests mint JWTs locally with the matching private key and point the
+lens at this server's URL. Mirrors the in-tree
+``_agentirc_server.py`` pattern so we don't add a network dep.
+"""
+from __future__ import annotations
+
+import json
+from typing import Any
+
+import jwt
+from aiohttp import web
+from cryptography.hazmat.primitives import serialization
+from cryptography.hazmat.primitives.asymmetric import rsa
+
+
+class FakeJWKS:
+    """Generate a keypair, expose the JWK set, mint signed JWTs."""
+
+    def __init__(self, kid: str = "test-kid-1") -> None:
+        self._kid = kid
+        self._key = rsa.generate_private_key(public_exponent=65537, key_size=2048)
+        self._site: web.TCPSite | None = None
+        self._runner: web.AppRunner | None = None
+        self.host: str = "127.0.0.1"
+        self.port: int = 0
+
+    @property
+    def base_url(self) -> str:
+        return f"http://{self.host}:{self.port}"
+
+    @property
+    def team_domain(self) -> str:
+        # Tests pass `host:port` as team_domain so we can talk over HTTP;
+        # production team_domain is a real Cloudflare hostname (use HTTPS).
+        return f"{self.host}:{self.port}"
+
+    @property
+    def issuer(self) -> str:
+        return f"http://{self.team_domain}"
+
+    def public_jwk(self) -> dict[str, Any]:
+        numbers = self._key.public_key().public_numbers()
+        from base64 import urlsafe_b64encode
+
+        def _b64(n: int) -> str:
+            blen = (n.bit_length() + 7) // 8
+            return urlsafe_b64encode(n.to_bytes(blen, "big")).rstrip(b"=").decode()
+
+        return {
+            "kty": "RSA",
+            "alg": "RS256",
+            "use": "sig",
+            "kid": self._kid,
+            "n": _b64(numbers.n),
+            "e": _b64(numbers.e),
+        }
+
+    def mint(self, *, aud: str, claims: dict[str, Any], kid: str | None = None) -> str:
+        payload = {"iss": self.issuer, "aud": aud, **claims}
+        return jwt.encode(
+            payload,
+            self._key.private_bytes(
+                encoding=serialization.Encoding.PEM,
+                format=serialization.PrivateFormat.PKCS8,
+                encryption_algorithm=serialization.NoEncryption(),
+            ),
+            algorithm="RS256",
+            headers={"kid": kid or self._kid},
+        )
+
+    async def start(self) -> None:
+        app = web.Application()
+
+        async def certs(_req: web.Request) -> web.Response:
+            return web.json_response({"keys": [self.public_jwk()]})
+
+        app.router.add_get("/cdn-cgi/access/certs", certs)
+        self._runner = web.AppRunner(app)
+        await self._runner.setup()
+        self._site = web.TCPSite(self._runner, self.host, 0)
+        await self._site.start()
+        # Resolve the actual port the OS assigned.
+        sockets = list(self._runner.addresses)
+        if sockets:
+            self.port = sockets[0][1]
+
+    async def stop(self) -> None:
+        if self._runner is not None:
+            await self._runner.cleanup()

--- a/tests/_jwks_server.py
+++ b/tests/_jwks_server.py
@@ -6,7 +6,6 @@ lens at this server's URL. Mirrors the in-tree
 """
 from __future__ import annotations
 
-import json
 from typing import Any
 
 import jwt

--- a/tests/_jwks_server.py
+++ b/tests/_jwks_server.py
@@ -70,6 +70,18 @@ class FakeJWKS:
             headers={"kid": kid or self._kid},
         )
 
+    def rotate(self, new_kid: str) -> None:
+        """Replace the keypair + kid; subsequent /certs returns the new key only.
+
+        Used by T3.4 to simulate Cloudflare's signing-key rotation. After
+        a `rotate("new-kid")`, JWTs minted with the default kid will be
+        signed with the *new* private key (because we replaced the
+        keypair), and the JWKS endpoint will publish only the new public
+        key under the new kid.
+        """
+        self._kid = new_kid
+        self._key = rsa.generate_private_key(public_exponent=65537, key_size=2048)
+
     async def start(self) -> None:
         app = web.Application()
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -132,3 +132,22 @@ async def seeded_lens_client(
     apply_seed(lens_session, _BASIC_SEED)
     async for client in _serve_lens(lens_session, agentirc_server.host, agentirc_server.port):
         yield client
+
+
+# ---------------------------------------------------------------------------
+# CF Access fixtures (shared across test_auth_middleware + test_audit_log)
+# ---------------------------------------------------------------------------
+
+
+@pytest_asyncio.fixture
+async def jwks() -> AsyncIterator["FakeJWKS"]:
+    """An in-tree FakeJWKS server bound to a random port. See
+    `tests/_jwks_server.py` for the full surface."""
+    from _jwks_server import FakeJWKS
+
+    j = FakeJWKS()
+    await j.start()
+    try:
+        yield j
+    finally:
+        await j.stop()

--- a/tests/test_audit_log.py
+++ b/tests/test_audit_log.py
@@ -1,0 +1,123 @@
+"""Audit log: every authenticated request emits one structured line.
+
+The format is `auth=ok principal=<…> nick=<…> method=<…> path=<…>`
+on the `irc_lens.web.auth` logger. `/healthz` and `/static/*` are
+bypassed by the middleware and produce no audit line."""
+from __future__ import annotations
+
+import logging
+from collections.abc import AsyncIterator
+
+import pytest_asyncio
+from aiohttp import web
+from aiohttp.test_utils import TestClient, TestServer
+
+from irc_lens.config import LensConfig
+from irc_lens.web import make_app
+
+from _jwks_server import FakeJWKS
+
+
+_AUTH_CANARY_PATH = "/test/auth-canary"
+
+
+async def _auth_canary_handler(request: web.Request) -> web.Response:
+    identity = request["identity"]
+    return web.json_response({"ok": True, "principal": identity.principal})
+
+
+def _cf_config_with_email(jwks: FakeJWKS, email: str) -> LensConfig:
+    return LensConfig(
+        auth_mode="cloudflare-access",
+        dev_nick=None,
+        dev_email=None,
+        cf_aud="aud-test",
+        cf_team_domain=jwks.team_domain,
+        allowed_emails=(email,),
+        allowed_service_tokens=(),
+        server_name="testsrv",
+        server_host="127.0.0.1",
+        server_port=6667,
+        web_bind="127.0.0.1",
+        web_port=0,
+    )
+
+
+@pytest_asyncio.fixture
+async def audit_client(jwks: FakeJWKS) -> AsyncIterator[TestClient]:
+    config = _cf_config_with_email(jwks, "alice@example.com")
+
+    def boom_factory(_n: str):
+        raise AssertionError("session factory must not run during audit tests")
+
+    app = make_app(config, boom_factory)
+    app.router.add_get(_AUTH_CANARY_PATH, _auth_canary_handler)
+    server = TestServer(app)
+    client = TestClient(server)
+    await client.start_server()
+    try:
+        yield client
+    finally:
+        await client.close()
+
+
+async def test_authenticated_request_logs_principal(
+    audit_client: TestClient, jwks: FakeJWKS, caplog
+) -> None:
+    """One `auth=ok …` line per authenticated request, on the
+    `irc_lens.web.auth` logger."""
+    token = jwks.mint(
+        aud="aud-test",
+        claims={"email": "alice@example.com", "sub": "s-1"},
+    )
+    with caplog.at_level(logging.INFO, logger="irc_lens.web.auth"):
+        r = await audit_client.get(
+            _AUTH_CANARY_PATH,
+            headers={"Cf-Access-Jwt-Assertion": token},
+        )
+        assert r.status == 200
+
+    msgs = [
+        rec.getMessage()
+        for rec in caplog.records
+        if rec.name == "irc_lens.web.auth"
+    ]
+    assert any(
+        "auth=ok" in m
+        and "alice@example.com" in m
+        and f"path={_AUTH_CANARY_PATH}" in m
+        for m in msgs
+    ), f"expected auth=ok line for alice; got: {msgs}"
+
+
+async def test_healthz_does_not_emit_audit_line(
+    audit_client: TestClient, caplog
+) -> None:
+    """`/healthz` bypasses the middleware (cloudflared probes hit it
+    without a JWT), so no `auth=ok` line lands for it."""
+    with caplog.at_level(logging.INFO, logger="irc_lens.web.auth"):
+        r = await audit_client.get("/healthz")
+        assert r.status == 200
+
+    auth_ok_lines = [
+        rec.getMessage()
+        for rec in caplog.records
+        if rec.name == "irc_lens.web.auth" and "auth=ok" in rec.getMessage()
+    ]
+    assert auth_ok_lines == [], f"expected no audit lines for /healthz; got: {auth_ok_lines}"
+
+
+async def test_static_does_not_emit_audit_line(
+    audit_client: TestClient, caplog
+) -> None:
+    """`/static/*` also bypasses the middleware → no audit line."""
+    with caplog.at_level(logging.INFO, logger="irc_lens.web.auth"):
+        # 404 from static handler is fine; we're checking the LOG, not status.
+        await audit_client.get("/static/missing.js")
+
+    auth_ok_lines = [
+        rec.getMessage()
+        for rec in caplog.records
+        if rec.name == "irc_lens.web.auth" and "auth=ok" in rec.getMessage()
+    ]
+    assert auth_ok_lines == [], f"expected no audit lines for /static/*; got: {auth_ok_lines}"

--- a/tests/test_auth_middleware.py
+++ b/tests/test_auth_middleware.py
@@ -44,16 +44,6 @@ def _cf_config(jwks: FakeJWKS, allowed: list[str]) -> LensConfig:
 
 
 @pytest_asyncio.fixture
-async def jwks() -> AsyncIterator[FakeJWKS]:
-    j = FakeJWKS()
-    await j.start()
-    try:
-        yield j
-    finally:
-        await j.stop()
-
-
-@pytest_asyncio.fixture
 async def cf_client(jwks: FakeJWKS) -> AsyncIterator[TestClient]:
     """A lens TestClient in cloudflare-access mode wired to FakeJWKS.
 
@@ -162,3 +152,92 @@ async def test_kid_miss_then_refresh_fails_when_kid_truly_unknown(
     )
     r2 = await cf_client.get(_AUTH_CANARY_PATH, headers={"Cf-Access-Jwt-Assertion": t2})
     assert r2.status == 401
+
+
+@pytest.mark.slow
+async def test_rotated_kid_accepted_after_refresh(
+    cf_client: TestClient, jwks: FakeJWKS
+) -> None:
+    """JWT signed with a NEW key after rotation must validate
+    post-refresh.
+
+    Without the wait, the lens's anti-flood window (5 s) would
+    reject the second request without re-fetching JWKS. Sleeping
+    past the window forces the lens to actually re-fetch and
+    discover the rotated key.
+    """
+    import asyncio
+
+    # Warm cache with the original kid.
+    t1 = jwks.mint(aud="aud-test", claims={"email": "alice@example.com", "sub": "s"})
+    r1 = await cf_client.get(_AUTH_CANARY_PATH, headers={"Cf-Access-Jwt-Assertion": t1})
+    assert r1.status == 200
+
+    # Sleep past the 5 s anti-flood window so the next miss triggers
+    # a real refetch instead of an immediate KeyError.
+    await asyncio.sleep(5.1)
+
+    # Rotate FakeJWKS, mint with the new key, expect success after
+    # the lens refetches and discovers the new kid.
+    jwks.rotate("kid-after-rotation")
+    t2 = jwks.mint(aud="aud-test", claims={"email": "alice@example.com", "sub": "s"})
+    r2 = await cf_client.get(_AUTH_CANARY_PATH, headers={"Cf-Access-Jwt-Assertion": t2})
+    assert r2.status == 200
+
+
+async def test_service_token_common_name_accepted(jwks: FakeJWKS) -> None:
+    """A JWT with `common_name` (no `email`) is accepted iff CN is in
+    auth.allowed_service_tokens. A rogue CN gets 403 from the
+    service-token allowlist branch."""
+    config = LensConfig(
+        auth_mode="cloudflare-access",
+        dev_nick=None,
+        dev_email=None,
+        cf_aud="aud-test",
+        cf_team_domain=jwks.team_domain,
+        allowed_emails=(),
+        allowed_service_tokens=("ci-bot",),
+        server_name="testsrv",
+        server_host="127.0.0.1",
+        server_port=6667,
+        web_bind="127.0.0.1",
+        web_port=0,
+    )
+
+    def boom_factory(_n: str):
+        raise AssertionError("session factory must not run during auth tests")
+
+    app = make_app(config, boom_factory)
+    app.router.add_get(_AUTH_CANARY_PATH, _auth_canary_handler)
+    server = TestServer(app)
+    client = TestClient(server)
+    await client.start_server()
+    try:
+        # Allowed common_name → middleware accepts, principal echoes back.
+        token = jwks.mint(
+            aud="aud-test",
+            claims={"common_name": "ci-bot", "sub": "svc"},
+        )
+        r = await client.get(
+            _AUTH_CANARY_PATH,
+            headers={"Cf-Access-Jwt-Assertion": token},
+        )
+        assert r.status == 200
+        body = await r.json()
+        assert body == {"ok": True, "principal": "ci-bot"}
+
+        # Rogue common_name (NOT in allowed_service_tokens) → 403.
+        bad = jwks.mint(
+            aud="aud-test",
+            claims={"common_name": "rogue", "sub": "svc"},
+        )
+        r2 = await client.get(
+            _AUTH_CANARY_PATH,
+            headers={"Cf-Access-Jwt-Assertion": bad},
+        )
+        assert r2.status == 403
+        body2 = await r2.json()
+        assert "service token" in body2["error"]
+        assert "rogue" in body2["error"]
+    finally:
+        await client.close()

--- a/tests/test_auth_middleware.py
+++ b/tests/test_auth_middleware.py
@@ -5,12 +5,25 @@ from collections.abc import AsyncIterator
 
 import pytest
 import pytest_asyncio
+from aiohttp import web
 from aiohttp.test_utils import TestClient, TestServer
 
 from irc_lens.config import LensConfig
 from irc_lens.web import make_app
 
 from _jwks_server import FakeJWKS
+
+# Test-only path that triggers the auth middleware but bypasses
+# `_resolve_session` so we don't need a real (or mocked) Session.
+# `/healthz` and `/static/*` are both bypassed by the middleware
+# per spec, so neither can serve as the "did the middleware run?"
+# canary — hence the dedicated route mounted by `cf_client`.
+_AUTH_CANARY_PATH = "/test/auth-canary"
+
+
+async def _auth_canary_handler(request: web.Request) -> web.Response:
+    identity = request["identity"]
+    return web.json_response({"ok": True, "principal": identity.principal})
 
 
 def _cf_config(jwks: FakeJWKS, allowed: list[str]) -> LensConfig:
@@ -47,6 +60,10 @@ async def cf_client(jwks: FakeJWKS) -> AsyncIterator[TestClient]:
     Sessions never actually open in these tests — the middleware
     intercepts before any handler that would call get_or_open.
     The factory raises if invoked, to catch accidental routing.
+    A test-only `/test/auth-canary` route is mounted to give us a
+    path that triggers the middleware without reaching the
+    SessionRegistry (so the boom_factory contract holds for both
+    accept and reject cases).
     """
     config = _cf_config(jwks, allowed=["alice@example.com"])
 
@@ -54,6 +71,7 @@ async def cf_client(jwks: FakeJWKS) -> AsyncIterator[TestClient]:
         raise AssertionError("session factory must not run during auth tests")
 
     app = make_app(config, boom_factory)
+    app.router.add_get(_AUTH_CANARY_PATH, _auth_canary_handler)
     server = TestServer(app)
     client = TestClient(server)
     await client.start_server()
@@ -72,18 +90,30 @@ async def test_missing_jwt_returns_401(cf_client: TestClient) -> None:
 
 async def test_valid_jwt_in_header_passes_to_handler(cf_client: TestClient, jwks: FakeJWKS) -> None:
     token = jwks.mint(aud="aud-test", claims={"email": "alice@example.com", "sub": "s-1"})
-    # The boom_factory raises if the handler tries to open a session.
-    # /healthz skips auth and the registry, so use it as the canary that the
-    # *middleware* accepted the token.
-    resp = await cf_client.get("/healthz", headers={"Cf-Access-Jwt-Assertion": token})
+    # `/test/auth-canary` triggers the middleware but doesn't open a
+    # Session, so the boom_factory contract holds. The handler echoes
+    # the validated principal back so we can confirm identity stashing.
+    resp = await cf_client.get(_AUTH_CANARY_PATH, headers={"Cf-Access-Jwt-Assertion": token})
     assert resp.status == 200
+    body = await resp.json()
+    assert body == {"ok": True, "principal": "alice@example.com"}
 
 
 async def test_valid_jwt_in_cookie_also_accepted(cf_client: TestClient, jwks: FakeJWKS) -> None:
     token = jwks.mint(aud="aud-test", claims={"email": "alice@example.com", "sub": "s-2"})
     cf_client.session.cookie_jar.update_cookies({"CF_Authorization": token})
+    resp = await cf_client.get(_AUTH_CANARY_PATH)
+    assert resp.status == 200
+
+
+async def test_healthz_bypasses_auth_per_spec(cf_client: TestClient) -> None:
+    """`/healthz` must NOT require a JWT — cloudflared and external
+    uptime probes hit it without auth. The handler returns the opaque
+    `{"ok": true}` so it can't leak allowlist state either way."""
     resp = await cf_client.get("/healthz")
     assert resp.status == 200
+    body = await resp.json()
+    assert body == {"ok": True}
 
 
 async def test_wrong_audience_returns_401(cf_client: TestClient, jwks: FakeJWKS) -> None:
@@ -108,19 +138,27 @@ async def test_static_path_skips_auth(cf_client: TestClient) -> None:
     assert resp.status in (200, 404)
 
 
-async def test_kid_miss_then_refresh_succeeds(cf_client: TestClient, jwks: FakeJWKS) -> None:
+async def test_kid_miss_then_refresh_fails_when_kid_truly_unknown(
+    cf_client: TestClient, jwks: FakeJWKS
+) -> None:
     """If the JWT's kid isn't in cache, we refetch JWKS once and retry.
 
-    FakeJWKS only serves the original kid, so a JWT with a different kid
-    must fail (401) even after a refresh — the lens refetches but still
-    doesn't find the rotated kid. T3.4 will add the success-path test."""
+    FakeJWKS only serves the original kid, so a JWT with a different
+    kid must fail (401) even after a refresh — the lens refetches
+    JWKS but still doesn't find the rotated kid. T3.4 covers the
+    success path where the rotated kid IS present in the refreshed
+    JWKS."""
     # First request populates the cache with the current kid.
     t1 = jwks.mint(aud="aud-test", claims={"email": "alice@example.com", "sub": "s"})
-    r1 = await cf_client.get("/healthz", headers={"Cf-Access-Jwt-Assertion": t1})
+    r1 = await cf_client.get(_AUTH_CANARY_PATH, headers={"Cf-Access-Jwt-Assertion": t1})
     assert r1.status == 200
-    # Mint with a different kid; the lens must refetch JWKS to discover it
-    # and accept the JWT after the refresh.
-    t2 = jwks.mint(aud="aud-test", claims={"email": "alice@example.com", "sub": "s"}, kid="rotated-kid")
-    # FakeJWKS still serves only the original kid, so this MUST fail.
-    r2 = await cf_client.get("/healthz", headers={"Cf-Access-Jwt-Assertion": t2})
+    # Mint with a kid the FakeJWKS doesn't actually serve. The lens
+    # refetches JWKS once after the cache miss and still won't find
+    # this kid — must respond 401.
+    t2 = jwks.mint(
+        aud="aud-test",
+        claims={"email": "alice@example.com", "sub": "s"},
+        kid="rotated-kid",
+    )
+    r2 = await cf_client.get(_AUTH_CANARY_PATH, headers={"Cf-Access-Jwt-Assertion": t2})
     assert r2.status == 401

--- a/tests/test_auth_middleware.py
+++ b/tests/test_auth_middleware.py
@@ -240,6 +240,127 @@ async def test_jwks_unreachable_mid_request_returns_502(jwks: FakeJWKS) -> None:
         await client.close()
 
 
+async def test_jwks_timeout_returns_502(jwks: FakeJWKS, monkeypatch) -> None:
+    """`aiohttp.ClientTimeout` raises `asyncio.TimeoutError`, which is
+    NOT a subclass of `aiohttp.ClientError`. The middleware must catch
+    both and surface a 502 — without it, a slow JWKS endpoint would
+    return an unhandled 500 (Qodo PR #34 review)."""
+    import asyncio
+    from irc_lens.web import auth as auth_module
+
+    config = _cf_config(jwks, allowed=["alice@example.com"])
+
+    def boom_factory(_n: str):
+        raise AssertionError("session factory must not run during auth tests")
+
+    app = make_app(config, boom_factory)
+    app.router.add_get(_AUTH_CANARY_PATH, _auth_canary_handler)
+
+    # Patch the JWKSCache._refresh to raise asyncio.TimeoutError.
+    async def fake_refresh(self):
+        raise asyncio.TimeoutError("simulated JWKS slow response")
+
+    monkeypatch.setattr(auth_module._JWKSCache, "_refresh", fake_refresh)
+
+    server = TestServer(app)
+    client = TestClient(server)
+    await client.start_server()
+    try:
+        token = jwks.mint(
+            aud="aud-test",
+            claims={"email": "alice@example.com", "sub": "s"},
+        )
+        r = await client.get(
+            _AUTH_CANARY_PATH,
+            headers={"Cf-Access-Jwt-Assertion": token},
+        )
+        assert r.status == 502
+        body = await r.json()
+        assert "could not reach Cloudflare JWKS" in body["error"]
+        assert "TimeoutError" in body["hint"]
+    finally:
+        await client.close()
+
+
+async def test_jwks_concurrent_misses_share_one_refresh(jwks: FakeJWKS) -> None:
+    """Concurrent `get_key` calls with the same unknown kid must NOT
+    each fire a separate JWKS fetch — single-flight via the lock means
+    one refresh, then the others see the populated cache (Copilot
+    PR #34 thundering-herd review)."""
+    import asyncio
+    from irc_lens.web.auth import _JWKSCache
+
+    cache = _JWKSCache(jwks.team_domain)
+    fetch_count = 0
+    original_refresh = cache._refresh
+
+    async def counting_refresh():
+        nonlocal fetch_count
+        fetch_count += 1
+        await original_refresh()
+
+    cache._refresh = counting_refresh
+    # Fire 5 concurrent get_key calls for the kid the FakeJWKS is
+    # serving. Without the lock they would each call _refresh; with
+    # it, exactly one call fetches.
+    results = await asyncio.gather(
+        *(cache.get_key("test-kid-1") for _ in range(5))
+    )
+    assert all(r is not None for r in results)
+    assert fetch_count == 1, (
+        f"expected exactly 1 JWKS refresh under contention, got {fetch_count}"
+    )
+
+
+async def test_build_cloudflare_middleware_invalid_mode_raises_afierror(
+    jwks: FakeJWKS,
+) -> None:
+    """If a caller bypasses load_config and hands in a non-CF mode,
+    the build-time guard must raise AfiError (so the dispatcher
+    renders error/hint), not a bare ValueError that would land in the
+    catch-all `file a bug` arm (Qodo PR #34 review)."""
+    from irc_lens._errors import EXIT_USER_ERROR, AfiError
+    from irc_lens.web.auth import build_cloudflare_middleware
+
+    bad_config = LensConfig(
+        auth_mode="dev",  # wrong for build_cloudflare_middleware
+        dev_nick="x",
+        dev_email="x@x",
+        cf_aud=None,
+        cf_team_domain=None,
+        allowed_emails=(),
+        allowed_service_tokens=(),
+        server_name="testsrv",
+        server_host="127.0.0.1",
+        server_port=6667,
+        web_bind="127.0.0.1",
+        web_port=0,
+    )
+    with pytest.raises(AfiError) as exc:
+        build_cloudflare_middleware(bad_config)
+    assert exc.value.code == EXIT_USER_ERROR
+
+    # Also: missing aud / team_domain in CF mode → AfiError, not ValueError.
+    incomplete = LensConfig(
+        auth_mode="cloudflare-access",
+        dev_nick=None,
+        dev_email=None,
+        cf_aud=None,         # missing
+        cf_team_domain=None, # missing
+        allowed_emails=("a@example.com",),
+        allowed_service_tokens=(),
+        server_name="testsrv",
+        server_host="127.0.0.1",
+        server_port=6667,
+        web_bind="127.0.0.1",
+        web_port=0,
+    )
+    with pytest.raises(AfiError) as exc2:
+        build_cloudflare_middleware(incomplete)
+    assert exc2.value.code == EXIT_USER_ERROR
+    assert "auth.cloudflare.aud" in exc2.value.message
+
+
 async def test_service_token_common_name_accepted(jwks: FakeJWKS) -> None:
     """A JWT with `common_name` (no `email`) is accepted iff CN is in
     auth.allowed_service_tokens. A rogue CN gets 403 from the

--- a/tests/test_auth_middleware.py
+++ b/tests/test_auth_middleware.py
@@ -185,6 +185,61 @@ async def test_rotated_kid_accepted_after_refresh(
     assert r2.status == 200
 
 
+async def test_warm_jwks_succeeds_against_live_server(jwks: FakeJWKS) -> None:
+    """`warm_jwks(config)` is the startup fail-fast contract. With the
+    FakeJWKS server live, it must complete without raising."""
+    from irc_lens.web.auth import warm_jwks
+
+    config = _cf_config(jwks, allowed=["alice@example.com"])
+    await warm_jwks(config)  # no raise = success
+
+
+async def test_warm_jwks_raises_when_server_unreachable(jwks: FakeJWKS) -> None:
+    """If the JWKS endpoint can't be reached, `warm_jwks` raises a
+    `ClientError` (which `serve.py` wraps as `AfiError(EXIT_ENV_ERROR)`)."""
+    import aiohttp
+
+    from irc_lens.web.auth import warm_jwks
+
+    config = _cf_config(jwks, allowed=["alice@example.com"])
+    await jwks.stop()  # tear down the JWKS server before warming
+    with pytest.raises(aiohttp.ClientError):
+        await warm_jwks(config)
+
+
+async def test_jwks_unreachable_mid_request_returns_502(jwks: FakeJWKS) -> None:
+    """If the JWKS server is reachable at startup but goes away before
+    the first request triggers a refresh, the middleware must surface
+    a 502, not crash with an unhandled exception."""
+    config = _cf_config(jwks, allowed=["alice@example.com"])
+
+    def boom_factory(_n: str):
+        raise AssertionError("session factory must not run during auth tests")
+
+    app = make_app(config, boom_factory)
+    app.router.add_get(_AUTH_CANARY_PATH, _auth_canary_handler)
+    server = TestServer(app)
+    client = TestClient(server)
+    await client.start_server()
+    try:
+        # Tear down the JWKS server BEFORE the first request, so the
+        # cache is empty and the refresh attempt fails with ClientError.
+        await jwks.stop()
+        token = jwks.mint(
+            aud="aud-test",
+            claims={"email": "alice@example.com", "sub": "s"},
+        )
+        r = await client.get(
+            _AUTH_CANARY_PATH,
+            headers={"Cf-Access-Jwt-Assertion": token},
+        )
+        assert r.status == 502
+        body = await r.json()
+        assert "could not reach Cloudflare JWKS" in body["error"]
+    finally:
+        await client.close()
+
+
 async def test_service_token_common_name_accepted(jwks: FakeJWKS) -> None:
     """A JWT with `common_name` (no `email`) is accepted iff CN is in
     auth.allowed_service_tokens. A rogue CN gets 403 from the

--- a/tests/test_auth_middleware.py
+++ b/tests/test_auth_middleware.py
@@ -1,0 +1,126 @@
+"""CF Access JWT validation + middleware behavior."""
+from __future__ import annotations
+
+from collections.abc import AsyncIterator
+
+import pytest
+import pytest_asyncio
+from aiohttp.test_utils import TestClient, TestServer
+
+from irc_lens.config import LensConfig
+from irc_lens.web import make_app
+
+from _jwks_server import FakeJWKS
+
+
+def _cf_config(jwks: FakeJWKS, allowed: list[str]) -> LensConfig:
+    return LensConfig(
+        auth_mode="cloudflare-access",
+        dev_nick=None,
+        dev_email=None,
+        cf_aud="aud-test",
+        cf_team_domain=jwks.team_domain,
+        allowed_emails=tuple(allowed),
+        allowed_service_tokens=(),
+        server_name="testsrv",
+        server_host="127.0.0.1",
+        server_port=6667,
+        web_bind="127.0.0.1",
+        web_port=0,
+    )
+
+
+@pytest_asyncio.fixture
+async def jwks() -> AsyncIterator[FakeJWKS]:
+    j = FakeJWKS()
+    await j.start()
+    try:
+        yield j
+    finally:
+        await j.stop()
+
+
+@pytest_asyncio.fixture
+async def cf_client(jwks: FakeJWKS) -> AsyncIterator[TestClient]:
+    """A lens TestClient in cloudflare-access mode wired to FakeJWKS.
+
+    Sessions never actually open in these tests — the middleware
+    intercepts before any handler that would call get_or_open.
+    The factory raises if invoked, to catch accidental routing.
+    """
+    config = _cf_config(jwks, allowed=["alice@example.com"])
+
+    def boom_factory(_nick: str):
+        raise AssertionError("session factory must not run during auth tests")
+
+    app = make_app(config, boom_factory)
+    server = TestServer(app)
+    client = TestClient(server)
+    await client.start_server()
+    try:
+        yield client
+    finally:
+        await client.close()
+
+
+async def test_missing_jwt_returns_401(cf_client: TestClient) -> None:
+    resp = await cf_client.get("/")
+    assert resp.status == 401
+    body = await resp.json()
+    assert "error" in body and "hint" in body
+
+
+async def test_valid_jwt_in_header_passes_to_handler(cf_client: TestClient, jwks: FakeJWKS) -> None:
+    token = jwks.mint(aud="aud-test", claims={"email": "alice@example.com", "sub": "s-1"})
+    # The boom_factory raises if the handler tries to open a session.
+    # /healthz skips auth and the registry, so use it as the canary that the
+    # *middleware* accepted the token.
+    resp = await cf_client.get("/healthz", headers={"Cf-Access-Jwt-Assertion": token})
+    assert resp.status == 200
+
+
+async def test_valid_jwt_in_cookie_also_accepted(cf_client: TestClient, jwks: FakeJWKS) -> None:
+    token = jwks.mint(aud="aud-test", claims={"email": "alice@example.com", "sub": "s-2"})
+    cf_client.session.cookie_jar.update_cookies({"CF_Authorization": token})
+    resp = await cf_client.get("/healthz")
+    assert resp.status == 200
+
+
+async def test_wrong_audience_returns_401(cf_client: TestClient, jwks: FakeJWKS) -> None:
+    token = jwks.mint(aud="aud-other", claims={"email": "alice@example.com", "sub": "s"})
+    resp = await cf_client.get("/", headers={"Cf-Access-Jwt-Assertion": token})
+    assert resp.status == 401
+
+
+async def test_email_not_on_allowlist_returns_403(cf_client: TestClient, jwks: FakeJWKS) -> None:
+    token = jwks.mint(aud="aud-test", claims={"email": "mallory@example.com", "sub": "s"})
+    resp = await cf_client.get("/", headers={"Cf-Access-Jwt-Assertion": token})
+    assert resp.status == 403
+    body = await resp.json()
+    assert "allowlist" in body["error"].lower()
+
+
+async def test_static_path_skips_auth(cf_client: TestClient) -> None:
+    # Static asset path must not require a JWT (browser fetches assets first
+    # before the SSO redirect lands on every request).
+    resp = await cf_client.get("/static/missing.js")
+    # 404 from the static handler is fine; 401 would mean middleware ran.
+    assert resp.status in (200, 404)
+
+
+async def test_kid_miss_then_refresh_succeeds(cf_client: TestClient, jwks: FakeJWKS) -> None:
+    """If the JWT's kid isn't in cache, we refetch JWKS once and retry.
+
+    FakeJWKS only serves the original kid, so a JWT with a different kid
+    must fail (401) even after a refresh — the lens refetches but still
+    doesn't find the rotated kid. T3.4 will add the success-path test."""
+    # First request populates the cache with the current kid.
+    t1 = jwks.mint(aud="aud-test", claims={"email": "alice@example.com", "sub": "s"})
+    r1 = await cf_client.get("/healthz", headers={"Cf-Access-Jwt-Assertion": t1})
+    assert r1.status == 200
+    # Mint with a different kid; the lens must refetch JWKS to discover it
+    # and accept the JWT after the refresh.
+    t2 = jwks.mint(aud="aud-test", claims={"email": "alice@example.com", "sub": "s"}, kid="rotated-kid")
+    # FakeJWKS still serves only the original kid, so this MUST fail.
+    r2 = await cf_client.get("/healthz", headers={"Cf-Access-Jwt-Assertion": t2})
+    assert r2.status == 401

--- a/tests/test_serve_cli.py
+++ b/tests/test_serve_cli.py
@@ -348,3 +348,27 @@ def test_serve_seed_missing_file_exits_user_error(
     assert "error:" in err
     assert "hint:" in err
     assert "Traceback" not in err
+
+
+def test_serve_explicit_config_missing_exits_user_error(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """`--config /missing/path` MUST error rather than silently fall
+    back to the synthetic dev config — a typo'd path could otherwise
+    quietly start an unauthenticated server when a CF deploy was
+    intended (Copilot PR #34 review)."""
+    rc = main(
+        [
+            "serve",
+            "--config", "/tmp/irc-lens-does-not-exist-12345.yaml",
+            "--nick", "lens",
+            "--web-port", "65002",
+        ]
+    )
+    assert rc == 1
+    err = capsys.readouterr().err
+    assert "error:" in err
+    assert "does not exist" in err
+    assert "hint:" in err
+    assert "config init" in err
+    assert "Traceback" not in err


### PR DESCRIPTION
Third PR in the [Cloudflare Access deployment plan](docs/superpowers/plans/2026-05-07-remote-connect-cloudflare-access.md) (issue #26). After this lands, the lens can validate Cloudflare Access JWTs end-to-end. Phase 4 ships CLI cleanups; Phase 5 ships docs and the real-CF round-trip.

## Summary

- New `src/irc_lens/web/auth.py` — Cloudflare Access JWT verification + JWKS cache + middleware.
  - Pins `algorithms=["RS256"]` (no `alg=none` attack), `audience` to `auth.cloudflare.aud`, `issuer` to `<scheme>://<auth.cloudflare.team_domain>`. Test mode uses `http://`, production `https://`.
  - `_JWKSCache` with kid-miss-then-refresh and a 5 s anti-flood window: empty cache always refreshes; populated cache + recent fetch raises `KeyError` immediately so a malformed-`kid` storm can't drive a refetch-per-request.
  - Service tokens (`common_name` claim) and interactive SSO (`email` claim) consult separate allowlists via an `is_email` discriminator. The two principal types can't cross-authorize.
  - `warm_jwks(config)` lets `serve.py` fail-fast at startup with `EXIT_ENV_ERROR` when Cloudflare is unreachable.
  - Audit log: one `auth=ok principal=… nick=… method=… path=…` line per authenticated request on the `irc_lens.web.auth` logger. Token / claims never logged.
- `src/irc_lens/web/app.py` — `make_app` now branches on `auth.mode`: `dev` keeps the synthetic identity middleware, `cloudflare-access` installs the new CF middleware. Unknown mode raises `AfiError(EXIT_USER_ERROR)` (not `RuntimeError`).
- `src/irc_lens/cli/_commands/serve.py` — new `--config` flag. Loads `LensConfig` from `--config` or `default_config_path()` when present; falls back to a synthetic dev `LensConfig` from CLI args when no file exists (Phase 4 will remove the fallback). CF mode warms JWKS at startup; dev mode preserves the singleton-Session-at-boot behavior.
- `tests/_jwks_server.py` — in-tree `FakeJWKS` fixture (RSA keypair, `/cdn-cgi/access/certs`, `mint()`, `rotate()`).
- `tests/test_auth_middleware.py` — 13 tests including `/healthz` bypass spec lock-down, kid-rotation success-path, service-token branch, JWKS-unreachable mid-request 502, and `warm_jwks` startup contract.
- `tests/test_audit_log.py` — 3 tests: one log line per authenticated request; `/healthz` and `/static/*` produce no audit line.
- Promoted the `jwks` fixture to `tests/conftest.py` for shared use.
- Added `slow` pytest marker (informational; the rotation test sleeps 5.1 s past the anti-flood window).

## Spec / plan reference

- Plan: `docs/superpowers/plans/2026-05-07-remote-connect-cloudflare-access.md` (Phase 3 = T3.1–T3.7)
- Spec: `docs/superpowers/specs/2026-05-06-remote-connect-cloudflare-access-design.md`

## Test plan

- [x] `uv run pytest -x` — 302 passed, 4 deselected.
- [x] `uv run pytest --cov=irc_lens.web.auth --cov-report=term-missing tests/test_auth_middleware.py tests/test_audit_log.py` — 89% on `web/auth.py`. Remaining 11% is defensive 401 paths (`ExpiredSignatureError`, `InvalidIssuerError`, no-principal, empty-nick-derivation, build-time misuse guards).
- [x] CLI smoke: `irc-lens serve --config /tmp/lens-cf.yaml` with bogus `team_domain` → exits 2 with `error: could not reach Cloudflare JWKS at … / hint: verify network egress and team_domain spelling`. No traceback leaked.
- [x] CLI smoke: `irc-lens serve --nick lens` (no config file) — backward-compat synthetic dev config still works.
- [x] Code-quality review by sonnet on the cumulative diff. Flagged S1192 (3× duplicated literal) + production-error coverage gaps; both addressed in commit `df6638d`.

## Security review highlights

The sonnet review verified, by reading the actual code:
- Algorithm pinning (no `alg=none`/`HS256` paths through).
- Audience/issuer captured by closure at factory time, not from token claims.
- Signature verified before claims read (`jwt.decode()` does both atomically).
- Service-token / interactive-SSO cross-authorization isolation (the `is_email` discriminator, no fallback path).
- Anti-flood window (one refetch per 5 s on kid miss).
- Token never logged (only `principal`, `nick`, `method`, `path`).
- `/healthz` bypass restored (`343bf0c`) and locked by `test_healthz_bypasses_auth_per_spec` so a future regression here would fail a test.

## Compatibility

- `irc-lens serve --nick lens` (no config) still works exactly as today via the synthetic-dev fallback. **Phase 4 (T4.4) will remove the fallback** — `--config` (or a config file at the default path) becomes required.
- `--seed` and `--icon` are silently ignored in CF mode. **Phase 4 (T4.1)** will hard-error on `--nick` in CF mode.
- The new `/test/auth-canary` route is mounted **only by the test fixtures**, never in production. Confirmed by `grep -rn auth-canary src/` returning nothing.

## Follow-ups (deferred to Phase 4 / Phase 5)

- `--nick`-rejected-in-CF, `--bind`-coercion-to-loopback, Origin/Referer floor on `POST /input`, version bump → **Phase 4**.
- Documentation deliverables (`docs/auth.md`, `docs/security-checklist.md`, `docs/deployment-cloudflare-access.md`) → **Phase 5**.
- Real-Cloudflare round-trip scripts + `@pytest.mark.cloudflare` test → **Phase 5**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

- Claude