### PR TITLE
feat(cf-roundtrip): optional CF_ALLOWED_EMAILS policy for SSO logins

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -31,3 +31,11 @@ CF_TEST_HOSTNAME=
 # The Cloudflare Zero Trust team domain (visible in the Zero Trust dashboard).
 # Format example: my-team.cloudflareaccess.com
 CF_TEAM_DOMAIN=
+
+# Optional: comma-separated emails permitted to log in interactively
+# via SSO. When set, setup.sh creates a second Allow-by-email policy on
+# the Access app alongside the service-token policy. Leave blank for
+# service-token-only access (e.g., the round-trip test). The IdP must
+# also be configured in Cloudflare Zero Trust for SSO to work.
+# Format example: alice@example.com,bob@example.com
+CF_ALLOWED_EMAILS=

--- a/scripts/cf-roundtrip/README.md
+++ b/scripts/cf-roundtrip/README.md
@@ -16,6 +16,12 @@ Access application, allow-policy, and service token for the
 | `CF_TEST_HOSTNAME` | the hostname the test will hit |
 | `CF_TEAM_DOMAIN` | `<team>.cloudflareaccess.com` |
 
+## Optional env
+
+| Var | Purpose |
+| --- | --- |
+| `CF_ALLOWED_EMAILS` | comma-separated emails to admit via interactive SSO. When set, `setup.sh` creates a second `allow-emails` policy on the Access app alongside the service-token policy. Requires an IdP configured in Cloudflare Zero Trust. Leave unset for service-token-only access. |
+
 ## Env file written by setup.sh
 
 `setup.sh` writes `.cf-roundtrip.env` (gitignored, `chmod 600`) with these variables:

--- a/scripts/cf-roundtrip/setup.sh
+++ b/scripts/cf-roundtrip/setup.sh
@@ -88,12 +88,19 @@ fi
 # exist on the app. To change the allowlist, delete the policy via the
 # dashboard (or teardown the whole app) and re-run setup.
 if [[ -n "${CF_ALLOWED_EMAILS:-}" ]]; then
+  # Parse + validate first so we don't post `include: []` to the CF API
+  # if the operator's value trims down to nothing (e.g. " , , , ").
+  EMAILS_INCLUDE="$(jq -nc --arg csv "$CF_ALLOWED_EMAILS" \
+    '$csv | split(",") | map(gsub("^\\s+|\\s+$";"")) | map(select(length>0)) | map({email:{email:.}})')"
+  if [[ "$(jq length <<<"$EMAILS_INCLUDE")" -eq 0 ]]; then
+    echo "error: CF_ALLOWED_EMAILS is set but contains no valid emails after trim/empty-filter" >&2
+    echo "hint: format is comma-separated, e.g. alice@example.com,bob@example.com" >&2
+    exit 1
+  fi
   echo "[5b/5] email-allow policy" >&2
   EMAIL_EXISTING="$(cf_get "/accounts/$CF_ACCOUNT_ID/access/apps/$APP_ID/policies" \
     | jq -r '.result[] | select(.name=="allow-emails") | .id' | head -1)"
   if [[ -z "$EMAIL_EXISTING" ]]; then
-    EMAILS_INCLUDE="$(jq -nc --arg csv "$CF_ALLOWED_EMAILS" \
-      '$csv | split(",") | map(gsub("^\\s+|\\s+$";"")) | map(select(length>0)) | map({email:{email:.}})')"
     cf_post "/accounts/$CF_ACCOUNT_ID/access/apps/$APP_ID/policies" \
       "$(jq -nc --argjson inc "$EMAILS_INCLUDE" \
           '{name:"allow-emails", decision:"allow", precedence:2, include:$inc}')" >/dev/null

--- a/scripts/cf-roundtrip/setup.sh
+++ b/scripts/cf-roundtrip/setup.sh
@@ -81,6 +81,25 @@ if [[ -z "$EXISTING" ]]; then
           include:[{service_token:{token_id:$cid}}]}')" >/dev/null
 fi
 
+# Optional second policy: allow listed emails via interactive SSO.
+# Active only when CF_ALLOWED_EMAILS is set (comma-separated). Leaving
+# it unset keeps the deployment service-token-only (round-trip default).
+# Idempotent: only created if a policy named "allow-emails" doesn't yet
+# exist on the app. To change the allowlist, delete the policy via the
+# dashboard (or teardown the whole app) and re-run setup.
+if [[ -n "${CF_ALLOWED_EMAILS:-}" ]]; then
+  echo "[5b/5] email-allow policy" >&2
+  EMAIL_EXISTING="$(cf_get "/accounts/$CF_ACCOUNT_ID/access/apps/$APP_ID/policies" \
+    | jq -r '.result[] | select(.name=="allow-emails") | .id' | head -1)"
+  if [[ -z "$EMAIL_EXISTING" ]]; then
+    EMAILS_INCLUDE="$(jq -nc --arg csv "$CF_ALLOWED_EMAILS" \
+      '$csv | split(",") | map(gsub("^\\s+|\\s+$";"")) | map(select(length>0)) | map({email:{email:.}})')"
+    cf_post "/accounts/$CF_ACCOUNT_ID/access/apps/$APP_ID/policies" \
+      "$(jq -nc --argjson inc "$EMAILS_INCLUDE" \
+          '{name:"allow-emails", decision:"allow", precedence:2, include:$inc}')" >/dev/null
+  fi
+fi
+
 cat >"$ENV_OUT" <<EOF
 IRC_LENS_TEST_AUD=$AUD
 IRC_LENS_TEST_HOSTNAME=$CF_TEST_HOSTNAME


### PR DESCRIPTION
## Summary

Extends \`scripts/cf-roundtrip/setup.sh\` with an optional second Access policy for interactive SSO logins, alongside the existing service-token policy. Required for the eventual \`chat.*\` production deployment where a human operator needs to sign in via Google/GitHub/etc. on the same hostname agents reach via service tokens.

When \`CF_ALLOWED_EMAILS\` is unset, behavior is unchanged — round-trip test stays service-token-only.

## Why now

While planning the live round-trip, an identity-flow concern surfaced: the user's Google account is on \`@gmail.com\` but the deployment hostname is on a different zone. The two are decoupled at the protocol level (the JWT carries the IdP's identity regardless of zone), but \`setup.sh\` had no path to provision an SSO email allowlist — only service tokens. Without this PR, every production deployment needs manual dashboard surgery to add the email policy.

cfafi-side concern (the IdP must be configured in Zero Trust for SSO to work) is documented as a comment on [agentculture/cfafi#22](https://github.com/agentculture/cfafi/issues/22).

## Changes

- **\`scripts/cf-roundtrip/setup.sh\`** — new optional \`[5b/5]\` block that creates an \`allow-emails\` policy when \`CF_ALLOWED_EMAILS\` is set. Comma-separated emails parsed via \`jq\` with whitespace-trim and empty-entry filter. Idempotent (create-if-missing by name); precedence 2 so the service-token policy at precedence 1 still wins for non-identity flows.
- **\`.env.example\`** — \`CF_ALLOWED_EMAILS=\` with format example in a comment block.
- **\`scripts/cf-roundtrip/README.md\`** — new \`Optional env\` table documenting the var and the IdP-required note.
- **\`scripts/cf-roundtrip/teardown.sh\`** — no changes; CF API cascades policy deletion when the Access app is removed.

## Test plan

- [x] \`bash -n scripts/cf-roundtrip/setup.sh\` — clean
- [x] \`shellcheck scripts/cf-roundtrip/setup.sh\` — clean
- [x] \`uv run pytest -x\` — 322 pass, 5 deselected (unchanged; this PR doesn't touch any code path the suite exercises)
- [x] jq email-list parsing verified against simple comma-separated input + whitespace + empty entries
- [ ] Live round-trip with \`CF_ALLOWED_EMAILS\` set — blocked on cfafi delivering credentials at [agentculture/cfafi#22](https://github.com/agentculture/cfafi/issues/22)

## Known limitation (documented inline)

Changing \`CF_ALLOWED_EMAILS\` and re-running \`setup.sh\` does NOT update an existing policy — the script is create-if-missing only. To change the allowlist: delete the \`allow-emails\` policy via the dashboard (or run full teardown) and re-run \`setup.sh\`. \`PUT\`-upsert path is more complex than needed for the current use case; leaving for a follow-up if anyone hits the limitation.

\- Claude