### PR TITLE
.env / .env.example convention for cf-roundtrip operator inputs

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -24,7 +24,10 @@ CF_ZONE_ID=
 
 # The hostname the round-trip test will hit. Must be under CF_ZONE_ID.
 # setup.sh creates a CNAME for this name; teardown.sh removes it.
-CF_TEST_HOSTNAME=test.<your-zone>
+# Format example: test.example.com  (no angle brackets — they would be
+# parsed as shell redirection when sourced via `set -a; source .env`).
+CF_TEST_HOSTNAME=
 
 # The Cloudflare Zero Trust team domain (visible in the Zero Trust dashboard).
-CF_TEAM_DOMAIN=<team>.cloudflareaccess.com
+# Format example: my-team.cloudflareaccess.com
+CF_TEAM_DOMAIN=

--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,30 @@
+# Inputs to scripts/cf-roundtrip/setup.sh.
+# Copy this file to .env, fill in the values, then:
+#
+#     set -a; source .env; set +a
+#     ./scripts/cf-roundtrip/setup.sh
+#
+# .env is gitignored; .env.example is the committed template. cfafi
+# (https://github.com/agentculture/cfafi) handles minting CF_API_TOKEN
+# and reporting CF_ACCOUNT_ID / CF_ZONE_ID / CF_TEAM_DOMAIN. The
+# CF_TEST_HOSTNAME is per-deployment — pick a name under your zone.
+
+# Cloudflare API token with these scopes:
+#   - Account → Cloudflare Tunnel → Edit
+#   - Account → Access: Apps and Policies → Edit
+#   - Account → Access: Service Tokens → Edit
+#   - Zone → DNS → Edit (on CF_ZONE_ID)
+CF_API_TOKEN=
+
+# Cloudflare account that owns the Zero Trust team and tunnel resources.
+CF_ACCOUNT_ID=
+
+# Zone ID of the DNS zone that hosts CF_TEST_HOSTNAME.
+CF_ZONE_ID=
+
+# The hostname the round-trip test will hit. Must be under CF_ZONE_ID.
+# setup.sh creates a CNAME for this name; teardown.sh removes it.
+CF_TEST_HOSTNAME=test.<your-zone>
+
+# The Cloudflare Zero Trust team domain (visible in the Zero Trust dashboard).
+CF_TEAM_DOMAIN=<team>.cloudflareaccess.com

--- a/.gitignore
+++ b/.gitignore
@@ -227,3 +227,8 @@ __marimo__/
 # CF round-trip service-token secret (written by scripts/cf-roundtrip/setup.sh)
 .cf-roundtrip.env
 .cf-roundtrip.env.*
+
+# Operator-supplied CF_* inputs to scripts/cf-roundtrip/setup.sh.
+# See .env.example for the committed template.
+.env
+.env.local

--- a/scripts/cf-roundtrip/README.md
+++ b/scripts/cf-roundtrip/README.md
@@ -37,6 +37,10 @@ from the committed `.env.example`); `cfafi` mints the API token and
 reports the account/zone/team values. `setup.sh` reads them, writes
 `IRC_LENS_TEST_*` outputs to `.cf-roundtrip.env`, which the test reads.
 
+**Run all commands below from the repo root** (the parent of
+`scripts/`). The `.env` and `.cf-roundtrip.env` paths and the script
+invocation are all relative to it.
+
     set -a; source .env; set +a                # CF_* inputs (from .env.example)
     ./scripts/cf-roundtrip/setup.sh
     set -a; source .cf-roundtrip.env; set +a   # IRC_LENS_TEST_* outputs from setup.sh

--- a/scripts/cf-roundtrip/README.md
+++ b/scripts/cf-roundtrip/README.md
@@ -32,8 +32,14 @@ Access application, allow-policy, and service token for the
 
 ## Run
 
+The `CF_*` inputs live in a gitignored `.env` at the repo root (copy
+from the committed `.env.example`); `cfafi` mints the API token and
+reports the account/zone/team values. `setup.sh` reads them, writes
+`IRC_LENS_TEST_*` outputs to `.cf-roundtrip.env`, which the test reads.
+
+    set -a; source .env; set +a                # CF_* inputs (from .env.example)
     ./scripts/cf-roundtrip/setup.sh
-    set -a; source .cf-roundtrip.env; set +a
+    set -a; source .cf-roundtrip.env; set +a   # IRC_LENS_TEST_* outputs from setup.sh
     cloudflared tunnel run --token "$IRC_LENS_TEST_TUNNEL_TOKEN" &  # in another terminal
     uv run pytest -m cloudflare -v
 


### PR DESCRIPTION
## Summary

Pre-flight for the first live CF round-trip. Lands the gitignore convention so cfafi-supplied credentials can be sourced from a gitignored \`.env\` at repo root.

## Changes

- \`.env.example\` (new) — committed template documenting the 5 \`CF_*\` inputs \`scripts/cf-roundtrip/setup.sh\` requires, with comments pointing at cfafi.
- \`.gitignore\` — adds \`.env\` and \`.env.local\` alongside the existing \`.cf-roundtrip.env*\` rules.
- \`scripts/cf-roundtrip/README.md\` — Run section now shows the explicit two-stage source: \`.env\` (inputs) before \`setup.sh\`, \`.cf-roundtrip.env\` (outputs) after.

## Why now

Phase 5 (#36) shipped the round-trip scripts but documented operator inputs as inline \`export CF_API_TOKEN=...\` lines. For the first live run, we want a gitignored \`.env\` file backed by a committed \`.env.example\` template — standard convention, lower-friction for re-runs, and prepares the repo for cfafi handing back credentials in machine-readable form.

## Test plan

- [x] \`git check-ignore -v .env\` confirms \`.gitignore:233\` matches.
- [x] \`uv run pytest -x\` — 322 pass, 5 deselected (unchanged).
- [x] \`markdownlint-cli2\` introduces no new violations on \`scripts/cf-roundtrip/README.md\` (pre-existing flags untouched).
- [x] No code path changed — pure repo-convention + docs.

\- Claude