### PR TITLE
Phase 4: CLI/HTTP cleanups (--nick reject in CF mode, Origin floor, config required)

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,8 @@ uv run pytest -m playwright -v           # browser e2e
 ## Production deployment
 
 To host irc-lens behind Cloudflare Access on your own domain, see
-[docs/deployment-cloudflare-access.md](docs/deployment-cloudflare-access.md).
+[docs/deployment-cloudflare-access.md](docs/deployment-cloudflare-access.md)
+(lands in the next release).
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -43,6 +43,11 @@ uv run pytest -m playwright -v           # browser e2e
   topology, module layout, decision log.
 * [`CITATION.md`](CITATION.md) — culture citations + divergences.
 
+## Production deployment
+
+To host irc-lens behind Cloudflare Access on your own domain, see
+[docs/deployment-cloudflare-access.md](docs/deployment-cloudflare-access.md).
+
 ## License
 
 See [LICENSE](LICENSE).

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -91,7 +91,8 @@ The starter file is in `auth.mode: dev`, suitable for a local AgentIRC
 on `127.0.0.1:6667`. To deploy behind Cloudflare Access, switch
 `auth.mode` to `cloudflare-access` and set `auth.cloudflare.aud`,
 `auth.cloudflare.team_domain`, and `auth.allowed_emails`. See
-[deployment-cloudflare-access.md](deployment-cloudflare-access.md).
+[deployment-cloudflare-access.md](deployment-cloudflare-access.md)
+(lands in the next release).
 
 ### `--nick` and `--bind`
 

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -98,8 +98,8 @@ on `127.0.0.1:6667`. To deploy behind Cloudflare Access, switch
 In `auth.mode: dev`, `--nick` overrides `auth.dev.nick`. In
 `auth.mode: cloudflare-access`, passing `--nick` is a hard error: the
 nick is derived per authenticated user from `auth.allowed_emails`.
-A non-loopback `--bind` (or `web.bind`) under CF mode is silently
-coerced to `127.0.0.1` because cloudflared terminates locally.
+A non-loopback `--bind` (or `web.bind`) under CF mode is coerced to
+`127.0.0.1` with a `WARNING` log line, because cloudflared terminates locally.
 
 ## `irc-lens serve`
 

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -96,8 +96,7 @@ on `127.0.0.1:6667`. To deploy behind Cloudflare Access, switch
 ### `--nick` and `--bind`
 
 In `auth.mode: dev`, `--nick` overrides `auth.dev.nick`. In
-`auth.mode: cloudflare-access`, passing `--nick` is a hard error: the
-nick is derived per authenticated user from `auth.allowed_emails`.
+`auth.mode: cloudflare-access`, passing `--nick` is a hard error: the nick is derived per authenticated user from the JWT principal (email or service-token common-name). `auth.allowed_emails` is only the allowlist.
 A non-loopback `--bind` (or `web.bind`) under CF mode is coerced to
 `127.0.0.1` with a `WARNING` log line, because cloudflared terminates locally.
 

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -80,6 +80,27 @@ irc-lens overview --json
 irc-lens cli overview
 ```
 
+## Configuration
+
+irc-lens reads `~/.config/irc-lens/config.yaml` by default (override with
+`--config <path>`, respecting `$XDG_CONFIG_HOME`). Initialize with:
+
+    irc-lens config init
+
+The starter file is in `auth.mode: dev`, suitable for a local AgentIRC
+on `127.0.0.1:6667`. To deploy behind Cloudflare Access, switch
+`auth.mode` to `cloudflare-access` and set `auth.cloudflare.aud`,
+`auth.cloudflare.team_domain`, and `auth.allowed_emails`. See
+[deployment-cloudflare-access.md](deployment-cloudflare-access.md).
+
+### `--nick` and `--bind`
+
+In `auth.mode: dev`, `--nick` overrides `auth.dev.nick`. In
+`auth.mode: cloudflare-access`, passing `--nick` is a hard error: the
+nick is derived per authenticated user from `auth.allowed_emails`.
+A non-loopback `--bind` (or `web.bind`) under CF mode is silently
+coerced to `127.0.0.1` because cloudflared terminates locally.
+
 ## `irc-lens serve`
 
 Launch the aiohttp web console against an AgentIRC server. The

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "irc-lens"
-version = "0.4.2"
+version = "0.5.0"
 description = "Reactive web console for AgentIRC — Playwright-driveable lens for the Culture mesh."
 readme = "README.md"
 requires-python = ">=3.11"

--- a/src/irc_lens/cli/_commands/serve.py
+++ b/src/irc_lens/cli/_commands/serve.py
@@ -1,10 +1,8 @@
 """``irc-lens serve`` — launch the aiohttp web console.
 
-Loads a ``LensConfig`` from ``--config`` (or ``default_config_path()`` if
-it exists). When no config file is found, falls back to building a synthetic
-dev ``LensConfig`` from the CLI args — this preserves backward compatibility
-with the existing ``irc-lens serve --nick lens`` invocation. Phase 4 (T4.4)
-makes the config file required.
+Loads a ``LensConfig`` from ``--config`` (or ``default_config_path()``).
+The config file is required; if it is absent the command exits 1 with an
+``error:`` / ``hint:`` pair that points at ``irc-lens config init``.
 
 In ``auth.mode: dev``, opens one Session at startup against the configured
 AgentIRC and pre-seeds the registry. In ``auth.mode: cloudflare-access``,
@@ -14,10 +12,13 @@ request.
 
 Spec contract enforced:
 
-* ``--nick`` is required (identity is the user's choice — no safe default).
-* ``--host`` / ``--port`` default to ``127.0.0.1`` / ``6667`` so a bare
-  ``irc-lens serve --nick <name>`` reaches a local AgentIRC out of the
-  box. Override either flag to point at a remote server.
+* Config file required — pass ``--config <path>`` or place a config at
+  ``~/.config/irc-lens/config.yaml``. Run ``irc-lens config init`` to
+  create one.
+* ``--nick`` in dev mode overrides ``auth.dev.nick`` from the config.
+  ``--nick`` is rejected in cloudflare-access mode.
+* ``--host`` / ``--port`` / ``--bind`` / ``--web-port`` supplement the
+  loaded config values.
 * ``--bind 0.0.0.0`` prints a loud stderr warning (no auth in v1).
 * AgentIRC unreachable → ``error:`` + ``hint:`` on stderr, exit 1,
   aiohttp never binds.
@@ -152,55 +153,14 @@ def _validate_cli_against_config(
     return config
 
 
-def _build_dev_config_from_args(args: argparse.Namespace) -> LensConfig:
-    """Build a synthetic dev-mode ``LensConfig`` from the CLI arguments.
-
-    This is the Phase-3 backward-compatibility fallback: when no config file
-    is found at ``--config`` (or ``default_config_path()``), the serve command
-    constructs a minimal ``LensConfig`` from the legacy ``--host``, ``--port``,
-    ``--nick``, ``--bind``, and ``--web-port`` flags so that the existing
-    ``irc-lens serve --nick lens`` invocation keeps working without a config
-    file. Phase 4 (T4.4) removes this fallback and makes ``--config`` (or the
-    default path) required.
-    """
-    if args.nick is None:
-        raise AfiError(
-            code=EXIT_USER_ERROR,
-            message="the following arguments are required: --nick",
-            remediation=(
-                "try 'irc-lens serve --nick <name>' (e.g. --nick lens); "
-                "run 'irc-lens serve --help' for all flags"
-            ),
-        )
-    dev_email = f"{args.nick}@local"
-    web_bind = args.bind if args.bind is not None else _LOOPBACK_DEFAULT
-    return LensConfig(
-        auth_mode="dev",
-        dev_nick=args.nick,
-        dev_email=dev_email,
-        cf_aud=None,
-        cf_team_domain=None,
-        allowed_emails=(),
-        allowed_service_tokens=(),
-        server_name="lens",
-        server_host=args.host,
-        server_port=args.port,
-        web_bind=web_bind,
-        web_port=args.web_port,
-    )
-
-
 def _resolve_config(args: argparse.Namespace) -> LensConfig:
-    """Load a LensConfig from `--config` / default path, or fall back
-    to the synthetic dev config from CLI args.
+    """Load a LensConfig from ``--config`` or the default path.
 
-    Phase 4 (T4.4) removes the fallback so the file becomes required.
-
-    If the user *explicitly* passes ``--config <path>``, the path must
-    exist — silently dropping to the synthetic dev config on a missed
-    typo would risk starting an unauthenticated server when the user
-    intended a CF-mode deploy. The fallback only applies when no
-    ``--config`` was passed AND the default location is empty.
+    The config file is required (T4.4). If the user passes ``--config
+    <path>`` that path must exist. If no ``--config`` is given, the default
+    location (``~/.config/irc-lens/config.yaml``) must exist. Either way,
+    a missing file exits 1 with ``error:`` / ``hint:`` pointing at
+    ``irc-lens config init``.
     """
     if args.config:
         explicit = Path(args.config)
@@ -215,9 +175,16 @@ def _resolve_config(args: argparse.Namespace) -> LensConfig:
             )
         return load_config(explicit)
     default = default_config_path()
-    if default.exists():
-        return load_config(default)
-    return _build_dev_config_from_args(args)
+    if not default.exists():
+        raise AfiError(
+            code=EXIT_USER_ERROR,
+            message=f"no config at {default}",
+            remediation=(
+                "run 'irc-lens config init' to create one, "
+                "or pass --config <path>"
+            ),
+        )
+    return load_config(default)
 
 
 async def _connect_dev_session(args: argparse.Namespace, config: LensConfig) -> Session:
@@ -382,7 +349,32 @@ async def _serve_async(args: argparse.Namespace) -> None:
     everything on one loop until shutdown.
     """
     config = _resolve_config(args)
+    # Apply explicit CLI overrides on top of the loaded config.  Each flag
+    # uses `is not None` (or `!= default`) so that an absent flag leaves the
+    # config value intact while an explicit flag always wins.
+    overrides: dict[str, object] = {}
+    # --host / --port supplement server.{host,port} from the config.
+    # argparse sets these to their defaults (127.0.0.1 / 6667) even when the
+    # flag is absent, so we cannot distinguish "flag absent" from "flag
+    # matches default".  We always apply them — the config author who wants
+    # a different default can set it in the file; the CLI flag always wins.
+    overrides["server_host"] = args.host
+    overrides["server_port"] = args.port
+    # --web-port: argparse default is 8765; always apply.
+    overrides["web_port"] = args.web_port
+    # --bind: None means "use config value"; any explicit string overrides it.
+    if args.bind is not None:
+        overrides["web_bind"] = args.bind
+    if overrides:
+        config = replace(config, **overrides)
+    # Apply CF-mode guards (rejects --nick in CF; coerces non-loopback --bind).
     config = _validate_cli_against_config(config, nick=args.nick, bind=args.bind)
+    # Dev-mode nick override: --nick <name> replaces auth.dev.nick from the
+    # config.  This path is intentionally reached only when mode is dev
+    # (CF mode already raised above).
+    if config.auth_mode == "dev" and args.nick is not None:
+        dev_email = f"{args.nick}@local"
+        config = replace(config, dev_nick=args.nick, dev_email=dev_email)
     app, dev_session = await _build_app(args, config)
     runner = web.AppRunner(app, handle_signals=True)
     await runner.setup()
@@ -427,8 +419,8 @@ def register(sub: argparse._SubParsersAction) -> None:
         help="Launch the aiohttp web console against an AgentIRC server.",
         description=(
             "Launch the aiohttp web console against an AgentIRC server. "
-            "Defaults target a local culture server on 127.0.0.1:6667 — only "
-            "--nick is required for the common case."
+            "A config file is required — run 'irc-lens config init' to create one. "
+            "Defaults target a local culture server on 127.0.0.1:6667."
         ),
         epilog=(
             "examples:\n"
@@ -447,7 +439,7 @@ def register(sub: argparse._SubParsersAction) -> None:
         default=None,
         help=(
             "Path to irc-lens config.yaml (default: ~/.config/irc-lens/config.yaml). "
-            "When absent, builds a synthetic dev config from the other CLI flags."
+            "Required — run 'irc-lens config init' to create one."
         ),
     )
     # `%(default)s` lets argparse render the actual default at help-time,
@@ -470,7 +462,7 @@ def register(sub: argparse._SubParsersAction) -> None:
         default=None,
         help=(
             "Nick to register on AgentIRC (e.g. --nick lens). "
-            "Required in dev mode (no config file). "
+            "Overrides auth.dev.nick from the config in dev mode. "
             "Invalid in cloudflare-access mode — nick is derived from the JWT."
         ),
     )

--- a/src/irc_lens/cli/_commands/serve.py
+++ b/src/irc_lens/cli/_commands/serve.py
@@ -137,8 +137,8 @@ def _validate_cli_against_config(
             code=EXIT_USER_ERROR,
             message="--nick is not valid when auth.mode is cloudflare-access",
             remediation=(
-                "remove --nick — in CF mode the nick is derived per "
-                "authenticated user from auth.allowed_emails"
+                "remove --nick — in CF mode the nick is derived per authenticated "
+                "user from the JWT principal (email or service-token common-name)"
             ),
         )
     effective_bind = bind if bind is not None else config.web_bind
@@ -353,28 +353,40 @@ async def _serve_async(args: argparse.Namespace) -> None:
     # uses `is not None` (or `!= default`) so that an absent flag leaves the
     # config value intact while an explicit flag always wins.
     overrides: dict[str, object] = {}
-    # --host / --port supplement server.{host,port} from the config.
-    # argparse sets these to their defaults (127.0.0.1 / 6667) even when the
-    # flag is absent, so we cannot distinguish "flag absent" from "flag
-    # matches default".  We always apply them — the config author who wants
-    # a different default can set it in the file; the CLI flag always wins.
-    overrides["server_host"] = args.host
-    overrides["server_port"] = args.port
-    # --web-port: argparse default is 8765; always apply.
-    overrides["web_port"] = args.web_port
-    # --bind: None means "use config value"; any explicit string overrides it.
+    # Each flag defaults to None (sentinel). Only override the config value
+    # when the flag was explicitly supplied on the command line.
+    if args.host is not None:
+        overrides["server_host"] = args.host
+    if args.port is not None:
+        overrides["server_port"] = args.port
+    if args.web_port is not None:
+        overrides["web_port"] = args.web_port
     if args.bind is not None:
         overrides["web_bind"] = args.bind
     if overrides:
         config = replace(config, **overrides)
     # Apply CF-mode guards (rejects --nick in CF; coerces non-loopback --bind).
+    # CF mode's coercion to 127.0.0.1 happens inside this call, so the
+    # 0.0.0.0 / :: warning below fires on the *effective* bind, not the raw
+    # CLI flag — an operator who sets `web.bind: 0.0.0.0` in YAML without
+    # passing --bind will still see the warning.
     config = _validate_cli_against_config(config, nick=args.nick, bind=args.bind)
+    # Warn when the effective bind address is a wildcard — the lens has no
+    # built-in authentication in v1 and a wildcard bind exposes it to every
+    # network interface. CF mode will have already coerced this to loopback;
+    # this warning therefore only fires in dev mode.
+    if config.web_bind in ("0.0.0.0", "::"):
+        emit_diagnostic(
+            f"warning: binding to {config.web_bind} exposes the lens with NO "
+            "authentication (0.0.0.0 / :: means reachable from any network "
+            "interface — there is no built-in authentication in v1). "
+            "Use --bind 127.0.0.1 unless you know what you're doing."
+        )
     # Dev-mode nick override: --nick <name> replaces auth.dev.nick from the
     # config.  This path is intentionally reached only when mode is dev
     # (CF mode already raised above).
     if config.auth_mode == "dev" and args.nick is not None:
-        dev_email = f"{args.nick}@local"
-        config = replace(config, dev_nick=args.nick, dev_email=dev_email)
+        config = replace(config, dev_nick=args.nick)
     app, dev_session = await _build_app(args, config)
     runner = web.AppRunner(app, handle_signals=True)
     await runner.setup()
@@ -396,13 +408,6 @@ async def _serve_async(args: argparse.Namespace) -> None:
 
 
 def cmd_serve(args: argparse.Namespace) -> int:
-    if args.bind == "0.0.0.0":
-        emit_diagnostic(
-            "warning: --bind 0.0.0.0 exposes the lens with NO authentication "
-            "(v1 has no auth). Use --bind 127.0.0.1 unless you know what "
-            "you're doing."
-        )
-
     _configure_logging(args.log_json)
 
     try:
@@ -448,14 +453,20 @@ def register(sub: argparse._SubParsersAction) -> None:
     # tests/test_serve_cli.py::test_serve_help_renders_defaults_from_argparse.
     p.add_argument(
         "--host",
-        default="127.0.0.1",
-        help="AgentIRC server host (default: %(default)s).",
+        default=None,
+        help=(
+            "AgentIRC server host "
+            "(default: from config; falls back to 127.0.0.1 if config doesn't set it)."
+        ),
     )
     p.add_argument(
         "--port",
         type=int,
-        default=6667,
-        help="AgentIRC server port (default: %(default)s).",
+        default=None,
+        help=(
+            "AgentIRC server port "
+            "(default: from config; falls back to 6667 if config doesn't set it)."
+        ),
     )
     p.add_argument(
         "--nick",
@@ -469,8 +480,11 @@ def register(sub: argparse._SubParsersAction) -> None:
     p.add_argument(
         "--web-port",
         type=int,
-        default=8765,
-        help="Local HTTP port for the lens UI (default: %(default)s).",
+        default=None,
+        help=(
+            "Local HTTP port for the lens UI "
+            "(default: from config; falls back to 8765 if config doesn't set it)."
+        ),
     )
     p.add_argument(
         "--bind",

--- a/src/irc_lens/cli/_commands/serve.py
+++ b/src/irc_lens/cli/_commands/serve.py
@@ -36,6 +36,7 @@ import json
 import logging
 import sys
 import webbrowser
+from dataclasses import replace
 from pathlib import Path
 
 from aiohttp import web
@@ -47,6 +48,10 @@ from irc_lens.session import LensConnectionLost, Session
 from irc_lens.web import make_app
 from irc_lens.web.auth import warm_jwks
 from irc_lens.web.sessions import SessionFactory, disconnect_all
+
+logger = logging.getLogger("irc_lens.serve")
+
+_LOOPBACK = {"127.0.0.1", "::1", "localhost"}
 
 # `irc_lens.seed` is imported function-locally inside `_serve_async`
 # to avoid a real-but-latent module-load cycle:
@@ -111,6 +116,40 @@ def _display_url(bind: str, port: int) -> str:
     return f"http://{host}:{port}/"
 
 
+def _validate_cli_against_config(
+    config: LensConfig,
+    nick: str | None,
+    bind: str | None,
+) -> LensConfig:
+    """Apply CF-mode CLI rules. Returns a possibly-coerced config.
+
+    In dev mode this is a no-op.  In cloudflare-access mode:
+    - ``--nick`` is rejected (nick is derived per user from the JWT).
+    - A non-loopback ``--bind`` is coerced to ``127.0.0.1`` with a WARNING,
+      because cloudflared terminates locally and a public bind would bypass auth.
+    """
+    if config.auth_mode != "cloudflare-access":
+        return config
+    if nick is not None:
+        raise AfiError(
+            code=EXIT_USER_ERROR,
+            message="--nick is not valid when auth.mode is cloudflare-access",
+            remediation=(
+                "remove --nick — in CF mode the nick is derived per "
+                "authenticated user from auth.allowed_emails"
+            ),
+        )
+    effective_bind = bind if bind is not None else config.web_bind
+    if effective_bind not in _LOOPBACK:
+        logger.warning(
+            "web.bind=%s is not loopback; coerced to 127.0.0.1 because "
+            "cloudflared terminates locally",
+            effective_bind,
+        )
+        return replace(config, web_bind="127.0.0.1")
+    return config
+
+
 def _build_dev_config_from_args(args: argparse.Namespace) -> LensConfig:
     """Build a synthetic dev-mode ``LensConfig`` from the CLI arguments.
 
@@ -122,7 +161,17 @@ def _build_dev_config_from_args(args: argparse.Namespace) -> LensConfig:
     file. Phase 4 (T4.4) removes this fallback and makes ``--config`` (or the
     default path) required.
     """
+    if args.nick is None:
+        raise AfiError(
+            code=EXIT_USER_ERROR,
+            message="the following arguments are required: --nick",
+            remediation=(
+                "try 'irc-lens serve --nick <name>' (e.g. --nick lens); "
+                "run 'irc-lens serve --help' for all flags"
+            ),
+        )
     dev_email = f"{args.nick}@local"
+    web_bind = args.bind if args.bind is not None else "127.0.0.1"
     return LensConfig(
         auth_mode="dev",
         dev_nick=args.nick,
@@ -134,7 +183,7 @@ def _build_dev_config_from_args(args: argparse.Namespace) -> LensConfig:
         server_name="lens",
         server_host=args.host,
         server_port=args.port,
-        web_bind=args.bind,
+        web_bind=web_bind,
         web_port=args.web_port,
     )
 
@@ -331,6 +380,7 @@ async def _serve_async(args: argparse.Namespace) -> None:
     everything on one loop until shutdown.
     """
     config = _resolve_config(args)
+    config = _validate_cli_against_config(config, nick=args.nick, bind=args.bind)
     app, dev_session = await _build_app(args, config)
     runner = web.AppRunner(app, handle_signals=True)
     await runner.setup()
@@ -415,8 +465,12 @@ def register(sub: argparse._SubParsersAction) -> None:
     )
     p.add_argument(
         "--nick",
-        required=True,
-        help="Nick to register on AgentIRC (e.g. --nick lens).",
+        default=None,
+        help=(
+            "Nick to register on AgentIRC (e.g. --nick lens). "
+            "Required in dev mode (no config file). "
+            "Invalid in cloudflare-access mode — nick is derived from the JWT."
+        ),
     )
     p.add_argument(
         "--web-port",
@@ -426,10 +480,12 @@ def register(sub: argparse._SubParsersAction) -> None:
     )
     p.add_argument(
         "--bind",
-        default="127.0.0.1",
+        default=None,
         help=(
-            "Bind address for the local web app (default: %(default)s). "
-            "Using 0.0.0.0 prints a warning — there is no auth in v1."
+            "Bind address for the local web app "
+            "(default: web.bind from config, or 127.0.0.1). "
+            "Using 0.0.0.0 prints a warning — there is no auth in v1. "
+            "In cloudflare-access mode a non-loopback bind is coerced to 127.0.0.1."
         ),
     )
     p.add_argument("--icon", default=None, help="Optional emoji passed to AgentIRC ICON.")

--- a/src/irc_lens/cli/_commands/serve.py
+++ b/src/irc_lens/cli/_commands/serve.py
@@ -39,6 +39,7 @@ import sys
 import webbrowser
 from dataclasses import replace
 from pathlib import Path
+from typing import cast
 
 from aiohttp import web
 
@@ -149,7 +150,7 @@ def _validate_cli_against_config(
             effective_bind,
             _LOOPBACK_DEFAULT,
         )
-        return replace(config, web_bind=_LOOPBACK_DEFAULT)
+        return cast(LensConfig, replace(config, web_bind=_LOOPBACK_DEFAULT))
     return config
 
 

--- a/src/irc_lens/cli/_commands/serve.py
+++ b/src/irc_lens/cli/_commands/serve.py
@@ -52,6 +52,7 @@ from irc_lens.web.sessions import SessionFactory, disconnect_all
 logger = logging.getLogger("irc_lens.serve")
 
 _LOOPBACK = {"127.0.0.1", "::1", "localhost"}
+_LOOPBACK_DEFAULT = "127.0.0.1"
 
 # `irc_lens.seed` is imported function-locally inside `_serve_async`
 # to avoid a real-but-latent module-load cycle:
@@ -142,11 +143,12 @@ def _validate_cli_against_config(
     effective_bind = bind if bind is not None else config.web_bind
     if effective_bind not in _LOOPBACK:
         logger.warning(
-            "web.bind=%s is not loopback; coerced to 127.0.0.1 because "
+            "web.bind=%s is not loopback; coerced to %s because "
             "cloudflared terminates locally",
             effective_bind,
+            _LOOPBACK_DEFAULT,
         )
-        return replace(config, web_bind="127.0.0.1")
+        return replace(config, web_bind=_LOOPBACK_DEFAULT)
     return config
 
 
@@ -171,7 +173,7 @@ def _build_dev_config_from_args(args: argparse.Namespace) -> LensConfig:
             ),
         )
     dev_email = f"{args.nick}@local"
-    web_bind = args.bind if args.bind is not None else "127.0.0.1"
+    web_bind = args.bind if args.bind is not None else _LOOPBACK_DEFAULT
     return LensConfig(
         auth_mode="dev",
         dev_nick=args.nick,
@@ -322,7 +324,7 @@ async def _build_app(
 
         app = make_app(config, cf_factory)
         # No pre-seed; --nick / --seed / --icon are ignored (Phase 4
-        # T4.1 will reject --nick with a hard error in CF mode).
+        # T4.1 rejects --nick with a hard error in CF mode).
         return app, None
     # Future-mode guard: load_config only allows "dev" or
     # "cloudflare-access", but a caller bypassing load_config (or a

--- a/src/irc_lens/web/routes.py
+++ b/src/irc_lens/web/routes.py
@@ -86,14 +86,17 @@ def _origin_ok(request: web.Request) -> bool:
     if not parsed.hostname:
         return False
     origin_host = parsed.hostname.lower()
-    origin_port = parsed.port if parsed.port is not None else (
-        443 if parsed.scheme == "https" else 80
-    )
+    origin_port = _effective_port(parsed.port, parsed.scheme)
     request_host = (request.url.host or "").lower()
-    request_port = request.url.port if request.url.port is not None else (
-        443 if request.url.scheme == "https" else 80
-    )
+    request_port = _effective_port(request.url.port, request.url.scheme)
     return (origin_host, origin_port) == (request_host, request_port)
+
+
+def _effective_port(port: int | None, scheme: str) -> int:
+    """Resolve an explicit port, defaulting to the scheme's standard port."""
+    if port is not None:
+        return port
+    return 443 if scheme == "https" else 80
 
 
 async def get_index(request: web.Request) -> web.Response:

--- a/src/irc_lens/web/routes.py
+++ b/src/irc_lens/web/routes.py
@@ -19,6 +19,7 @@ from __future__ import annotations
 
 import json
 import logging
+import urllib.parse
 
 from aiohttp import web
 
@@ -63,6 +64,24 @@ def _connection_lost(message: str) -> web.Response:
         {"error": message, "hint": _UNHEALTHY_HINT},
         status=503,
     )
+
+
+def _origin_ok(request: web.Request) -> bool:
+    """CSRF defense-in-depth: verify the Origin header matches the request host.
+
+    - Origin absent → allow (curl, cloudflared probes, internal monitors).
+    - Origin present → parse netloc (host:port) and compare against the
+      ``Host`` request header. Match → allow. Mismatch → deny.
+
+    ``Referer`` is intentionally NOT checked here — Origin is the only
+    signal in this iteration. A proper CSRF-token scheme is tracked in
+    issue #27 and will replace this floor in a later phase.
+    """
+    origin = request.headers.get("Origin")
+    if origin is None:
+        return True
+    parsed = urllib.parse.urlparse(origin)
+    return parsed.netloc == request.headers.get("Host", "")
 
 
 async def get_index(request: web.Request) -> web.Response:
@@ -140,6 +159,18 @@ async def post_input(request: web.Request) -> web.Response:
     # was honest about the Content-Length.
     if request.content_length is not None and request.content_length > _MAX_INPUT_BODY:
         return _too_large()
+
+    # CSRF defense floor: reject cross-origin POSTs. Origin-absent requests
+    # (curl, cloudflared probes, internal monitors) pass through unchanged.
+    # A full CSRF-token scheme is tracked in issue #27.
+    if not _origin_ok(request):
+        return web.json_response(
+            {
+                "error": "Origin does not match request host",
+                "hint": "this is a CSRF defense; submit from the lens UI itself",
+            },
+            status=403,
+        )
 
     session = await _resolve_session(request)
     # Health gate before parsing: once the AgentIRC pipe is gone, the

--- a/src/irc_lens/web/routes.py
+++ b/src/irc_lens/web/routes.py
@@ -67,21 +67,33 @@ def _connection_lost(message: str) -> web.Response:
 
 
 def _origin_ok(request: web.Request) -> bool:
-    """CSRF defense-in-depth: verify the Origin header matches the request host.
+    """CSRF defense-in-depth: verify Origin matches the request host.
+
+    Compares ``(hostname.lower(), port_or_default_for_scheme)`` tuples
+    rather than raw header strings so that case, default-port elision,
+    and IPv6 bracket formatting don't cause false 403s.
 
     - Origin absent → allow (curl, cloudflared probes, internal monitors).
-    - Origin present → parse netloc (host:port) and compare against the
-      ``Host`` request header. Match → allow. Mismatch → deny.
+    - Origin present → match → allow; mismatch → deny.
 
-    ``Referer`` is intentionally NOT checked here — Origin is the only
-    signal in this iteration. A proper CSRF-token scheme is tracked in
-    issue #27 and will replace this floor in a later phase.
+    A proper CSRF-token scheme is tracked in issue #27 and will replace
+    this floor in a later phase.
     """
     origin = request.headers.get("Origin")
     if origin is None:
         return True
     parsed = urllib.parse.urlparse(origin)
-    return parsed.netloc == request.headers.get("Host", "")
+    if not parsed.hostname:
+        return False
+    origin_host = parsed.hostname.lower()
+    origin_port = parsed.port if parsed.port is not None else (
+        443 if parsed.scheme == "https" else 80
+    )
+    request_host = (request.url.host or "").lower()
+    request_port = request.url.port if request.url.port is not None else (
+        443 if request.url.scheme == "https" else 80
+    )
+    return (origin_host, origin_port) == (request_host, request_port)
 
 
 async def get_index(request: web.Request) -> web.Response:

--- a/tests/test_healthz.py
+++ b/tests/test_healthz.py
@@ -1,0 +1,74 @@
+"""Spec contract tests for the ``/healthz`` endpoint.
+
+Per the Phase 4 plan (T4.2):
+1. ``/healthz`` returns HTTP 200 with body ``{"ok": true}`` and NOTHING ELSE.
+2. No IRC state leak (opaque response).
+3. Available unauthenticated in BOTH dev mode AND cloudflare-access mode.
+
+The auth middleware's bypass for ``/healthz`` is a hard contract — this test
+guards against future regression of that bypass.
+"""
+from __future__ import annotations
+
+from aiohttp.test_utils import TestClient, TestServer
+
+import pytest_asyncio
+
+from irc_lens.config import LensConfig
+from irc_lens.web import make_app
+
+from _jwks_server import FakeJWKS
+
+
+async def test_healthz_returns_only_ok(lens_client: TestClient) -> None:
+    """In dev mode, ``/healthz`` returns 200 with exact response ``{"ok": true}``.
+
+    No IRC state, no extra fields, no allowlist leak — the response is opaque.
+    Asserts exact JSON equality to catch accidental field additions in the future.
+    """
+    r = await lens_client.get("/healthz")
+    assert r.status == 200
+    body = await r.json()
+    assert body == {"ok": True}
+
+
+async def test_healthz_without_auth_in_cf_mode_works(jwks: FakeJWKS) -> None:
+    """In cloudflare-access mode, ``/healthz`` bypasses auth and returns 200.
+
+    No JWT header, no JWT cookie, no auth middleware validation — the
+    response must still be 200 with ``{"ok": true}``. The session factory
+    is never invoked, proving the middleware doesn't require auth to reach
+    this endpoint.
+    """
+    # Build a CF-mode config pointed at the test JWKS server.
+    config = LensConfig(
+        auth_mode="cloudflare-access",
+        dev_nick=None,
+        dev_email=None,
+        cf_aud="aud-test",
+        cf_team_domain=jwks.team_domain,
+        allowed_emails=("alice@example.com",),
+        allowed_service_tokens=(),
+        server_name="spark",
+        server_host="127.0.0.1",
+        server_port=6667,
+        web_bind="127.0.0.1",
+        web_port=0,
+    )
+
+    # Factory that raises if invoked — /healthz must not trigger session creation.
+    def boom_factory(_nick: str):
+        raise AssertionError("session factory must not run for /healthz")
+
+    app = make_app(config, boom_factory)
+    server = TestServer(app)
+    client = TestClient(server)
+    await client.start_server()
+    try:
+        # Hit /healthz with no JWT header and no JWT cookie.
+        r = await client.get("/healthz")
+        assert r.status == 200
+        body = await r.json()
+        assert body == {"ok": True}
+    finally:
+        await client.close()

--- a/tests/test_origin_check.py
+++ b/tests/test_origin_check.py
@@ -69,3 +69,55 @@ async def test_post_input_foreign_origin_rejected(lens_client: TestClient) -> No
     assert "origin" in body["error"].lower(), (
         f"Expected 'origin' in error message, got: {body['error']!r}"
     )
+    assert "hint" in body, f"Response body missing 'hint' key: {body}"
+    assert body["hint"], f"Expected non-empty 'hint', got: {body['hint']!r}"
+
+
+@pytest.mark.asyncio
+async def test_post_input_origin_default_port_omitted(lens_client: TestClient) -> None:
+    """Origin with default port omitted for a foreign host still 403s.
+
+    Verifies that default-port elision (no :80 in the Origin header)
+    doesn't break the foreign-origin rejection path.  The lens fixture
+    binds on a non-standard port so the comparison tuple always differs.
+    """
+    resp = await lens_client.post(
+        "/input",
+        data={"text": "hello"},
+        headers={"Origin": "http://evil.example.com"},  # no port → default 80
+    )
+    assert resp.status == 403, (
+        f"Expected 403 for default-port-omitted foreign Origin, got {resp.status}"
+    )
+    body = await resp.json()
+    assert "error" in body
+    assert "hint" in body
+    assert body["hint"]
+
+
+@pytest.mark.asyncio
+async def test_post_input_origin_with_path_component(lens_client: TestClient) -> None:
+    """Origin with a path component is allowed when the host+port matches.
+
+    The Origin header normally doesn't include a path, but this defensive
+    test confirms the helper only compares (hostname, port) — a spurious
+    path in the header doesn't break the match.
+    """
+    port = lens_client.port
+    origin = f"http://127.0.0.1:{port}/some/path"
+    resp = await lens_client.post(
+        "/input",
+        data={"text": "hello"},
+        headers={"Origin": origin},
+    )
+    assert resp.status in (204, 503), (
+        f"Expected 204 or 503 for matching-host Origin-with-path, got {resp.status}"
+    )
+
+
+# omitted: test_post_input_origin_case_insensitive — the aiohttp TestServer
+# binds on 127.0.0.1 (IP literal); constructing an Origin with an uppercase
+# hostname like 'LOCALHOST' that maps to the same address would require DNS
+# mocking or a second server bind.  The implementation handles it (hostname
+# comparison is lowercased on both sides) but the fixture mechanics make an
+# in-test assertion impractical.

--- a/tests/test_origin_check.py
+++ b/tests/test_origin_check.py
@@ -1,0 +1,71 @@
+"""Spec contract tests for the same-host Origin CSRF floor on ``POST /input``.
+
+Per Phase 4 plan T4.3:
+1. Origin absent  → NOT 403 (204 or 503 acceptable — depends on session state).
+2. Origin matches Host → NOT 403.
+3. Origin mismatches Host → 403 with JSON body containing ``"origin"`` in ``error``.
+
+The floor deliberately allows Origin-absent requests so that curl,
+cloudflared probes, and internal monitors continue to work unmodified.
+Full CSRF-token protection is tracked in issue #27.
+"""
+from __future__ import annotations
+
+import pytest
+from aiohttp.test_utils import TestClient
+
+
+@pytest.mark.asyncio
+async def test_post_input_no_origin_allowed(lens_client: TestClient) -> None:
+    """POST /input with no Origin header must NOT return 403.
+
+    The spec guarantees Origin-absent requests pass through; the response
+    will be 204 (success) or 503 (no healthy upstream) depending on
+    AgentIRC state — both are acceptable. The important contract is that
+    the CSRF floor is not triggered.
+    """
+    resp = await lens_client.post("/input", data={"text": "hello"})
+    assert resp.status in (204, 503), (
+        f"Expected 204 or 503 for Origin-absent request, got {resp.status}"
+    )
+
+
+@pytest.mark.asyncio
+async def test_post_input_matching_origin_allowed(lens_client: TestClient) -> None:
+    """POST /input with Origin matching the server host must NOT return 403.
+
+    The aiohttp TestServer binds on 127.0.0.1:<port>. We construct the
+    Origin as ``http://127.0.0.1:<port>`` so netloc comparison succeeds.
+    """
+    port = lens_client.port
+    origin = f"http://127.0.0.1:{port}"
+    resp = await lens_client.post(
+        "/input",
+        data={"text": "hello"},
+        headers={"Origin": origin},
+    )
+    assert resp.status in (204, 503), (
+        f"Expected 204 or 503 for matching-Origin request, got {resp.status}"
+    )
+
+
+@pytest.mark.asyncio
+async def test_post_input_foreign_origin_rejected(lens_client: TestClient) -> None:
+    """POST /input with a foreign Origin must return 403 with ``{error, hint}`` JSON.
+
+    The error message must contain the word ``"origin"`` (case-insensitive)
+    so the caller can identify the cause without parsing the hint.
+    """
+    resp = await lens_client.post(
+        "/input",
+        data={"text": "hello"},
+        headers={"Origin": "https://evil.example.com"},
+    )
+    assert resp.status == 403, (
+        f"Expected 403 for foreign-Origin request, got {resp.status}"
+    )
+    body = await resp.json()
+    assert "error" in body, f"Response body missing 'error' key: {body}"
+    assert "origin" in body["error"].lower(), (
+        f"Expected 'origin' in error message, got: {body['error']!r}"
+    )

--- a/tests/test_serve_cf_mode.py
+++ b/tests/test_serve_cf_mode.py
@@ -2,7 +2,6 @@
 from __future__ import annotations
 
 import logging
-from pathlib import Path
 
 import pytest
 
@@ -28,7 +27,7 @@ def _cf_config() -> LensConfig:
     )
 
 
-def test_nick_rejected_in_cf_mode(tmp_path: Path) -> None:
+def test_nick_rejected_in_cf_mode() -> None:
     cfg = _cf_config()
     with pytest.raises(AfiError) as exc:
         _validate_cli_against_config(cfg, nick="something", bind="127.0.0.1")
@@ -44,10 +43,11 @@ def test_bind_coerced_to_loopback_in_cf_mode(caplog) -> None:
     assert any("coerced" in r.getMessage().lower() for r in caplog.records)
 
 
-def test_loopback_bind_unchanged_in_cf_mode() -> None:
+@pytest.mark.parametrize("loopback_bind", ["127.0.0.1", "::1", "localhost"])
+def test_loopback_bind_unchanged_in_cf_mode(loopback_bind: str) -> None:
     cfg = _cf_config()
-    coerced = _validate_cli_against_config(cfg, nick=None, bind="127.0.0.1")
-    assert coerced.web_bind == "127.0.0.1"
+    coerced = _validate_cli_against_config(cfg, nick=None, bind=loopback_bind)
+    assert coerced.web_bind == cfg.web_bind
 
 
 def test_dev_mode_passes_through_unchanged() -> None:

--- a/tests/test_serve_cf_mode.py
+++ b/tests/test_serve_cf_mode.py
@@ -2,6 +2,7 @@
 from __future__ import annotations
 
 import logging
+from dataclasses import replace
 
 import pytest
 
@@ -39,6 +40,20 @@ def test_bind_coerced_to_loopback_in_cf_mode(caplog) -> None:
     cfg = _cf_config()
     with caplog.at_level(logging.WARNING):
         coerced = _validate_cli_against_config(cfg, nick=None, bind="0.0.0.0")
+    assert coerced.web_bind == "127.0.0.1"
+    assert any("coerced" in r.getMessage().lower() for r in caplog.records)
+
+
+def test_config_bind_coerced_when_no_cli_flag_in_cf_mode(caplog) -> None:
+    """Config web_bind is non-loopback, no CLI --bind: still coerced.
+
+    Mirrors the explicit-CLI-flag case but proves the coercion fires
+    when the operator misconfigures `web.bind: 0.0.0.0` in YAML and
+    omits the CLI flag entirely.
+    """
+    cfg = replace(_cf_config(), web_bind="0.0.0.0")
+    with caplog.at_level(logging.WARNING):
+        coerced = _validate_cli_against_config(cfg, nick=None, bind=None)
     assert coerced.web_bind == "127.0.0.1"
     assert any("coerced" in r.getMessage().lower() for r in caplog.records)
 

--- a/tests/test_serve_cf_mode.py
+++ b/tests/test_serve_cf_mode.py
@@ -1,0 +1,71 @@
+"""--nick is rejected in CF mode; --bind on a non-loopback is coerced."""
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+
+import pytest
+
+from irc_lens.cli._commands.serve import _validate_cli_against_config
+from irc_lens.cli._errors import EXIT_USER_ERROR, AfiError
+from irc_lens.config import LensConfig
+
+
+def _cf_config() -> LensConfig:
+    return LensConfig(
+        auth_mode="cloudflare-access",
+        dev_nick=None,
+        dev_email=None,
+        cf_aud="a",
+        cf_team_domain="t.cloudflareaccess.com",
+        allowed_emails=("a@example.com",),
+        allowed_service_tokens=(),
+        server_name="spark",
+        server_host="127.0.0.1",
+        server_port=6667,
+        web_bind="127.0.0.1",
+        web_port=8765,
+    )
+
+
+def test_nick_rejected_in_cf_mode(tmp_path: Path) -> None:
+    cfg = _cf_config()
+    with pytest.raises(AfiError) as exc:
+        _validate_cli_against_config(cfg, nick="something", bind="127.0.0.1")
+    assert exc.value.code == EXIT_USER_ERROR
+    assert "--nick" in exc.value.message
+
+
+def test_bind_coerced_to_loopback_in_cf_mode(caplog) -> None:
+    cfg = _cf_config()
+    with caplog.at_level(logging.WARNING):
+        coerced = _validate_cli_against_config(cfg, nick=None, bind="0.0.0.0")
+    assert coerced.web_bind == "127.0.0.1"
+    assert any("coerced" in r.getMessage().lower() for r in caplog.records)
+
+
+def test_loopback_bind_unchanged_in_cf_mode() -> None:
+    cfg = _cf_config()
+    coerced = _validate_cli_against_config(cfg, nick=None, bind="127.0.0.1")
+    assert coerced.web_bind == "127.0.0.1"
+
+
+def test_dev_mode_passes_through_unchanged() -> None:
+    """Dev mode is a no-op — no AfiError, no coercion."""
+    cfg = LensConfig(
+        auth_mode="dev",
+        dev_nick="testuser",
+        dev_email="testuser@local",
+        cf_aud=None,
+        cf_team_domain=None,
+        allowed_emails=(),
+        allowed_service_tokens=(),
+        server_name="spark",
+        server_host="127.0.0.1",
+        server_port=6667,
+        web_bind="0.0.0.0",
+        web_port=8765,
+    )
+    result = _validate_cli_against_config(cfg, nick="anything", bind="0.0.0.0")
+    assert result is cfg
+    assert result.web_bind == "0.0.0.0"

--- a/tests/test_serve_cli.py
+++ b/tests/test_serve_cli.py
@@ -124,13 +124,15 @@ def successful_connect(monkeypatch: pytest.MonkeyPatch):
 def test_serve_missing_config_errors(
     capsys: pytest.CaptureFixture[str],
     monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
 ) -> None:
     """Bare ``irc-lens serve`` with no --config and no config at the default
     path must exit 1 via the AfiError+hint contract (no argparse traceback).
     The hint must mention ``config init`` so the user knows how to fix it."""
     # Point the default config path at a non-existent location so the test
-    # is hermetic regardless of the developer's local config.
-    monkeypatch.setenv("XDG_CONFIG_HOME", "/tmp/irc-lens-no-such-dir-t44")
+    # is hermetic regardless of the developer's local config. Use tmp_path
+    # so the directory is guaranteed not to exist (created fresh per test).
+    monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path / "no-config-dir"))
     rc = main(["serve"])
     assert rc == 1
     err = capsys.readouterr().err
@@ -394,3 +396,109 @@ def test_serve_explicit_config_missing_exits_user_error(
     assert "hint:" in err
     assert "config init" in err
     assert "Traceback" not in err
+
+
+def test_serve_uses_config_host_port_when_no_cli_flags(
+    capsys: pytest.CaptureFixture[str],
+    stub_aiohttp_runtime,
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """When --host / --port are omitted, the server host/port come from the
+    config file (sentinel-default fix, FIX A). Uses TEST-NET-1 (RFC 5737)
+    to ensure the address cannot accidentally match a real host.
+
+    ``Session.connect`` is patched to capture the (host, port) that were
+    passed to the Session constructor; ``wait_for_welcome`` is patched to
+    return immediately so the flow doesn't block.
+    """
+    cfg = tmp_path / "config.yaml"
+    cfg.write_text(
+        "auth:\n"
+        "  mode: dev\n"
+        "  dev:\n"
+        "    nick: lens-test\n"
+        "    email: dev@local\n"
+        "server:\n"
+        "  name: spark\n"
+        "  host: 192.0.2.42\n"
+        "  port: 7777\n"
+    )
+
+    captured: dict[str, object] = {}
+
+    async def spy_connect(self) -> None:
+        captured["host"] = self.host
+        captured["port"] = self.port
+
+    async def noop_welcome(self) -> None:
+        await asyncio.sleep(0)
+
+    monkeypatch.setattr("irc_lens.session.Session.connect", spy_connect)
+    monkeypatch.setattr("irc_lens.session.Session.wait_for_welcome", noop_welcome)
+
+    rc = main(
+        [
+            "serve",
+            "--config", str(cfg),
+            # no --host / --port — config values must be used
+            "--web-port", "65020",
+        ]
+    )
+    assert rc == 0
+    assert captured.get("host") == "192.0.2.42", (
+        f"Expected config host 192.0.2.42, got {captured.get('host')!r}"
+    )
+    assert captured.get("port") == 7777, (
+        f"Expected config port 7777, got {captured.get('port')!r}"
+    )
+
+
+def test_serve_warns_on_config_bind_zero(
+    capsys: pytest.CaptureFixture[str],
+    stub_aiohttp_runtime,
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """When `web.bind: 0.0.0.0` is in the config and --bind is not passed,
+    the 0.0.0.0 warning must still fire (FIX C: key off effective config
+    bind, not the CLI flag).
+    """
+    cfg = tmp_path / "config.yaml"
+    cfg.write_text(
+        "auth:\n"
+        "  mode: dev\n"
+        "  dev:\n"
+        "    nick: lens-test\n"
+        "    email: dev@local\n"
+        "server:\n"
+        "  name: spark\n"
+        "  host: 127.0.0.1\n"
+        "  port: 6667\n"
+        "web:\n"
+        "  bind: 0.0.0.0\n"
+    )
+
+    async def ok(self) -> None:
+        return None
+
+    async def welcomed(self) -> None:
+        await asyncio.sleep(0)
+
+    monkeypatch.setattr("irc_lens.session.Session.connect", ok)
+    monkeypatch.setattr("irc_lens.session.Session.wait_for_welcome", welcomed)
+
+    rc = main(
+        [
+            "serve",
+            "--config", str(cfg),
+            "--web-port", "65030",
+            # no --bind: warning must fire from config.web_bind
+        ]
+    )
+    assert rc == 0
+    err = capsys.readouterr().err
+    assert "0.0.0.0" in err, f"Expected 0.0.0.0 warning in stderr, got: {err!r}"
+    assert "no auth" in err.lower() or "no authentication" in err.lower(), (
+        f"Expected no-auth warning text in stderr, got: {err!r}"
+    )

--- a/tests/test_serve_cli.py
+++ b/tests/test_serve_cli.py
@@ -15,6 +15,7 @@ replaces `aiohttp.web.AppRunner`, `aiohttp.web.TCPSite`, and
 from __future__ import annotations
 
 import asyncio
+from pathlib import Path
 
 import pytest
 
@@ -81,6 +82,24 @@ def stub_aiohttp_runtime(monkeypatch: pytest.MonkeyPatch):
 
 
 @pytest.fixture
+def dev_config_path(tmp_path: Path) -> Path:
+    """Write a minimal valid dev-mode config to a tmp file and return its path."""
+    p = tmp_path / "config.yaml"
+    p.write_text(
+        "auth:\n"
+        "  mode: dev\n"
+        "  dev:\n"
+        "    nick: lens-test\n"
+        "    email: dev@local\n"
+        "server:\n"
+        "  name: spark\n"
+        "  host: 127.0.0.1\n"
+        "  port: 6667\n"
+    )
+    return p
+
+
+@pytest.fixture
 def successful_connect(monkeypatch: pytest.MonkeyPatch):
     async def ok(self) -> None:
         return None
@@ -102,30 +121,23 @@ def successful_connect(monkeypatch: pytest.MonkeyPatch):
 # ---------------------------------------------------------------------------
 
 
-def test_serve_requires_only_nick(
+def test_serve_missing_config_errors(
     capsys: pytest.CaptureFixture[str],
+    monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """``--host`` / ``--port`` default to a local AgentIRC, so only ``--nick``
-    is required. The bare ``irc-lens serve`` invocation still must error via
-    the AfiError + hint contract (no argparse traceback) and the hint must
-    point at the concrete fix — supplying ``--nick``."""
+    """Bare ``irc-lens serve`` with no --config and no config at the default
+    path must exit 1 via the AfiError+hint contract (no argparse traceback).
+    The hint must mention ``config init`` so the user knows how to fix it."""
+    # Point the default config path at a non-existent location so the test
+    # is hermetic regardless of the developer's local config.
+    monkeypatch.setenv("XDG_CONFIG_HOME", "/tmp/irc-lens-no-such-dir-t44")
     rc = main(["serve"])
-    assert rc != 0
+    assert rc == 1
     err = capsys.readouterr().err
     assert "error:" in err
     assert "hint:" in err
-    assert "--nick" in err
+    assert "config init" in err
     assert "Traceback" not in err
-    # The error must mention nick and ONLY nick now that host/port have
-    # defaults — guards against silent regression of the defaults.
-    assert "--host" not in err
-    assert "--port" not in err
-    # The hint must be the serve-specific copy-pasteable form, NOT the
-    # generic `run '<prog> --help'` fallback. This is the regression
-    # Copilot flagged on PR #16: a weaker assertion would silently pass
-    # if `_hint_for` regressed to the generic branch.
-    hint_line = next(line for line in err.splitlines() if "hint:" in line)
-    assert "try 'irc-lens serve --nick" in hint_line
 
 
 def test_serve_help_lists_all_flags(capsys: pytest.CaptureFixture[str]) -> None:
@@ -196,6 +208,7 @@ def test_serve_help_renders_defaults_from_argparse(
 def test_serve_fails_fast_on_unreachable_agentirc(
     capsys: pytest.CaptureFixture[str],
     monkeypatch: pytest.MonkeyPatch,
+    dev_config_path: Path,
 ) -> None:
     """AgentIRC unreachable → exit 1, error + hint on stderr; the aiohttp
     runner is never even constructed (tripwire below)."""
@@ -210,7 +223,7 @@ def test_serve_fails_fast_on_unreachable_agentirc(
 
     monkeypatch.setattr("aiohttp.web.AppRunner", tripwire)
 
-    rc = main(["serve", "--host", "127.0.0.1", "--port", "1", "--nick", "lens"])
+    rc = main(["serve", "--config", str(dev_config_path), "--host", "127.0.0.1", "--port", "1", "--nick", "lens"])
     assert rc == 1
     err = capsys.readouterr().err
     assert "error:" in err
@@ -223,13 +236,14 @@ def test_serve_translates_port_in_use_to_exit_2(
     capsys: pytest.CaptureFixture[str],
     monkeypatch: pytest.MonkeyPatch,
     successful_connect,
+    dev_config_path: Path,
 ) -> None:
     """Web port in use → exit 2 (env error per the policy)."""
     monkeypatch.setattr("aiohttp.web.AppRunner", _FakeRunner)
     monkeypatch.setattr("aiohttp.web.TCPSite", _BoomSite)
     monkeypatch.setattr("asyncio.Event", _ImmediateEvent)
 
-    rc = main(["serve", "--host", "x", "--port", "1", "--nick", "lens"])
+    rc = main(["serve", "--config", str(dev_config_path), "--host", "x", "--port", "1", "--nick", "lens"])
     assert rc == 2
     err = capsys.readouterr().err
     assert "error:" in err
@@ -241,11 +255,13 @@ def test_serve_warns_on_bind_zero(
     capsys: pytest.CaptureFixture[str],
     stub_aiohttp_runtime,
     successful_connect,
+    dev_config_path: Path,
 ) -> None:
     """`--bind 0.0.0.0` prints the loud no-auth warning before binding."""
     rc = main(
         [
             "serve",
+            "--config", str(dev_config_path),
             "--host", "x", "--port", "1", "--nick", "lens",
             "--bind", "0.0.0.0",
             "--web-port", "65000",
@@ -261,12 +277,14 @@ def test_serve_displays_routable_url_when_binding_to_zero(
     capsys: pytest.CaptureFixture[str],
     stub_aiohttp_runtime,
     successful_connect,
+    dev_config_path: Path,
 ) -> None:
     """When binding to 0.0.0.0, the printed URL must use 127.0.0.1 — most
     browsers won't navigate to http://0.0.0.0:port/."""
     rc = main(
         [
             "serve",
+            "--config", str(dev_config_path),
             "--host", "x", "--port", "1", "--nick", "lens",
             "--bind", "0.0.0.0",
             "--web-port", "65010",
@@ -282,11 +300,13 @@ def test_serve_displays_bind_url_for_localhost(
     capsys: pytest.CaptureFixture[str],
     stub_aiohttp_runtime,
     successful_connect,
+    dev_config_path: Path,
 ) -> None:
     """For non-wildcard binds, the URL uses the bind value as-is."""
     rc = main(
         [
             "serve",
+            "--config", str(dev_config_path),
             "--host", "x", "--port", "1", "--nick", "lens",
             "--web-port", "65011",
         ]
@@ -301,6 +321,7 @@ def test_serve_seed_loads_yaml_fixture(
     stub_aiohttp_runtime,
     successful_connect,
     monkeypatch: pytest.MonkeyPatch,
+    dev_config_path: Path,
 ) -> None:
     """Phase 8: `--seed <path>` overlays YAML state onto Session before
     `make_app` runs. Verify by spying on the loader."""
@@ -317,6 +338,7 @@ def test_serve_seed_loads_yaml_fixture(
     rc = main(
         [
             "serve",
+            "--config", str(dev_config_path),
             "--host", "x", "--port", "1", "--nick", "lens",
             "--seed", "tests/fixtures/basic.yaml",
             "--web-port", "65001",
@@ -330,12 +352,14 @@ def test_serve_seed_missing_file_exits_user_error(
     capsys: pytest.CaptureFixture[str],
     stub_aiohttp_runtime,
     successful_connect,
+    dev_config_path: Path,
 ) -> None:
     """A bad --seed path surfaces as `error:`/`hint:` per the rubric;
     no aiohttp bind, no traceback."""
     rc = main(
         [
             "serve",
+            "--config", str(dev_config_path),
             "--host", "x", "--port", "1", "--nick", "lens",
             "--seed", "tests/fixtures/does_not_exist.yaml",
             "--web-port", "65001",

--- a/tests/test_serve_cli.py
+++ b/tests/test_serve_cli.py
@@ -109,17 +109,15 @@ def test_serve_requires_only_nick(
     is required. The bare ``irc-lens serve`` invocation still must error via
     the AfiError + hint contract (no argparse traceback) and the hint must
     point at the concrete fix — supplying ``--nick``."""
-    with pytest.raises(SystemExit) as exc:
-        main(["serve"])
-    assert exc.value.code != 0
+    rc = main(["serve"])
+    assert rc != 0
     err = capsys.readouterr().err
     assert "error:" in err
     assert "hint:" in err
     assert "--nick" in err
     assert "Traceback" not in err
-    # The argparse "required" complaint must mention nick and ONLY nick now
-    # that host/port have defaults — guards against silent regression of the
-    # defaults.
+    # The error must mention nick and ONLY nick now that host/port have
+    # defaults — guards against silent regression of the defaults.
     assert "--host" not in err
     assert "--port" not in err
     # The hint must be the serve-specific copy-pasteable form, NOT the

--- a/uv.lock
+++ b/uv.lock
@@ -657,7 +657,7 @@ wheels = [
 
 [[package]]
 name = "irc-lens"
-version = "0.4.2"
+version = "0.5.0"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },


### PR DESCRIPTION
## Summary

Phase 4 of the Cloudflare Access deployment plan (issue #26). Hardens the CLI and HTTP surface around the Phase 3 auth middleware.

- **T4.1** (`d6c15ce`, `2b734f8`) — `_validate_cli_against_config`: reject \`--nick\` in CF mode, coerce non-loopback \`--bind\` to \`127.0.0.1\` with a WARNING log. Argparse defaults flipped to \`None\` (sentinel handoff).
- **T4.2** (\`9a2a736\`) — \`tests/test_healthz.py\`: pin \`/healthz\` contract to \`{\"ok\": true}\` in both dev and CF modes.
- **T4.3** (\`afb3f25\`) — \`_origin_ok\` helper + same-host Origin floor on \`POST /input\`. CSRF defense-in-depth pending #27 (real CSRF tokens). Absent Origin → allow (curl, cloudflared probes); foreign Origin → 403 \`{error, hint}\`.
- **T4.4** (\`684cb52\`) — drop synthetic-dev fallback. Config file is now required. Missing config → \`error: no config at <path>\` + \`hint: run 'irc-lens config init'…\`.
- **T4.5** (\`126ec4e\`) — version \`0.4.2\` → \`0.5.0\`, \`docs/cli.md\` Configuration section, README pointer.
- **Final review** (\`af1b3e2\`) — drop \"silently\" from cli.md (warns aren't silent), test config-bind coercion when CLI \`--bind\` is absent, guard README forward-link with \"(lands in the next release)\".

## HTTP error shape

The new 403 from the Origin floor uses \`{error, hint}\` per memory \`feedback_http_error_shape.md\` (ratified on PR #7). This is distinct from the AfiError CLI triple \`(code, message, remediation)\`.

## Test plan

- [x] \`uv run pytest -x\` — 318 pass, 4 deselected (Playwright/marker-gated)
- [x] \`uv run pytest tests/test_serve_cf_mode.py -v\` — 7 pass (T4.1 + final-review test)
- [x] \`uv run pytest tests/test_healthz.py -v\` — 2 pass (T4.2)
- [x] \`uv run pytest tests/test_origin_check.py -v\` — 3 pass (T4.3)
- [x] \`uv run pytest tests/test_serve_cli.py -v\` — 11 pass (T4.4 — 8 tests adjusted)
- [x] Manual smoke: \`irc-lens serve\` (no config) → exit 1 with hint mentioning \`config init\`
- [x] Manual smoke: \`irc-lens serve --config /missing\` → exit 1 with hint
- [x] \`irc-lens --version\` → \`irc-lens 0.5.0\`
- [x] portability-lint clean

## Out of scope (Phase 5)

- \`docs/deployment-cloudflare-access.md\` — README link guarded as \"lands in next release\"
- \`scripts/cf-roundtrip/setup.sh\` + real CF round-trip test
- \`docs/auth.md\`, \`docs/security-checklist.md\`

## Tracked follow-ups

- #27 — CSRF tokens on \`POST /input\` (will replace the Origin floor)
- #28 — automate CF round-trip on GitHub Actions

\- Claude