### PR TITLE
fix(cf-roundtrip): unblock public-host POST + UX/diagnostic polish

### DIFF
--- a/docs/cf-roundtrip-live-test.md
+++ b/docs/cf-roundtrip-live-test.md
@@ -1,0 +1,247 @@
+# Live-testing irc-lens behind Cloudflare Access (operator runbook)
+
+Sister document to [deployment-cloudflare-access.md](deployment-cloudflare-access.md).
+That one walks through a manual self-managed deployment from scratch.
+This one covers the **live-test path**: you've been handed an
+auto-provisioned env file by a tool like `cfafi`/`cultureflare` (or
+the bundled `scripts/cf-roundtrip/setup.sh`), and you want to bring up
+`cloudflared` + `irc-lens serve` locally and validate that the public
+hostname round-trips end-to-end. It also captures the gotchas that
+will eat your afternoon if you skip them.
+
+The shape of the handoff: a gitignored `.cf-roundtrip.env` (mode 0600)
+in the repo root, populated with seven `IRC_LENS_TEST_*` variables —
+see `scripts/cf-roundtrip/README.md` for the canonical list. The
+provisioner has already created the Cloudflare Tunnel, DNS record,
+Access app, allow-policy, and service token. You're plugging into the
+local end.
+
+Throughout this doc, replace `<your-host>` with the public hostname
+the provisioner used.
+
+## Prerequisites
+
+- `.cf-roundtrip.env` present in the repo root, with all seven
+  `IRC_LENS_TEST_*` keys populated.
+- `cloudflared` on `$PATH` (any recent version).
+- AgentIRC running on `127.0.0.1:6667` (or wherever the lens config
+  will dial). The round-trip test asserts behavior past the auth
+  layer; without an IRC backend, slash-commands will land but get
+  503'd downstream.
+- `uv` for managing Python deps.
+
+## Run the round-trip
+
+All commands from the repo root.
+
+### 1. Load the env file
+
+```bash
+set -a; source .cf-roundtrip.env; set +a
+```
+
+Sanity check (every line should print `set`):
+
+```bash
+for v in IRC_LENS_TEST_AUD IRC_LENS_TEST_HOSTNAME IRC_LENS_TEST_TEAM_DOMAIN \
+         IRC_LENS_TEST_CLIENT_ID IRC_LENS_TEST_CLIENT_SECRET \
+         IRC_LENS_TEST_TOKEN_NAME IRC_LENS_TEST_TUNNEL_TOKEN; do
+  printf '%s=%s\n' "$v" "${!v:+set}"
+done
+```
+
+### 2. Bring up the cloudflared connector
+
+```bash
+nohup cloudflared tunnel run --token "$IRC_LENS_TEST_TUNNEL_TOKEN" \
+  >/tmp/cloudflared.log 2>&1 &
+```
+
+Wait for four `Registered tunnel connection` lines in the log (one per
+edge connection, ~5 s).
+
+### 3. Write the lens config and start `irc-lens serve`
+
+```bash
+mkdir -p /tmp/lens-cf-live
+cat >/tmp/lens-cf-live/config.yaml <<EOF
+auth:
+  mode: cloudflare-access
+  cloudflare:
+    aud: ${IRC_LENS_TEST_AUD}
+    team_domain: ${IRC_LENS_TEST_TEAM_DOMAIN}
+  allowed_emails:
+    - <your-email>
+  allowed_service_tokens:
+    - ${IRC_LENS_TEST_CLIENT_ID}
+server:
+  name: <agentirc-server-name>
+  host: 127.0.0.1
+  port: 6667
+web:
+  bind: 127.0.0.1
+  port: 8765
+EOF
+chmod 600 /tmp/lens-cf-live/config.yaml
+
+nohup uv run irc-lens serve --config /tmp/lens-cf-live/config.yaml \
+  >/tmp/lens.log 2>&1 &
+```
+
+Wait for local `/healthz`:
+
+```bash
+until curl -fsS http://127.0.0.1:8765/healthz >/dev/null; do sleep 1; done
+```
+
+### 4. Smoke through the public hostname
+
+```bash
+H_ID="CF-Access-Client-Id: $IRC_LENS_TEST_CLIENT_ID"
+H_SEC="CF-Access-Client-Secret: $IRC_LENS_TEST_CLIENT_SECRET"
+URL="https://$IRC_LENS_TEST_HOSTNAME"
+
+# Edge blocks unauth → 302 to SSO (or 401 if no email policy).
+curl -isS -o /dev/null -w '%{http_code}\n' "$URL/"
+
+# Service-token authed → lens responds.
+curl -isS -H "$H_ID" -H "$H_SEC" -o /dev/null -w '%{http_code}\n' "$URL/healthz"
+curl -isS -H "$H_ID" -H "$H_SEC" -H "Origin: $URL" \
+  -o /dev/null -w '%{http_code}\n' "$URL/"
+curl -isS -X POST -H "$H_ID" -H "$H_SEC" -H "Origin: $URL" \
+  --data 'text=/help' -o /dev/null -w '%{http_code}\n' "$URL/input"
+```
+
+Expected: 302/401, 200, 200, 204 (or 503 if AgentIRC is offline).
+
+### 5. Run the formal test
+
+```bash
+uv run pytest -m cloudflare -v tests/test_cf_roundtrip.py
+```
+
+The pytest fixture spawns its own `irc-lens serve` on `:8765`, so stop
+your manual lens (see step 7) before running this and restart it
+afterwards if you want the URL to stay live.
+
+### 6. Browser path
+
+Open `https://<your-host>` in a browser; SSO via your email allow-
+policy. The chat UI loads; sending messages POSTs to `/input` (which
+is what the curl smoke at step 4 covered).
+
+### 7. Teardown
+
+```bash
+pkill -f 'cloudflared tunnel run'
+pkill -f '\.venv/bin/irc-lens serve'
+```
+
+## Gotchas we hit (and what to look for)
+
+These are the ones that produced the longest debugging sessions; flag
+them early if your numbers in step 4 disagree with the expected
+shapes.
+
+### Provisioner-side gaps
+
+A `cfafi`/`cultureflare`-style provisioner can hand you a complete-
+looking env file while leaving the tunnel and the Access app under-
+configured. Two pieces are easy to omit:
+
+- **Tunnel needs a public-hostname → service mapping.** Token-based
+  tunnels pull ingress from the Cloudflare dashboard, not local
+  config. If the public hostname isn't bound to a service URL, the
+  cloudflared log will say "No ingress rules were defined… cloudflared
+  will return 503 for all incoming HTTP requests" and every public
+  request comes back as 503 from cloudflared itself, never reaching
+  the lens. Fix: have the provisioner add the mapping, or configure
+  it manually under Zero Trust → Networks → Tunnels → your tunnel →
+  Public Hostname → Service URL = `http://localhost:8765`.
+
+- **Access app needs a `non_identity` service-token policy.** An
+  email-allow policy alone admits browser SSO but rejects programmatic
+  service-token auth. Symptom: with `CF-Access-Client-Id` /
+  `CF-Access-Client-Secret` headers, you get 302 → SSO redirect
+  anyway. Decoded `meta=` JWT in the redirect URL shows
+  `service_token_status: false`. Fix: add a
+  `decision: non_identity` policy (commonly named `allow-svc-token`)
+  whose `include` references the service token's client_id. The
+  bundled `scripts/cf-roundtrip/setup.sh` does this; some external
+  provisioners don't.
+
+### Lens-side gotchas
+
+- **`auth.allowed_service_tokens` takes the client_id, not the token
+  display name.** Cloudflare puts the service token's *client_id*
+  (the `<uuid>.access` form, e.g. from
+  `IRC_LENS_TEST_CLIENT_ID`) in the JWT's `common_name` claim, which
+  is what the lens checks against. The token's *display name* (from
+  `IRC_LENS_TEST_TOKEN_NAME`) is what you'd see in the dashboard but
+  isn't what arrives in the JWT. If you hit a 403 with the body
+  `service token <uuid>.access not on allowlist` after the edge
+  passed, that's this. List the client_id in
+  `auth.allowed_service_tokens`. (The README in
+  `scripts/cf-roundtrip/` predates this clarification; trust the
+  config snippet in step 3 above.)
+
+- **AgentIRC may enforce a nick prefix.** The lens derives nicks as
+  `<server.name>-<sanitized-principal>`. If your AgentIRC daemon
+  rejects nicks that don't start with a specific prefix, set
+  `server.name` to that prefix. Example symptom: lens log says
+  `LensConnectionLost: nick rejected: Nickname must start with
+  spark-`. Set `server.name: spark` in the config.
+
+- **`POST /input` from a TLS-terminating proxy needs
+  `X-Forwarded-Proto`.** The Origin CSRF floor compares
+  `(host, port)` tuples and uses `request.url.scheme` to derive the
+  port default. Cloudflared TLS-terminates and forwards plain HTTP, so
+  without XFP-handling the request side resolves to port 80 while the
+  origin side says 443 → 403 on every public POST. As of the PR that
+  introduced this runbook the lens honors `X-Forwarded-Proto: https`
+  and lifts the request port to 443. If you see
+  `WARNING irc_lens.web.routes: origin_mismatch` lines with
+  `scheme=http request_port=80` despite XFP being set upstream, your
+  proxy isn't sending the header — for cloudflared, the connector
+  should send it by default; check the connector version.
+
+  This XFP path is **interim**: it trusts a header any local process
+  on the host can forge. The replacement (an explicit
+  `auth.allowed_origins` config) is tracked in
+  [issue #39](https://github.com/agentculture/irc-lens/issues/39) and
+  the long-term cryptographic-CSRF fix in #27.
+
+### Static-asset cache busting
+
+The HTML template emits hashed query strings on `/static/*` URLs
+(`lens.css?v=<hash>`, `lens.js?v=<hash>`, etc.). Restart the lens to
+update the hash; all browsers refetch on next load — no manual cache
+clear required. If you edit a static file and the browser still serves
+the old copy, confirm you restarted the process (the hash is computed
+once at startup).
+
+## Threat-model notes
+
+- The lens binds `127.0.0.1` in CF mode; nothing on the public
+  internet can reach `:8765` directly. Anyone on the host can.
+- The XFP-honoring Origin floor (above) trusts `X-Forwarded-Proto`
+  unconditionally. Loopback-resident attackers can forge it. Issue
+  #39 tracks the replacement.
+- Service-token credentials are highly privileged in this setup
+  (they bypass identity entirely). Treat `IRC_LENS_TEST_CLIENT_SECRET`
+  and `IRC_LENS_TEST_TUNNEL_TOKEN` like any other production secret —
+  they're already gitignored via `.cf-roundtrip.env`'s mode 0600 and
+  the repo's `.gitignore`, but don't echo them to logs or share env
+  files between deployments.
+
+## Cross-references
+
+- [`scripts/cf-roundtrip/README.md`](../scripts/cf-roundtrip/README.md)
+  — exact provisioning script and env-file format.
+- [`tests/test_cf_roundtrip.py`](../tests/test_cf_roundtrip.py) — the
+  formal `@pytest.mark.cloudflare` round-trip test; canonical config
+  shape lives in its `lens_subprocess` fixture.
+- [`docs/deployment-cloudflare-access.md`](deployment-cloudflare-access.md)
+  — manual deployment guide; this runbook is the live-test cousin.
+- [`docs/security-checklist.md`](security-checklist.md) — walk this
+  before exposing a hostname to the public internet.

--- a/src/irc_lens/static/lens.css
+++ b/src/irc_lens/static/lens.css
@@ -134,10 +134,12 @@ body[data-conn="down"] .lens-conn { color: var(--lens-down); }
 
 #toast-region {
   position: fixed;
-  bottom: 1em;
-  right: 1em;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
   display: grid;
   gap: 0.5em;
+  justify-items: center;
   z-index: 10;
   pointer-events: none;
 }

--- a/src/irc_lens/templates/index.html.j2
+++ b/src/irc_lens/templates/index.html.j2
@@ -4,19 +4,19 @@
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <title>irc-lens — {{ session.nick }}@{{ session.host }}</title>
-    <link rel="icon" type="image/png" sizes="32x32" href="/static/favicon-32x32.png">
-    <link rel="icon" type="image/png" sizes="16x16" href="/static/favicon-16x16.png">
-    <link rel="icon" href="/static/favicon.ico">
-    <link rel="apple-touch-icon" sizes="180x180" href="/static/apple-touch-icon.png">
+    <link rel="icon" type="image/png" sizes="32x32" href="{{ static_url('favicon-32x32.png') }}">
+    <link rel="icon" type="image/png" sizes="16x16" href="{{ static_url('favicon-16x16.png') }}">
+    <link rel="icon" href="{{ static_url('favicon.ico') }}">
+    <link rel="apple-touch-icon" sizes="180x180" href="{{ static_url('apple-touch-icon.png') }}">
     <meta name="color-scheme" content="dark">
-    <link rel="stylesheet" href="/static/lens.css">
-    <script src="/static/vendor/htmx.min.js" defer></script>
-    <script src="/static/vendor/sse.js" defer></script>
-    <script src="/static/lens.js" defer></script>
+    <link rel="stylesheet" href="{{ static_url('lens.css') }}">
+    <script src="{{ static_url('vendor/htmx.min.js') }}" defer></script>
+    <script src="{{ static_url('vendor/sse.js') }}" defer></script>
+    <script src="{{ static_url('lens.js') }}" defer></script>
   </head>
   <body data-view="{{ session.view }}">
     <header class="lens-header">
-      <img class="lens-logo" src="/static/culture-logo.png" alt="Culture" width="24" height="24">
+      <img class="lens-logo" src="{{ static_url('culture-logo.png') }}" alt="Culture" width="24" height="24">
       <span data-testid="connection-status" class="lens-conn {{ 'lens-conn--healthy' if session.healthy else 'lens-conn--down' }}">
         {% if session.healthy %}connected{% else %}disconnected{% endif %}
       </span>

--- a/src/irc_lens/web/app.py
+++ b/src/irc_lens/web/app.py
@@ -17,6 +17,7 @@ from irc_lens.config import LensConfig
 from irc_lens.web import routes
 from irc_lens.web.auth import build_cloudflare_middleware
 from irc_lens.web.identity import Identity
+from irc_lens.web.render import precompute_static_hashes
 from irc_lens.web.routes import _MAX_INPUT_BODY
 from irc_lens.web.sessions import SessionFactory, SessionRegistry
 
@@ -86,5 +87,9 @@ def make_app(config: LensConfig, session_factory: SessionFactory) -> web.Applica
         show_index=False,
         follow_symlinks=False,
     )
+
+    # Pre-warm asset-hash cache so the first GET / doesn't pay file I/O
+    # synchronously inside the async handler (per Qodo PR #40 review).
+    precompute_static_hashes()
 
     return app

--- a/src/irc_lens/web/render.py
+++ b/src/irc_lens/web/render.py
@@ -29,6 +29,11 @@ def static_url(name: str) -> str:
     Hashes the file's bytes once per process and reuses the result.
     Restarting the lens picks up edits; the changed hash forces
     browsers to refetch instead of serving the disk-cached copy.
+
+    Pre-warm via :func:`precompute_static_hashes` at startup to avoid
+    blocking file I/O on the event loop during the first request; the
+    lazy path here remains as a fallback for assets added after
+    startup or in tests with mocked package layouts.
     """
     cached = _asset_hash_cache.get(name)
     if cached is None:
@@ -36,6 +41,31 @@ def static_url(name: str) -> str:
         cached = hashlib.sha256(path.read_bytes()).hexdigest()[:8]
         _asset_hash_cache[name] = cached
     return f"/static/{name}?v={cached}"
+
+
+def precompute_static_hashes() -> None:
+    """Eagerly fill :data:`_asset_hash_cache` for every file under
+    ``irc_lens/static``. Called once from ``web.app.make_app`` so the
+    first ``GET /`` doesn't hash assets synchronously inside an async
+    handler.
+
+    Failures are swallowed: if the static layout isn't a real
+    filesystem (zipimport, partial test fixtures), :func:`static_url`
+    will retry lazily and surface the error there.
+    """
+    try:
+        _walk_static(files("irc_lens").joinpath("static"), "")
+    except Exception:  # pragma: no cover — defensive, see docstring
+        pass
+
+
+def _walk_static(node: Any, prefix: str) -> None:
+    for entry in node.iterdir():
+        rel = f"{prefix}{entry.name}" if not prefix else f"{prefix}/{entry.name}"
+        if entry.is_file():
+            static_url(rel)
+        elif entry.is_dir():
+            _walk_static(entry, rel)
 
 
 def _strftime(value: Any, fmt: str = "%H:%M:%S") -> str:

--- a/src/irc_lens/web/render.py
+++ b/src/irc_lens/web/render.py
@@ -9,13 +9,33 @@ ship in the wheel without a separate ``MANIFEST.in``.
 
 from __future__ import annotations
 
+import hashlib
 import time
+from importlib.resources import files
 from typing import TYPE_CHECKING, Any
 
 from jinja2 import Environment, PackageLoader, select_autoescape
 
 if TYPE_CHECKING:
     from irc_lens.session import Session
+
+
+_asset_hash_cache: dict[str, str] = {}
+
+
+def static_url(name: str) -> str:
+    """Return ``/static/<name>?v=<hash>`` for cache-busting.
+
+    Hashes the file's bytes once per process and reuses the result.
+    Restarting the lens picks up edits; the changed hash forces
+    browsers to refetch instead of serving the disk-cached copy.
+    """
+    cached = _asset_hash_cache.get(name)
+    if cached is None:
+        path = files("irc_lens").joinpath("static").joinpath(name)
+        cached = hashlib.sha256(path.read_bytes()).hexdigest()[:8]
+        _asset_hash_cache[name] = cached
+    return f"/static/{name}?v={cached}"
 
 
 def _strftime(value: Any, fmt: str = "%H:%M:%S") -> str:
@@ -38,6 +58,7 @@ _env = Environment(
     lstrip_blocks=True,
 )
 _env.filters["strftime"] = _strftime
+_env.globals["static_url"] = static_url
 
 
 def render_fragment(template: str, **ctx: Any) -> str:

--- a/src/irc_lens/web/routes.py
+++ b/src/irc_lens/web/routes.py
@@ -88,8 +88,28 @@ def _origin_ok(request: web.Request) -> bool:
     origin_host = parsed.hostname.lower()
     origin_port = _effective_port(parsed.port, parsed.scheme)
     request_host = (request.url.host or "").lower()
-    request_port = _effective_port(request.url.port, request.url.scheme)
+    request_port = _request_effective_port(request)
     return (origin_host, origin_port) == (request_host, request_port)
+
+
+def _request_effective_port(request: web.Request) -> int:
+    """Return the public-facing port for Origin comparison.
+
+    When ``X-Forwarded-Proto`` is set (we're behind a TLS-terminating
+    proxy), we use the *scheme*'s default port and ignore the local TCP
+    port — cloudflared & friends terminate TLS and forward plain HTTP
+    to this loopback listener, so ``request.url.port`` reflects the
+    proxy hop, not the client's view. Without XFP, fall back to the
+    actual URL.
+
+    Interim heuristic: trusts a header any local process can forge.
+    Replacement tracked alongside #27.
+    """
+    xfp = request.headers.get("X-Forwarded-Proto")
+    if xfp:
+        forwarded_scheme = xfp.lower().split(",")[0].strip()
+        return _effective_port(None, forwarded_scheme)
+    return _effective_port(request.url.port, request.url.scheme)
 
 
 def _effective_port(port: int | None, scheme: str) -> int:
@@ -179,6 +199,20 @@ async def post_input(request: web.Request) -> web.Response:
     # (curl, cloudflared probes, internal monitors) pass through unchanged.
     # A full CSRF-token scheme is tracked in issue #27.
     if not _origin_ok(request):
+        xfp = request.headers.get("X-Forwarded-Proto")
+        forwarded_scheme = (
+            xfp.lower().split(",")[0].strip() if xfp else request.url.scheme
+        )
+        logger.warning(
+            "origin_mismatch origin=%s request_host=%s request_port=%s "
+            "scheme=%s method=%s path=%s",
+            request.headers.get("Origin"),
+            (request.url.host or "").lower(),
+            _request_effective_port(request),
+            forwarded_scheme,
+            request.method,
+            request.path,
+        )
         return web.json_response(
             {
                 "error": "Origin does not match request host",

--- a/src/irc_lens/web/routes.py
+++ b/src/irc_lens/web/routes.py
@@ -96,20 +96,32 @@ def _request_effective_port(request: web.Request) -> int:
     """Return the public-facing port for Origin comparison.
 
     When ``X-Forwarded-Proto`` is set (we're behind a TLS-terminating
-    proxy), we use the *scheme*'s default port and ignore the local TCP
-    port — cloudflared & friends terminate TLS and forward plain HTTP
-    to this loopback listener, so ``request.url.port`` reflects the
-    proxy hop, not the client's view. Without XFP, fall back to the
-    actual URL.
+    proxy), ``request.url.port`` reflects the proxy hop, not the
+    client's view. Resolve the public-side port by preference:
+    explicit ``X-Forwarded-Port`` > explicit port in the ``Host``
+    header > default port for the forwarded scheme. The ``Host``-
+    explicit case keeps deployments on non-standard public ports (e.g.
+    ``https://example.com:8443``) from 403'ing on every POST.
+
+    Without XFP, fall back to the actual URL.
 
     Interim heuristic: trusts a header any local process can forge.
-    Replacement tracked alongside #27.
+    Replacement tracked in #39.
     """
     xfp = request.headers.get("X-Forwarded-Proto")
-    if xfp:
-        forwarded_scheme = xfp.lower().split(",")[0].strip()
-        return _effective_port(None, forwarded_scheme)
-    return _effective_port(request.url.port, request.url.scheme)
+    if not xfp:
+        return _effective_port(request.url.port, request.url.scheme)
+    forwarded_scheme = xfp.lower().split(",")[0].strip()
+    xfport = request.headers.get("X-Forwarded-Port")
+    if xfport:
+        try:
+            return int(xfport.split(",")[0].strip())
+        except ValueError:
+            pass
+    explicit = request.url.explicit_port
+    if explicit is not None:
+        return explicit
+    return _effective_port(None, forwarded_scheme)
 
 
 def _effective_port(port: int | None, scheme: str) -> int:

--- a/tests/test_origin_check.py
+++ b/tests/test_origin_check.py
@@ -124,6 +124,33 @@ async def test_post_input_origin_with_path_component(lens_client: TestClient) ->
 
 
 @pytest.mark.asyncio
+async def test_post_input_xfp_https_explicit_port_allowed(lens_client: TestClient) -> None:
+    """Non-standard public port behind a TLS-terminating proxy must NOT 403.
+
+    Cloudflare-style deployments use the scheme default (443), but other
+    reverse proxies expose lens on `https://<host>:8443`. The Origin
+    floor must accept these by honoring the explicit port from the Host
+    header (or X-Forwarded-Port) instead of always returning 443/80.
+    Without this case, every POST /input on a non-standard public port
+    would 403 — the bug Qodo flagged on PR #40.
+    """
+    public_host = "lens.example.test"
+    public_port = 8443
+    resp = await lens_client.post(
+        "/input",
+        data={"text": "hello"},
+        headers={
+            "Host": f"{public_host}:{public_port}",
+            "Origin": f"https://{public_host}:{public_port}",
+            "X-Forwarded-Proto": "https",
+        },
+    )
+    assert resp.status in (204, 503), (
+        f"Expected 204 or 503 with explicit non-standard public port, got {resp.status}"
+    )
+
+
+@pytest.mark.asyncio
 async def test_post_input_xfp_https_allowed(lens_client: TestClient) -> None:
     """TLS-terminating proxy case: Origin=https + X-Forwarded-Proto=https
     must NOT 403, even though the actual TCP connection is plain HTTP.

--- a/tests/test_origin_check.py
+++ b/tests/test_origin_check.py
@@ -121,3 +121,34 @@ async def test_post_input_origin_with_path_component(lens_client: TestClient) ->
 # mocking or a second server bind.  The implementation handles it (hostname
 # comparison is lowercased on both sides) but the fixture mechanics make an
 # in-test assertion impractical.
+
+
+@pytest.mark.asyncio
+async def test_post_input_xfp_https_allowed(lens_client: TestClient) -> None:
+    """TLS-terminating proxy case: Origin=https + X-Forwarded-Proto=https
+    must NOT 403, even though the actual TCP connection is plain HTTP.
+
+    Replicates Cloudflare Tunnel's shape: cloudflared TLS-terminates and
+    forwards plain HTTP to the lens, so request.url.scheme is "http" but
+    the original client-facing scheme is "https". Without honoring XFP,
+    every public-host POST /input would fail the floor on port (80 vs
+    443) even though the host already matches. With XFP honored, the
+    derived request port lifts to 443 and the comparison passes.
+
+    Uses Host-header override so request.url.host/port reflect the
+    "public" hostname (no port → default-for-scheme), matching the
+    production shape rather than the TestServer's loopback bind.
+    """
+    public_host = "lens.example.test"
+    resp = await lens_client.post(
+        "/input",
+        data={"text": "hello"},
+        headers={
+            "Host": public_host,
+            "Origin": f"https://{public_host}",
+            "X-Forwarded-Proto": "https",
+        },
+    )
+    assert resp.status in (204, 503), (
+        f"Expected 204 or 503 with XFP=https honored, got {resp.status}"
+    )


### PR DESCRIPTION
## Summary

- **Origin floor honors `X-Forwarded-Proto`** so `POST /input` through a TLS-terminating proxy (cloudflared) stops 403'ing on the port half of the `(host, port)` comparison. New `_request_effective_port` helper. Caveat tracked in #39 — interim heuristic, replacement is `auth.allowed_origins`.
- **`WARNING irc_lens.web.routes: origin_mismatch …` log** on rejection. The new line names origin, request_host, request_port, scheme, method, path — exactly the inputs the floor compares, so the next failure is diagnosable from `/tmp/lens.log` instead of an access-log status code.
- **Centered toast.** `#toast-region` moves from `bottom-right` to viewport center via `top: 50%; left: 50%; transform: translate(-50%, -50%)`. Failures now appear where the user is looking.
- **Static-asset cache busting.** `static_url()` Jinja global emits `/static/<name>?v=<sha256[:8]>`; hashes computed at startup and cached. Restart the lens → new hash → browsers refetch automatically. Closes the "ctrl+shift+r doesn't help" class of bug.
- **`docs/cf-roundtrip-live-test.md`** — new operator runbook for the live-test path with a `cfafi`/`cultureflare`-style provisioner. Anonymized; captures both provisioner-side gaps (missing tunnel ingress, missing `non_identity` service-token policy) and lens-side gotchas (JWT `common_name` is the service-token client_id, AgentIRC nick prefix, XFP/Origin).

## Why bundled

Each item is small, but they're all artifacts of the same exercise: bringing an automatically-provisioned cf-roundtrip deployment to a working public-hostname end-to-end. Splitting them would scatter the context. Centered toast + cache bust + Origin log are also UX/diagnostic prerequisites for finding the XFP issue at all — the centered toast is what made the Origin error visible, the log is what pinpointed the cause, and the cache bust is what let the user see CSS/code changes without fighting Chromium's cache.

## Tracking

- New: #39 — XFP-derived port honors a header any local process can forge. Recommends `auth.allowed_origins` as the next iteration; #27 is the eventual cryptographic-CSRF fix.

## Test plan

- [x] `uv run pytest -q tests/test_origin_check.py` → 6 passed (5 prior + 1 new XFP case).
- [x] Full suite (excluding `test_cf_roundtrip.py` and `test_e2e_playwright.py`) → 323 passed.
- [x] Live: `POST https://<host>/input` with service-token + `Origin: https://<host>` returns **204** (was 403 before this PR). Lens log shows `auth=ok` and a clean access entry, no `origin_mismatch` warning.
- [x] Live: browser SSO → `/join #general` → no 403 toast at the lens layer (whatever AgentIRC answers is the next layer's behavior).
- [x] Live: page reload picks up centered toast + new CSS without a hard-refresh, thanks to the hashed `lens.css?v=<hash>` URL.
- [ ] If a maintainer can rerun `pytest -m cloudflare` against a configured cf-roundtrip env, confirm it still parses (this PR doesn't touch the round-trip test fixture; pre-existing test-code issues there are separate from this PR's scope).

🤖 Generated with [Claude Code](https://claude.com/claude-code)