### PR TITLE
Phase 5 (FINAL): docs, CF round-trip scripts + test (closes #26)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -223,3 +223,7 @@ __marimo__/
 # Per-user Claude Code config (settings, scheduled tasks, project-local
 # skills, etc. — none of these belong in the repo).
 .claude/
+
+# CF round-trip service-token secret (written by scripts/cf-roundtrip/setup.sh)
+.cf-roundtrip.env
+.cf-roundtrip.env.*

--- a/README.md
+++ b/README.md
@@ -46,8 +46,7 @@ uv run pytest -m playwright -v           # browser e2e
 ## Production deployment
 
 To host irc-lens behind Cloudflare Access on your own domain, see
-[docs/deployment-cloudflare-access.md](docs/deployment-cloudflare-access.md)
-(lands in the next release).
+[docs/deployment-cloudflare-access.md](docs/deployment-cloudflare-access.md).
 
 ## License
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -243,3 +243,27 @@ without verifying the SSE event-listener API still matches what
 * [`CITATION.md`](../CITATION.md) — culture citations + divergences.
 * [`docs/superpowers/specs/2026-04-27-irc-lens-handover-design.md`](superpowers/specs/2026-04-27-irc-lens-handover-design.md) — spec.
 * [`docs/superpowers/plans/2026-04-27-irc-lens-build-plan.md`](superpowers/plans/2026-04-27-irc-lens-build-plan.md) — build plan.
+
+## Deployment modes
+
+irc-lens has two operational modes selected by `auth.mode` in the config:
+
+### `dev` mode
+
+A single `Session` opens at startup against the configured AgentIRC
+on `auth.dev.nick`. The identity middleware injects a synthetic
+`Identity` for every request. Existing tests run in this mode.
+
+### `cloudflare-access` mode
+
+Each authenticated user gets their own lazy-opened `Session` with a
+nick derived from their email's local part (sanitized to
+`[a-z0-9-]`). The identity middleware validates the
+Cloudflare-issued JWT against the team's JWKS, pins audience and
+issuer, and enforces the lens-side allowlist as a second line of
+defense behind the Cloudflare Access policy. JWKS is cached
+in-process with kid-miss-then-refresh semantics.
+
+The lens never opens an inbound port in CF mode; cloudflared
+terminates the tunnel locally and the lens listens on
+`127.0.0.1:<web.port>`.

--- a/docs/auth.md
+++ b/docs/auth.md
@@ -1,0 +1,70 @@
+# Authentication and Identity
+
+irc-lens supports two auth modes, selected by `auth.mode` in the config
+file: `dev` (no auth, single synthetic identity) and
+`cloudflare-access` (per-user JWT-validated identity behind Cloudflare
+Access).
+
+## Identity model
+
+- One `Session` per authenticated principal, opened lazily on first
+  request.
+- Nick is derived: `<server_name>-<sanitized-local-part>`. Sanitization
+  drops everything outside `[a-z0-9-]` from the email's local part (or
+  from the service-token common name).
+- The principal — `email` for interactive SSO, `common_name` for
+  service tokens — keys the registry. Two browsers signed in as the
+  same principal share one Session and one IRC connection.
+
+## JWT validation rules
+
+For each authenticated request the lens:
+
+1. Reads the JWT from the `Cf-Access-Jwt-Assertion` header (preferred)
+   or the `CF_Authorization` cookie.
+2. Looks up the signing key by `kid` against an in-process JWKS cache.
+3. On `kid` miss: refreshes the cache once (rate-limited to once every
+   5 s) and retries; permanent miss → 401.
+4. Verifies signature, audience (`auth.cloudflare.aud`), and issuer
+   (`https://<auth.cloudflare.team_domain>`).
+5. Reads `email` (or `common_name`) and checks against
+   `auth.allowed_emails` / `auth.allowed_service_tokens`.
+6. Derives the nick and stashes the `Identity` on `request["identity"]`.
+
+## Dev mode
+
+In `auth.mode: dev`, the same middleware is installed but synthesizes
+`Identity(principal=auth.dev.email, nick=auth.dev.nick, ...)` on every
+request. Handlers see the same contract as in CF mode.
+
+## Failure modes
+
+| Status | Cause |
+| --- | --- |
+| 401 | missing or invalid JWT |
+| 403 | allowlist denied / Origin mismatch on POST /input |
+| 500 | nick derivation produced empty (server-config bug) |
+| 502 | JWKS unreachable on first fetch |
+| 503 | Session unhealthy / cannot reach AgentIRC |
+
+## Audit log
+
+Every authenticated request emits one structured line on stderr:
+
+    auth=ok principal=<email-or-common-name> nick=<derived> method=<verb> path=<path>
+
+Auth denials log:
+
+    auth=denied principal=<...> reason=<short-tag>
+
+When `--log-json` is passed, the same data goes through the
+`_JsonLineFormatter` and lands as one JSON object per line.
+
+## Service tokens
+
+Cloudflare Access supports service tokens for non-interactive callers
+(CI, scripts). They authenticate via `CF-Access-Client-Id` and
+`CF-Access-Client-Secret` headers; Cloudflare mints a JWT that carries
+`common_name` instead of `email`. List the allowed common-names under
+`auth.allowed_service_tokens`. Service tokens have no MFA and no SSO
+identity; treat them as long-lived secrets.

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -91,8 +91,7 @@ The starter file is in `auth.mode: dev`, suitable for a local AgentIRC
 on `127.0.0.1:6667`. To deploy behind Cloudflare Access, switch
 `auth.mode` to `cloudflare-access` and set `auth.cloudflare.aud`,
 `auth.cloudflare.team_domain`, and `auth.allowed_emails`. See
-[deployment-cloudflare-access.md](deployment-cloudflare-access.md)
-(lands in the next release).
+[deployment-cloudflare-access.md](deployment-cloudflare-access.md).
 
 ### `--nick` and `--bind`
 

--- a/docs/deployment-cloudflare-access.md
+++ b/docs/deployment-cloudflare-access.md
@@ -1,0 +1,136 @@
+# Deploying irc-lens behind Cloudflare Access on your own domain
+
+This runbook walks you through hosting irc-lens at a public hostname
+on your own Cloudflare-managed zone, gated by Cloudflare Access. The
+result: anyone you allowlist can sign in via your IdP and reach a
+private AgentIRC mesh; nobody else can.
+
+## Prerequisites
+
+- A Cloudflare account with `<your-zone>` (e.g. `example.com`) managed.
+- An IdP set up in Cloudflare Access (Google SSO, GitHub, etc.).
+  Cloudflare's dashboard has a wizard.
+- `cloudflared` installed on the host machine. See Cloudflare's docs
+  for current install instructions.
+- `irc-lens` and AgentIRC running (or about to run) on the same host.
+
+## 1. Pick a hostname
+
+Decide on `<your-hostname>` under `<your-zone>` (e.g.
+`lens.<your-zone>`). The runbook uses these placeholders below.
+
+## 2. Create the tunnel
+
+```bash
+cloudflared tunnel login                   # one-time, browser-based
+cloudflared tunnel create irc-lens
+```
+
+This writes a credentials JSON to `~/.cloudflared/<tunnel-uuid>.json`.
+
+## 3. Route DNS
+
+```bash
+cloudflared tunnel route dns irc-lens <your-hostname>
+```
+
+Cloudflare creates a CNAME `<your-hostname>` →
+`<tunnel-uuid>.cfargotunnel.com`.
+
+## 4. Configure cloudflared
+
+Create `~/.cloudflared/config.yml`:
+
+```yaml
+tunnel: <tunnel-uuid>
+credentials-file: /home/<user>/.cloudflared/<tunnel-uuid>.json
+
+ingress:
+  - hostname: <your-hostname>
+    service: http://localhost:8765
+  - service: http_status:404
+```
+
+## 5. Run cloudflared as a service (systemd example)
+
+```bash
+sudo cloudflared service install
+sudo systemctl start cloudflared
+sudo systemctl enable cloudflared
+```
+
+## 6. Create the Access application
+
+In the Cloudflare dashboard → Zero Trust → Access → Applications:
+
+- **Application type**: Self-hosted.
+- **Application domain**: `<your-hostname>`.
+- **Identity providers**: select your configured IdP.
+- **Add policy**: Allow + `Emails` → list the same emails you'll put in
+  `auth.allowed_emails`.
+
+Note the **Application Audience (AUD) Tag** — you need this for the
+lens config.
+
+## 7. Configure irc-lens
+
+Run `irc-lens config init` to drop a starter file
+(`~/.config/irc-lens/config.yaml`; respects `$XDG_CONFIG_HOME`). If
+the file already exists, pass `--force` to overwrite it, or use
+`--path <custom-path>` to write to a different location.
+
+Then edit the file and replace the dev-mode stanza with:
+
+```yaml
+auth:
+  mode: cloudflare-access
+  cloudflare:
+    aud: <your-aud-tag>
+    team_domain: <your-team>.cloudflareaccess.com
+  allowed_emails:
+    - <your-email>
+server:
+  name: <agentirc-server-name>
+  host: 127.0.0.1
+  port: 6667
+web:
+  bind: 127.0.0.1
+  port: 8765
+```
+
+## 8. Start in this order
+
+1. AgentIRC (so it's ready when the lens connects).
+2. `irc-lens serve` (validates JWKS on startup, binds `127.0.0.1:8765`).
+3. `cloudflared` (already running as a systemd unit after step 5).
+
+Reverse on shutdown.
+
+## 9. Verify
+
+- Visit `https://<your-hostname>/healthz` → `{"ok": true}` (no auth
+  required; safe for uptime probes).
+- Visit `https://<your-hostname>/` → SSO redirect → lens UI.
+- Send a slash-command — it dispatches into AgentIRC under the
+  derived nick `<agentirc-server-name>-<sanitized-email-local>`.
+
+## Troubleshooting
+
+**401 at `/`** — JWT not reaching the lens.
+Check cloudflared logs; `cloudflared tunnel info irc-lens` should
+show a healthy edge connection.
+
+**403 not on allowlist** — email passed CF Access but is missing from
+`auth.allowed_emails`. Add it to the config and restart irc-lens.
+
+**502 on first request** — lens couldn't reach the Cloudflare JWKS
+endpoint (`/cdn-cgi/access/certs`) at startup. Verify outbound egress
+from the host to `<your-team>.cloudflareaccess.com`.
+
+**503 on `/input`** — AgentIRC is unreachable. Check `server.host` /
+`server.port` and the IRCd's status.
+
+## Security checklist
+
+Walk [security-checklist.md](security-checklist.md) before opening
+the hostname to the internet.

--- a/docs/deployment-cloudflare-access.md
+++ b/docs/deployment-cloudflare-access.md
@@ -110,6 +110,18 @@ Reverse on shutdown.
 
 - Visit `https://<your-hostname>/healthz` → `{"ok": true}` (no auth
   required; safe for uptime probes).
+
+  > **Note on `/healthz`**: The lens itself bypasses auth on `/healthz`
+  > (so cloudflared-local probes work). Cloudflare Access at the edge,
+  > however, gates **all** paths under the protected hostname by default —
+  > so an unauthenticated browser hitting `https://<your-hostname>/healthz`
+  > from the public internet will be redirected to SSO. If you want
+  > unauthenticated uptime probes to reach the lens, add a Bypass policy
+  > in the Access app (Cloudflare dashboard → Access → Applications →
+  > your app → Policies → Add policy → Action: **Bypass** → Include:
+  > Everyone → Path: `/healthz`). With the bypass policy in place,
+  > external probes get the lens's `{"ok": true}` directly.
+
 - Visit `https://<your-hostname>/` → SSO redirect → lens UI.
 - Send a slash-command — it dispatches into AgentIRC under the
   derived nick `<agentirc-server-name>-<sanitized-email-local>`.

--- a/docs/security-checklist.md
+++ b/docs/security-checklist.md
@@ -1,0 +1,54 @@
+# Security Checklist — public-facing irc-lens
+
+Before opening your hostname to the internet, walk this list. Every
+item is a yes/no.
+
+## Network exposure
+
+- [ ] AgentIRC is bound to `127.0.0.1` (or a private mesh interface),
+      never `0.0.0.0`.
+- [ ] `irc-lens serve`'s `web.bind` is `127.0.0.1`. CF mode coerces
+      this automatically; verify with `ss -lntp | grep 8765`.
+- [ ] No firewall rule forwards an inbound port to either service.
+      cloudflared is the only reachable surface.
+
+## Cloudflare config
+
+- [ ] `auth.mode: cloudflare-access` in the active config file.
+- [ ] `auth.cloudflare.aud` matches the AUD shown in the Access app's
+      "Application Audience (AUD) Tag" field.
+- [ ] `auth.cloudflare.team_domain` matches your Cloudflare team
+      domain (`<team>.cloudflareaccess.com`).
+- [ ] `auth.allowed_emails` matches the Access policy's email list.
+      Both must say yes for a request to land — defense in depth.
+- [ ] The IdP (Google SSO, GitHub, etc.) enforces MFA on every
+      account in `auth.allowed_emails`.
+
+## cloudflared
+
+- [ ] cloudflared's tunnel `ingress` rule points to
+      `http://localhost:<web.port>`, not `http://0.0.0.0:<web.port>`.
+- [ ] cloudflared and irc-lens both run as a non-root user.
+- [ ] cloudflared's `tunnel-credentials` file is `chmod 600`.
+
+## Operational
+
+- [ ] Logs are persisted somewhere auditable (systemd journal is
+      fine). Review `auth=denied` lines after each test session.
+- [ ] `GET /healthz` returns `{"ok": true}` and nothing else; the
+      response does not reveal whether any user has a live session.
+- [ ] You have a way to rotate the IdP credentials and the CF API
+      token without downtime.
+
+## Things to revisit later
+
+These ship in v1 with a known floor; tighten as the deployment grows:
+
+- CSRF defense on `POST /input` is currently Origin/Referer only. See
+  [issue #27](https://github.com/agentculture/irc-lens/issues/27)
+  for the CSRF-token uplift.
+- The CF round-trip test runs only manually / via agent. Automation
+  on GitHub Actions is tracked in
+  [issue #28](https://github.com/agentculture/irc-lens/issues/28).
+- Group-based authorization (using the `groups` JWT claim) is not
+  consumed in v1.

--- a/docs/security-checklist.md
+++ b/docs/security-checklist.md
@@ -8,7 +8,8 @@ item is a yes/no.
 - [ ] AgentIRC is bound to `127.0.0.1` (or a private mesh interface),
       never `0.0.0.0`.
 - [ ] `irc-lens serve`'s `web.bind` is `127.0.0.1`. CF mode coerces
-      this automatically; verify with `ss -lntp | grep 8765`.
+      this automatically; verify with `ss -lntp | grep <web.port>`
+      (the port you set in the lens config; default 8765).
 - [ ] No firewall rule forwards an inbound port to either service.
       cloudflared is the only reachable surface.
 

--- a/scripts/cf-roundtrip/README.md
+++ b/scripts/cf-roundtrip/README.md
@@ -1,0 +1,31 @@
+# CF round-trip helpers
+
+> **Secrets**: `setup.sh` writes the service-token client-secret to `.cf-roundtrip.env` in the repo root. The repo's `.gitignore` excludes this file — do not commit it.
+
+`setup.sh` provisions (or reuses) a Cloudflare Tunnel, DNS record,
+Access application, allow-policy, and service token for the
+`@pytest.mark.cloudflare` round-trip test.
+
+## Required env
+
+| Var | Purpose |
+| --- | --- |
+| `CF_API_TOKEN` | Cloudflare token with Account:Tunnel:Edit, Account:Access:Apps and Policies:Edit, Zone:DNS:Edit on `CF_ZONE_ID` |
+| `CF_ACCOUNT_ID` | your Cloudflare account ID |
+| `CF_ZONE_ID` | the zone hosting `CF_TEST_HOSTNAME` |
+| `CF_TEST_HOSTNAME` | the hostname the test will hit |
+| `CF_TEAM_DOMAIN` | `<team>.cloudflareaccess.com` |
+
+## Run
+
+    ./scripts/cf-roundtrip/setup.sh
+    set -a; source .cf-roundtrip.env; set +a
+    pytest -m cloudflare -v
+
+## Teardown
+
+    ./scripts/cf-roundtrip/teardown.sh
+
+## Notes
+
+These scripts are intended for operator-driven (manual) use. Issue #28 tracks automation of this provisioning step in CI.

--- a/scripts/cf-roundtrip/README.md
+++ b/scripts/cf-roundtrip/README.md
@@ -28,12 +28,16 @@ Access application, allow-policy, and service token for the
 | `IRC_LENS_TEST_CLIENT_ID` | service-token client ID (`<uuid>.access`), used in `CF-Access-Client-Id` request header |
 | `IRC_LENS_TEST_CLIENT_SECRET` | service-token client secret, used in `CF-Access-Client-Secret` request header |
 | `IRC_LENS_TEST_TOKEN_NAME` | service-token display name written by setup.sh; the test puts this value in `auth.allowed_service_tokens` (Cloudflare populates `common_name` with the token's display name, not the UUID client_id) |
+| `IRC_LENS_TEST_TUNNEL_TOKEN` | tunnel run token; use with `cloudflared tunnel run --token "$IRC_LENS_TEST_TUNNEL_TOKEN"` to start the tunnel against this test setup |
 
 ## Run
 
     ./scripts/cf-roundtrip/setup.sh
     set -a; source .cf-roundtrip.env; set +a
-    pytest -m cloudflare -v
+    cloudflared tunnel run --token "$IRC_LENS_TEST_TUNNEL_TOKEN" &  # in another terminal
+    uv run pytest -m cloudflare -v
+
+> **Note**: AgentIRC must also be running on `127.0.0.1:6667` for the round-trip to land beyond the auth check.
 
 ## Teardown
 

--- a/scripts/cf-roundtrip/README.md
+++ b/scripts/cf-roundtrip/README.md
@@ -16,6 +16,19 @@ Access application, allow-policy, and service token for the
 | `CF_TEST_HOSTNAME` | the hostname the test will hit |
 | `CF_TEAM_DOMAIN` | `<team>.cloudflareaccess.com` |
 
+## Env file written by setup.sh
+
+`setup.sh` writes `.cf-roundtrip.env` (gitignored, `chmod 600`) with these variables:
+
+| Var | Purpose |
+| --- | --- |
+| `IRC_LENS_TEST_AUD` | Cloudflare Access application audience tag |
+| `IRC_LENS_TEST_HOSTNAME` | public hostname the test hits |
+| `IRC_LENS_TEST_TEAM_DOMAIN` | `<team>.cloudflareaccess.com` |
+| `IRC_LENS_TEST_CLIENT_ID` | service-token client ID (`<uuid>.access`), used in `CF-Access-Client-Id` request header |
+| `IRC_LENS_TEST_CLIENT_SECRET` | service-token client secret, used in `CF-Access-Client-Secret` request header |
+| `IRC_LENS_TEST_TOKEN_NAME` | service-token display name written by setup.sh; the test puts this value in `auth.allowed_service_tokens` (Cloudflare populates `common_name` with the token's display name, not the UUID client_id) |
+
 ## Run
 
     ./scripts/cf-roundtrip/setup.sh

--- a/scripts/cf-roundtrip/setup.sh
+++ b/scripts/cf-roundtrip/setup.sh
@@ -33,6 +33,7 @@ if [[ -z "$TUNNEL_ID" ]]; then
     | jq -r '.result.id')"
 fi
 echo "  tunnel_id=$TUNNEL_ID" >&2
+TUNNEL_TOKEN="$(cf_get "/accounts/$CF_ACCOUNT_ID/cfd_tunnel/$TUNNEL_ID/token" | jq -r '.result')"
 
 echo "[2/5] dns" >&2
 DNS_ID="$(cf_get "/zones/$CF_ZONE_ID/dns_records?name=$CF_TEST_HOSTNAME" \
@@ -87,6 +88,7 @@ IRC_LENS_TEST_TEAM_DOMAIN=$CF_TEAM_DOMAIN
 IRC_LENS_TEST_CLIENT_ID=$CLIENT_ID
 IRC_LENS_TEST_CLIENT_SECRET=$CLIENT_SECRET
 IRC_LENS_TEST_TOKEN_NAME=$TOKEN_NAME
+IRC_LENS_TEST_TUNNEL_TOKEN=$TUNNEL_TOKEN
 EOF
 chmod 600 "$ENV_OUT"
 echo "wrote $ENV_OUT" >&2

--- a/scripts/cf-roundtrip/setup.sh
+++ b/scripts/cf-roundtrip/setup.sh
@@ -1,0 +1,88 @@
+#!/usr/bin/env bash
+# Idempotent CF round-trip setup. Re-runs are safe: existing resources
+# are reused, only missing ones are created. Prints / writes
+# `.cf-roundtrip.env` with values the test reads at runtime.
+set -euo pipefail
+
+: "${CF_API_TOKEN:?must be set}"
+: "${CF_ACCOUNT_ID:?must be set}"
+: "${CF_ZONE_ID:?must be set}"
+: "${CF_TEST_HOSTNAME:?must be set}"
+: "${CF_TEAM_DOMAIN:?must be set}"
+
+BASE="https://api.cloudflare.com/client/v4"
+HDR=(-H "Authorization: Bearer $CF_API_TOKEN" -H "Content-Type: application/json")
+TUNNEL_NAME="irc-lens-roundtrip"
+APP_NAME="irc-lens roundtrip"
+TOKEN_FILE="${HOME}/.config/irc-lens/cf-roundtrip-token.json"
+ENV_OUT="${ENV_OUT:-.cf-roundtrip.env}"
+
+cf_get() { curl -sS "${HDR[@]}" "$BASE$1"; }
+cf_post() { curl -sS "${HDR[@]}" -X POST "$BASE$1" -d "$2"; }
+
+echo "[1/5] tunnel" >&2
+TUNNEL_ID="$(cf_get "/accounts/$CF_ACCOUNT_ID/cfd_tunnel?name=$TUNNEL_NAME" \
+  | jq -r '.result[0].id // empty')"
+if [[ -z "$TUNNEL_ID" ]]; then
+  TUNNEL_SECRET="$(openssl rand -base64 32)"
+  TUNNEL_ID="$(cf_post "/accounts/$CF_ACCOUNT_ID/cfd_tunnel" \
+    "$(jq -n --arg n "$TUNNEL_NAME" --arg s "$TUNNEL_SECRET" \
+        '{name:$n, tunnel_secret:$s}')" \
+    | jq -r '.result.id')"
+fi
+echo "  tunnel_id=$TUNNEL_ID" >&2
+
+echo "[2/5] dns" >&2
+DNS_ID="$(cf_get "/zones/$CF_ZONE_ID/dns_records?name=$CF_TEST_HOSTNAME" \
+  | jq -r '.result[0].id // empty')"
+if [[ -z "$DNS_ID" ]]; then
+  cf_post "/zones/$CF_ZONE_ID/dns_records" \
+    "$(jq -n --arg n "$CF_TEST_HOSTNAME" --arg c "$TUNNEL_ID.cfargotunnel.com" \
+        '{type:"CNAME", name:$n, content:$c, proxied:true}')" >/dev/null
+fi
+
+echo "[3/5] access app" >&2
+APP_ID="$(cf_get "/accounts/$CF_ACCOUNT_ID/access/apps?name=$APP_NAME" \
+  | jq -r '.result[0].id // empty')"
+if [[ -z "$APP_ID" ]]; then
+  APP_ID="$(cf_post "/accounts/$CF_ACCOUNT_ID/access/apps" \
+    "$(jq -n --arg n "$APP_NAME" --arg d "$CF_TEST_HOSTNAME" \
+        '{name:$n, domain:$d, type:"self_hosted", session_duration:"24h"}')" \
+    | jq -r '.result.id')"
+fi
+echo "  app_id=$APP_ID" >&2
+
+AUD="$(cf_get "/accounts/$CF_ACCOUNT_ID/access/apps/$APP_ID" | jq -r '.result.aud')"
+
+echo "[4/5] service token" >&2
+if [[ -f "$TOKEN_FILE" ]]; then
+  CLIENT_ID="$(jq -r .client_id "$TOKEN_FILE")"
+  CLIENT_SECRET="$(jq -r .client_secret "$TOKEN_FILE")"
+else
+  TOKEN_JSON="$(cf_post "/accounts/$CF_ACCOUNT_ID/access/service_tokens" \
+    "$(jq -n '{name:"irc-lens-roundtrip"}')" | jq -r '.result')"
+  CLIENT_ID="$(echo "$TOKEN_JSON" | jq -r .client_id)"
+  CLIENT_SECRET="$(echo "$TOKEN_JSON" | jq -r .client_secret)"
+  mkdir -p "$(dirname "$TOKEN_FILE")"
+  echo "$TOKEN_JSON" >"$TOKEN_FILE"
+  chmod 600 "$TOKEN_FILE"
+fi
+
+echo "[5/5] policy" >&2
+EXISTING="$(cf_get "/accounts/$CF_ACCOUNT_ID/access/apps/$APP_ID/policies" \
+  | jq -r '.result[] | select(.name=="allow-svc-token") | .id' | head -1)"
+if [[ -z "$EXISTING" ]]; then
+  cf_post "/accounts/$CF_ACCOUNT_ID/access/apps/$APP_ID/policies" \
+    "$(jq -n --arg cid "$CLIENT_ID" \
+        '{name:"allow-svc-token", decision:"non_identity", precedence:1,
+          include:[{service_token:{token_id:$cid}}]}')" >/dev/null
+fi
+
+cat >"$ENV_OUT" <<EOF
+IRC_LENS_TEST_AUD=$AUD
+IRC_LENS_TEST_HOSTNAME=$CF_TEST_HOSTNAME
+IRC_LENS_TEST_TEAM_DOMAIN=$CF_TEAM_DOMAIN
+IRC_LENS_TEST_CLIENT_ID=$CLIENT_ID
+IRC_LENS_TEST_CLIENT_SECRET=$CLIENT_SECRET
+EOF
+echo "wrote $ENV_OUT" >&2

--- a/scripts/cf-roundtrip/setup.sh
+++ b/scripts/cf-roundtrip/setup.sh
@@ -13,7 +13,9 @@ set -euo pipefail
 BASE="https://api.cloudflare.com/client/v4"
 HDR=(-H "Authorization: Bearer $CF_API_TOKEN" -H "Content-Type: application/json")
 TUNNEL_NAME="irc-lens-roundtrip"
+TOKEN_NAME="irc-lens-roundtrip"
 APP_NAME="irc-lens roundtrip"
+APP_NAME_ENCODED="irc-lens%20roundtrip"
 TOKEN_FILE="${HOME}/.config/irc-lens/cf-roundtrip-token.json"
 ENV_OUT="${ENV_OUT:-.cf-roundtrip.env}"
 
@@ -42,7 +44,7 @@ if [[ -z "$DNS_ID" ]]; then
 fi
 
 echo "[3/5] access app" >&2
-APP_ID="$(cf_get "/accounts/$CF_ACCOUNT_ID/access/apps?name=$APP_NAME" \
+APP_ID="$(cf_get "/accounts/$CF_ACCOUNT_ID/access/apps?name=$APP_NAME_ENCODED" \
   | jq -r '.result[0].id // empty')"
 if [[ -z "$APP_ID" ]]; then
   APP_ID="$(cf_post "/accounts/$CF_ACCOUNT_ID/access/apps" \
@@ -60,7 +62,7 @@ if [[ -f "$TOKEN_FILE" ]]; then
   CLIENT_SECRET="$(jq -r .client_secret "$TOKEN_FILE")"
 else
   TOKEN_JSON="$(cf_post "/accounts/$CF_ACCOUNT_ID/access/service_tokens" \
-    "$(jq -n '{name:"irc-lens-roundtrip"}')" | jq -r '.result')"
+    "$(jq -n --arg n "$TOKEN_NAME" '{name:$n}')" | jq -r '.result')"
   CLIENT_ID="$(echo "$TOKEN_JSON" | jq -r .client_id)"
   CLIENT_SECRET="$(echo "$TOKEN_JSON" | jq -r .client_secret)"
   mkdir -p "$(dirname "$TOKEN_FILE")"
@@ -84,5 +86,7 @@ IRC_LENS_TEST_HOSTNAME=$CF_TEST_HOSTNAME
 IRC_LENS_TEST_TEAM_DOMAIN=$CF_TEAM_DOMAIN
 IRC_LENS_TEST_CLIENT_ID=$CLIENT_ID
 IRC_LENS_TEST_CLIENT_SECRET=$CLIENT_SECRET
+IRC_LENS_TEST_TOKEN_NAME=$TOKEN_NAME
 EOF
+chmod 600 "$ENV_OUT"
 echo "wrote $ENV_OUT" >&2

--- a/scripts/cf-roundtrip/teardown.sh
+++ b/scripts/cf-roundtrip/teardown.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Remove every resource setup.sh creates. Idempotent (404s ignored).
+# Remove every resource setup.sh creates. Idempotent (404s and 2xx ignored; other statuses logged as warnings).
 set -euo pipefail
 
 : "${CF_API_TOKEN:?}"
@@ -13,7 +13,14 @@ TOKEN_NAME="irc-lens-roundtrip"
 TUNNEL_NAME="irc-lens-roundtrip"
 APP_NAME_ENCODED="irc-lens%20roundtrip"
 
-cf_del() { curl -sS "${HDR[@]}" -X DELETE "$BASE$1" || true; }
+cf_del() {
+  local resp
+  resp="$(curl -sS -o /dev/null -w '%{http_code}' "${HDR[@]}" -X DELETE "$BASE$1" 2>/dev/null || echo "000")"
+  case "$resp" in
+    2*|404) ;;  # success or already gone — both fine for teardown
+    *) printf 'warning: DELETE %s returned HTTP %s\n' "$1" "$resp" >&2 ;;
+  esac
+}
 cf_get() { curl -sS "${HDR[@]}" "$BASE$1"; }
 
 # Service token

--- a/scripts/cf-roundtrip/teardown.sh
+++ b/scripts/cf-roundtrip/teardown.sh
@@ -9,17 +9,20 @@ set -euo pipefail
 
 BASE="https://api.cloudflare.com/client/v4"
 HDR=(-H "Authorization: Bearer $CF_API_TOKEN")
+TOKEN_NAME="irc-lens-roundtrip"
+TUNNEL_NAME="irc-lens-roundtrip"
+APP_NAME_ENCODED="irc-lens%20roundtrip"
 
 cf_del() { curl -sS "${HDR[@]}" -X DELETE "$BASE$1" || true; }
 cf_get() { curl -sS "${HDR[@]}" "$BASE$1"; }
 
 # Service token
 TOK_ID="$(cf_get "/accounts/$CF_ACCOUNT_ID/access/service_tokens" \
-  | jq -r '.result[] | select(.name=="irc-lens-roundtrip") | .id' | head -1)"
+  | jq -r --arg n "$TOKEN_NAME" '.result[] | select(.name==$n) | .id' | head -1)"
 [[ -n "$TOK_ID" ]] && cf_del "/accounts/$CF_ACCOUNT_ID/access/service_tokens/$TOK_ID"
 
 # Access app
-APP_ID="$(cf_get "/accounts/$CF_ACCOUNT_ID/access/apps?name=irc-lens%20roundtrip" \
+APP_ID="$(cf_get "/accounts/$CF_ACCOUNT_ID/access/apps?name=$APP_NAME_ENCODED" \
   | jq -r '.result[0].id // empty')"
 [[ -n "$APP_ID" ]] && cf_del "/accounts/$CF_ACCOUNT_ID/access/apps/$APP_ID"
 
@@ -29,7 +32,7 @@ DNS_ID="$(cf_get "/zones/$CF_ZONE_ID/dns_records?name=$CF_TEST_HOSTNAME" \
 [[ -n "$DNS_ID" ]] && cf_del "/zones/$CF_ZONE_ID/dns_records/$DNS_ID"
 
 # Tunnel
-TUN_ID="$(cf_get "/accounts/$CF_ACCOUNT_ID/cfd_tunnel?name=irc-lens-roundtrip" \
+TUN_ID="$(cf_get "/accounts/$CF_ACCOUNT_ID/cfd_tunnel?name=$TUNNEL_NAME" \
   | jq -r '.result[0].id // empty')"
 [[ -n "$TUN_ID" ]] && cf_del "/accounts/$CF_ACCOUNT_ID/cfd_tunnel/$TUN_ID"
 

--- a/scripts/cf-roundtrip/teardown.sh
+++ b/scripts/cf-roundtrip/teardown.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+# Remove every resource setup.sh creates. Idempotent (404s ignored).
+set -euo pipefail
+
+: "${CF_API_TOKEN:?}"
+: "${CF_ACCOUNT_ID:?}"
+: "${CF_ZONE_ID:?}"
+: "${CF_TEST_HOSTNAME:?}"
+
+BASE="https://api.cloudflare.com/client/v4"
+HDR=(-H "Authorization: Bearer $CF_API_TOKEN")
+
+cf_del() { curl -sS "${HDR[@]}" -X DELETE "$BASE$1" || true; }
+cf_get() { curl -sS "${HDR[@]}" "$BASE$1"; }
+
+# Service token
+TOK_ID="$(cf_get "/accounts/$CF_ACCOUNT_ID/access/service_tokens" \
+  | jq -r '.result[] | select(.name=="irc-lens-roundtrip") | .id' | head -1)"
+[[ -n "$TOK_ID" ]] && cf_del "/accounts/$CF_ACCOUNT_ID/access/service_tokens/$TOK_ID"
+
+# Access app
+APP_ID="$(cf_get "/accounts/$CF_ACCOUNT_ID/access/apps?name=irc-lens%20roundtrip" \
+  | jq -r '.result[0].id // empty')"
+[[ -n "$APP_ID" ]] && cf_del "/accounts/$CF_ACCOUNT_ID/access/apps/$APP_ID"
+
+# DNS
+DNS_ID="$(cf_get "/zones/$CF_ZONE_ID/dns_records?name=$CF_TEST_HOSTNAME" \
+  | jq -r '.result[0].id // empty')"
+[[ -n "$DNS_ID" ]] && cf_del "/zones/$CF_ZONE_ID/dns_records/$DNS_ID"
+
+# Tunnel
+TUN_ID="$(cf_get "/accounts/$CF_ACCOUNT_ID/cfd_tunnel?name=irc-lens-roundtrip" \
+  | jq -r '.result[0].id // empty')"
+[[ -n "$TUN_ID" ]] && cf_del "/accounts/$CF_ACCOUNT_ID/cfd_tunnel/$TUN_ID"
+
+rm -f "${HOME}/.config/irc-lens/cf-roundtrip-token.json"
+echo "teardown complete" >&2

--- a/tests/test_cf_roundtrip.py
+++ b/tests/test_cf_roundtrip.py
@@ -1,0 +1,136 @@
+"""Real Cloudflare round-trip. Skipped unless setup.sh has run.
+
+Requires: AgentIRC running locally on 127.0.0.1:6667 (or a fixture),
+`cloudflared` installed, and the env vars in .cf-roundtrip.env loaded.
+"""
+from __future__ import annotations
+
+import asyncio
+import os
+import shutil
+import subprocess
+import time
+from pathlib import Path  # noqa: F401 — available for fixture use
+
+import aiohttp
+import pytest
+
+pytestmark = pytest.mark.cloudflare
+
+REQUIRED_ENV = (
+    "IRC_LENS_TEST_AUD",
+    "IRC_LENS_TEST_HOSTNAME",
+    "IRC_LENS_TEST_TEAM_DOMAIN",
+    "IRC_LENS_TEST_CLIENT_ID",
+    "IRC_LENS_TEST_CLIENT_SECRET",
+)
+
+
+def _missing_env() -> str | None:
+    for k in REQUIRED_ENV:
+        if not os.environ.get(k):
+            return k
+    return None
+
+
+@pytest.fixture(scope="module")
+def lens_subprocess(tmp_path_factory) -> subprocess.Popen:
+    if _missing_env():
+        pytest.skip(f"missing env: {_missing_env()}")
+    if not shutil.which("cloudflared"):
+        pytest.skip("cloudflared not on PATH")
+
+    cfg_dir = tmp_path_factory.mktemp("lens-cf")
+    cfg = cfg_dir / "config.yaml"
+    cfg.write_text(f"""
+auth:
+  mode: cloudflare-access
+  cloudflare:
+    aud: {os.environ['IRC_LENS_TEST_AUD']}
+    team_domain: {os.environ['IRC_LENS_TEST_TEAM_DOMAIN']}
+  allowed_emails: []
+  allowed_service_tokens:
+    - {os.environ['IRC_LENS_TEST_CLIENT_ID']}
+server:
+  name: roundtrip
+  host: 127.0.0.1
+  port: 6667
+web:
+  bind: 127.0.0.1
+  port: 8765
+""")
+    proc = subprocess.Popen(
+        ["uv", "run", "irc-lens", "serve", "--config", str(cfg)],
+        env={**os.environ, "IRC_LENS_TEST_HOOKS": "1"},
+    )
+    try:
+        # Wait for local /healthz before yielding.
+        for _ in range(30):
+            if _local_healthz():
+                break
+            time.sleep(1)
+        yield proc
+    finally:
+        proc.terminate()
+        proc.wait(timeout=10)
+
+
+def _local_healthz() -> bool:
+    import urllib.request
+    try:
+        with urllib.request.urlopen("http://127.0.0.1:8765/healthz", timeout=1) as r:
+            return r.status == 200
+    except Exception:
+        return False
+
+
+async def _get(url: str, headers: dict[str, str]) -> tuple[int, bytes]:
+    async with aiohttp.ClientSession() as s:
+        async with s.get(url, headers=headers, timeout=aiohttp.ClientTimeout(total=15)) as r:
+            return r.status, await r.read()
+
+
+async def _post(url: str, headers: dict[str, str], data: dict) -> int:
+    async with aiohttp.ClientSession() as s:
+        async with s.post(url, headers=headers, data=data,
+                          timeout=aiohttp.ClientTimeout(total=15)) as r:
+            return r.status
+
+
+@pytest.mark.asyncio
+async def test_cloudflare_round_trip(lens_subprocess) -> None:
+    host = os.environ["IRC_LENS_TEST_HOSTNAME"]
+    base = f"https://{host}"
+    auth_headers = {
+        "CF-Access-Client-Id": os.environ["IRC_LENS_TEST_CLIENT_ID"],
+        "CF-Access-Client-Secret": os.environ["IRC_LENS_TEST_CLIENT_SECRET"],
+    }
+
+    # Wait until the public hostname starts answering — DNS may need to
+    # settle on first run, and cloudflared takes a few seconds to come up.
+    deadline = time.time() + 60
+    while time.time() < deadline:
+        status, _ = await _get(f"{base}/healthz", headers=auth_headers)
+        if status == 200:
+            break
+        await asyncio.sleep(2)
+    else:
+        pytest.fail("public /healthz never came up")
+
+    # Unauthenticated request must be blocked at the CF edge.
+    status_unauth, _ = await _get(f"{base}/", headers={})
+    assert status_unauth in (401, 302)
+
+    # Service-token call lands on the lens.
+    status_auth, body = await _get(f"{base}/", headers=auth_headers)
+    assert status_auth == 200
+    assert b"<html" in body or b"<!DOCTYPE" in body
+
+    # POST /input via service token. With AgentIRC offline the response
+    # may be 503; that still proves the auth path landed in the handler.
+    status_post = await _post(
+        f"{base}/input",
+        headers={**auth_headers, "Origin": base},
+        data={"text": "/help"},
+    )
+    assert status_post in (204, 503)

--- a/tests/test_cf_roundtrip.py
+++ b/tests/test_cf_roundtrip.py
@@ -65,11 +65,25 @@ web:
         env={**os.environ, "IRC_LENS_TEST_HOOKS": "1"},
     )
     try:
-        # Wait for local /healthz before yielding.
+        # Wait for local /healthz before yielding; fail fast if the process dies.
+        healthz_ok = False
         for _ in range(30):
+            if proc.poll() is not None:
+                pytest.fail(
+                    f"lens subprocess exited prematurely with code "
+                    f"{proc.returncode}; cannot run round-trip"
+                )
             if _local_healthz():
+                healthz_ok = True
                 break
             time.sleep(1)
+        if not healthz_ok:
+            proc.terminate()
+            proc.wait(timeout=5)
+            pytest.fail(
+                f"local /healthz never came up after 30s; "
+                f"proc.poll()={proc.poll()}"
+            )
         yield proc
     finally:
         proc.terminate()

--- a/tests/test_cf_roundtrip.py
+++ b/tests/test_cf_roundtrip.py
@@ -23,6 +23,7 @@ REQUIRED_ENV = (
     "IRC_LENS_TEST_TEAM_DOMAIN",
     "IRC_LENS_TEST_CLIENT_ID",
     "IRC_LENS_TEST_CLIENT_SECRET",
+    "IRC_LENS_TEST_TOKEN_NAME",
 )
 
 
@@ -50,7 +51,7 @@ auth:
     team_domain: {os.environ['IRC_LENS_TEST_TEAM_DOMAIN']}
   allowed_emails: []
   allowed_service_tokens:
-    - {os.environ['IRC_LENS_TEST_CLIENT_ID']}
+    - {os.environ['IRC_LENS_TEST_TOKEN_NAME']}
 server:
   name: roundtrip
   host: 127.0.0.1


### PR DESCRIPTION
## Summary

Final phase of the Cloudflare Access deployment plan (issue #26). Lands the operator-facing docs, the idempotent setup/teardown scripts, and the real-Cloudflare round-trip test (operator-driven, deselected by default).

After this merges the lens is feature-complete for the CF Access deployment story.

## Changes

| Task | What | Commit |
| --- | --- | --- |
| T5.1 | `docs/auth.md` — protocol-level reference (identity, JWT validation, audit log, service tokens) | `023d4cf` |
| T5.2 | `docs/security-checklist.md` — pre-launch yes/no checklist (refs #27, #28) | `d696153` |
| T5.3 | `docs/deployment-cloudflare-access.md` — domain-neutral runbook + drop `(lands in the next release)` from README and cli.md | `e08a65b` |
| T5.4 | `docs/architecture.md` — new "Deployment modes" section | `aedfb88` |
| T5.5a | `.cf-roundtrip.env` gitignore (FIRST so secrets can't leak) | `4ac7c7e` |
| T5.5b | `scripts/cf-roundtrip/{setup.sh,teardown.sh,README.md}` — idempotent CF API plumbing | `689a4eb` |
| T5.6 | `tests/test_cf_roundtrip.py` — `@pytest.mark.cloudflare`, skips cleanly without env | `95eec05` |

## Test plan

- [x] `uv run pytest -v` — 322 passed, 5 deselected (was 4 before; new `cloudflare` test deselected by default)
- [x] `uv run pytest -m cloudflare -v` — 1 SKIPPED with message `missing env: IRC_LENS_TEST_AUD` (operator-driven; runs only when `setup.sh` env is loaded)
- [x] `uv run pytest -m playwright -v` — untouched
- [x] `uv run pytest -m slow -v` — untouched
- [x] `markdownlint-cli2 docs/auth.md docs/security-checklist.md docs/deployment-cloudflare-access.md docs/architecture.md` — clean on the new content (pre-existing flags in cli.md/README.md left alone)
- [x] `bash -n scripts/cf-roundtrip/*.sh` — silent
- [x] `shellcheck scripts/cf-roundtrip/*.sh` — clean
- [x] `git check-ignore -v .cf-roundtrip.env` — confirms gitignore rule fires
- [x] `grep -rn 'lands in the next release' docs README.md` — empty
- [x] Domain-neutral: every doc and script uses placeholders (`<your-zone>`, `<your-hostname>`, etc.); no specific hostname or email is committed

## Operator quickstart (for the round-trip test)

```bash
export CF_API_TOKEN=...   CF_ACCOUNT_ID=...   CF_ZONE_ID=...
export CF_TEST_HOSTNAME=lens-test.<your-zone>
export CF_TEAM_DOMAIN=<team>.cloudflareaccess.com
./scripts/cf-roundtrip/setup.sh
set -a; source .cf-roundtrip.env; set +a
# (start AgentIRC + cloudflared in another terminal)
uv run pytest -m cloudflare -v
./scripts/cf-roundtrip/teardown.sh
```

## Closes

Closes #26.

Tracked follow-ups remain open:
- #27 — CSRF tokens replace the Origin floor (separate PR)
- #28 — automate the round-trip on GitHub Actions (separate PR; uses these scripts)

\- Claude