### PR TITLE
skills: replace pr-review with cicd, add communicate

### DIFF
--- a/.claude/skills/cicd/SKILL.md
+++ b/.claude/skills/cicd/SKILL.md
@@ -1,0 +1,228 @@
+---
+name: cicd
+description: >
+  irc-lens CI/CD lane: open PR (auto-wait for Qodo/Copilot), push fixes
+  (re-poll bots), triage feedback, reply, resolve. Adds a portability lint
+  (no absolute /home paths, no per-user dotfile refs in committed docs),
+  an alignment-delta check when CLAUDE.md or culture.yaml change, and
+  greenfield-aware test/version-bump steps. Use when: creating PRs in
+  irc-lens, handling review feedback, polling CI status, or the user says
+  "create PR", "review comments", "address feedback", "resolve threads".
+  Vendored from steward's `cicd` skill — see the `irc-lens notes` section
+  below for the AFI-rubric guardrails specific to this repo.
+---
+
+# CI/CD — irc-lens edition
+
+irc-lens is the lens CLI for AgentIRC in the Culture ecosystem; its PRs touch
+the AFI-rubric CLI surface, mesh-observability code paths, and committed
+docs that other contributors clone fresh. The two recurring bug classes that
+this skill is built to catch up front:
+
+- **Path leaks** — committing absolute home-directory paths that work only on
+  the author's machine.
+- **Per-user config dependencies** — referencing a dotfile under the user's
+  home directory in repo guidance, breaking reproducibility for other
+  contributors and CI.
+
+The workflow is encapsulated in `scripts/workflow.sh` — follow that, not a
+manual checklist. AFI-rubric-specific PUSHBACK rules and bug classes live in
+the `## irc-lens notes` section at the bottom.
+
+## Prerequisites
+
+Hard requirements: `gh` (GitHub CLI), `jq`, `bash`, `python3` (stdlib only),
+`curl` (used by `pr-status.sh`).
+
+Optional: `.claude/skills.local.yaml` declares per-machine
+`sibling_projects` paths used by the `delta` subcommand. With no file
+present, `delta` is a no-op — fine for irc-lens until cross-project
+alignment work starts.
+
+## How to run
+
+`scripts/workflow.sh` is the entry point. Subcommands:
+
+| Command | Purpose |
+|---------|---------|
+| `workflow.sh lint` | Portability lint on the current diff (staged + unstaged). |
+| `workflow.sh open-pr --title T [--body-file F] [--wait SECS] [...]` | `gh pr create` then sleep 180s (or `--wait SECS`) and fetch reviewer comments in one shot. Use after pushing the initial branch. |
+| `workflow.sh poll <PR>` | Fetch and display all review comments. |
+| `workflow.sh poll-readiness <PR> [--max-iters N] [--interval SECS] [--require LIST]` | Loop until all required reviewers are ready (default `qodo`; pass `--require qodo,copilot` to also gate on Copilot) — or the PR closes / iteration cap hits. Headline on stdout, per-iteration diagnostics on stderr. Direct wrapper around `scripts/poll-readiness.sh`. |
+| `workflow.sh wait-after-push <PR> [--wait SECS]` | Sleep 180s (or `--wait SECS`) then re-fetch comments. Use after pushing fixes. |
+| `workflow.sh await <PR>` | Poll for reviewer readiness (default: 30 × 60s ≈ 30 min cap, requires qodo only; tune with `STEWARD_PR_AWAIT_ITERS`, `STEWARD_PR_AWAIT_INTERVAL`, and `STEWARD_PR_REVIEWERS`), then run `pr-status.sh` (CI checks + SonarCloud quality gate, OPEN issues, hotspots) and `pr-comments.sh` (inline / issue / top-level / SonarCloud-new-issues sections). Exits non-zero on SonarCloud `ERROR` or unresolved threads. Setting the legacy `STEWARD_PR_AWAIT_SECONDS=<n>` falls back to a fixed sleep with a deprecation warning. |
+| `workflow.sh delta` | Dump each sibling project's `CLAUDE.md` head + `culture.yaml`. |
+| `workflow.sh reply <PR>` | Batch reply (JSONL on stdin) and resolve threads. |
+| `workflow.sh help` | Print this list. |
+
+The vendored single-comment helpers — `pr-reply.sh`, `pr-status.sh` — live
+next to `workflow.sh` and are usable directly when batching isn't appropriate.
+
+The `STEWARD_PR_*` env vars keep their historical prefix because the scripts
+are vendored verbatim from the upstream steward skill. They work the same
+regardless of which repo vendors the skill — no rename is needed, and
+keeping the prefix makes upstream tracking clean.
+
+## Polling for reviewer readiness
+
+`scripts/poll-readiness.sh` watches a PR until its required reviewers post
+real (not placeholder) feedback, the PR closes, or an iteration cap fires.
+It fetches `gh api` JSON directly — never `pr-comments.sh` output — so
+truncation can't bias the gate. Default required set is qodo only
+(see header comments and `--help` for tunables, env vars, and the `qodo` /
+`copilot` heuristics; Copilot is detected but not required because its
+review bot is silent on agentculture repos in 2026). Heartbeats stream to
+stderr; the final headline is the only thing on stdout.
+
+Two ways to drive it:
+
+- **Synchronous** — `workflow.sh await <PR>` after `gh pr create`. The
+  main session burns context during the wait; fine up to ~5 minutes.
+- **Asynchronous** — for longer waits, run the looper inside a background
+  subagent (Agent tool, `run_in_background: true`) so the main session
+  only pays the cache cost when readiness fires. The subagent's only job
+  is to invoke `poll-readiness.sh` and echo its headline back. The
+  parent triages with `workflow.sh await <PR>` when the notification
+  arrives. The user can interrupt with TaskStop.
+
+This pattern is borrowed from sibling repo
+[`agentculture/cfafi`](https://github.com/agentculture/cfafi)'s `poll`
+skill — only the looper is vendored here rather than promoting `poll`
+to its own first-class skill until other verbs need the same primitive.
+
+## End-to-end flow
+
+```text
+git checkout -b <type>/<desc>
+# ... edit ...
+.claude/skills/cicd/scripts/workflow.sh lint
+git commit -am "..." && git push -u origin <branch>
+gh pr create --title "..." --body "..."   # title <70 chars, body signed "- <nick> (Claude)"
+.claude/skills/cicd/scripts/workflow.sh await <PR>   # readiness loop, then CI + SonarCloud + all comments
+# triage; if CLAUDE.md/culture.yaml/.claude/skills changed:
+.claude/skills/cicd/scripts/workflow.sh delta
+# fix, re-lint, push
+.claude/skills/cicd/scripts/workflow.sh reply <PR> < replies.jsonl
+gh pr checks <PR>
+# Wait for human merge — never merge yourself.
+```
+
+Branch naming: `fix/<desc>`, `feat/<desc>`, `docs/<desc>`, `skill/<name>`,
+`add-<desc>`.
+PR / comment signature: `- <nick> (Claude)`, where `<nick>` comes from
+the agent's own `culture.yaml` — first agent's `suffix` — falling back
+to the git-repo basename when no `culture.yaml` is present. irc-lens has
+no `culture.yaml` today, so the resolver falls back to `irc-lens` and
+signs `- irc-lens (Claude)`. The reply script resolves this via
+`scripts/_resolve-nick.sh` and auto-appends the signature only when the
+body isn't already signed, so JSONL reply entries can include or omit it.
+Hand-rolled `gh pr create` and `gh issue comment` calls should follow the
+same convention.
+
+## Triage rules
+
+For every comment, decide **FIX** or **PUSHBACK** with reasoning.
+
+Default to **FIX** for: portability complaints (always valid for irc-lens —
+recurring bug class), test or doc requests, style nits aligned with workspace
+conventions, AFI-rubric divergence (see irc-lens notes below).
+
+Default to **PUSHBACK** for: architecture opinions that conflict with workspace
+`CLAUDE.md`, `.afi/reference/python-cli/`, or the all-backends rule;
+greenfield false-positives (e.g. "add tests" before there's any source —
+defer to a later PR, don't refuse). Always cite the *reason* — workspace
+convention, rubric clause, or scoping. PUSHBACK without reasoning is just
+a refusal.
+
+### Alignment-delta rule
+
+If the PR touches `CLAUDE.md`, `culture.yaml`, or anything under
+`.claude/skills/`, run `workflow.sh delta` **before** declaring FIX or
+PUSHBACK on each comment. The script dumps the head of every sibling
+project's `CLAUDE.md` plus the full `culture.yaml`, using `sibling_projects`
+from `skills.local.yaml`. Note any sibling that needs a follow-up PR and
+mention it in your reply. With no `skills.local.yaml`, this no-ops cleanly.
+
+## Greenfield-aware steps
+
+The lint and the workflow script are always-on. Stack-specific steps are
+conditional and run only when their preconditions exist:
+
+```bash
+[ -d tests ] && [ -f pyproject.toml ] && uv run pytest tests/ -x -q
+[ -f pyproject.toml ] && bump_version_per_project_convention   # see project README
+[ -f .markdownlint-cli2.yaml ] && markdownlint-cli2 "$(git diff --name-only --cached '*.md')"
+```
+
+irc-lens has `pyproject.toml` and `tests/` once code lands, so these
+activate as the package matures. Revisit each line as the corresponding
+stack element evolves.
+
+## Reply etiquette
+
+Every comment must get a reply — no silent fixes. Always pass `--resolve`
+when batch-replying so threads close automatically. Reference the
+review-comment IDs in the fix-up commit message.
+
+SonarCloud is queried in two places: `pr-status.sh` (quality gate, OPEN
+issues, hotspots) and the Section-4 dump in `pr-comments.sh` (new-issue
+list). Both derive the project key as `<owner>_<repo>`; override with
+`SONAR_PROJECT_KEY=<key>` for non-standard naming, and they silently skip
+when the project isn't on SonarCloud. irc-lens is registered as
+`agentculture_irc-lens` on SonarCloud, so the default derivation works.
+
+irc-lens isn't yet a registered mesh agent, so the post-merge IRC ping
+that Culture's stock `pr-review` includes is still skipped — that returns
+when irc-lens joins the mesh.
+
+## irc-lens notes
+
+irc-lens conforms to the agent-first Python CLI rubric cited from
+`citation-cli` (see top-level `CLAUDE.md` and `.afi/reference/python-cli/`).
+The cited material is authoritative — these notes summarize the
+guardrails this skill should enforce on PRs.
+
+### Recurring bug classes
+
+- **Path leaks** — caught by `scripts/portability-lint.sh`. Default lint
+  ignores `~/.claude/skills/<x>/scripts/` (vendored tool calls) and
+  `~/.culture/` (Culture-mesh data; irc-lens may read this once it has
+  IRC inspection code).
+- **Per-user config dependencies** — referencing `~/.<dotfile>` paths in
+  committed docs/configs.
+- **Rubric divergence** — `afi cli verify` enforces 6 bundles (Structure,
+  Learnability, JSON, Errors, Explain, Overview). Any change to the
+  CLI core surface must keep them green.
+
+### PUSHBACK rules specific to irc-lens
+
+- **"Vendor `.afi/reference/` into `docs/`"** → no, by design it is cited
+  via `afi cli cite` and gitignored. The right fix is to document the
+  regen command, not to commit the reference.
+- **"Merge `cli/_errors.py` into `cli/__init__.py`"** (or any consolidation
+  of the stable-contract files: `cli/_errors.py`, `cli/_output.py`, the
+  `_ArgumentParser` override, the `learn`/`explain` surface) → no, the
+  split is part of the rubric contract.
+- **"Hard-fail on missing target in `overview`"** → no, `overview` is
+  descriptive, not verifying. `overview <bogus-path>` exits 0 with a
+  warning section; hard-failing is `afi cli verify`'s job.
+
+### Stable-contract checklist
+
+When PRs touch `cli/_errors.py`, `cli/_output.py`, the `_ArgumentParser`
+override, or the `learn` / `explain` / `overview` surface:
+
+- Exit-code policy intact: `0` success, `1` user error, `2` env error,
+  `3+` reserved. All failures raise `AfiError`; the dispatcher catches
+  and exits with `err.code`. No Python traceback ever leaks.
+- stdout/stderr split intact: results to stdout, errors and diagnostics
+  to stderr, even in `--json` mode.
+- Errors keep shape `{code, message, remediation}`; text-mode renders as
+  `error: <msg>\nhint: <remediation>`.
+- `_ArgumentParser` override still routes argparse errors through
+  `emit_error` so unknown verbs/flags exit with `error:` + `hint:` and
+  no traceback.
+- Globals `learn`, `explain`, `overview` still exist at the top level —
+  not nested under a noun.
+- `learn` output rubric still passes (≥ 200 chars, mentions purpose,
+  commands, exit codes, `--json`, `explain`).

--- a/.claude/skills/cicd/scripts/_resolve-nick.sh
+++ b/.claude/skills/cicd/scripts/_resolve-nick.sh
@@ -1,0 +1,43 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Resolve the agent's nick for GitHub message signing.
+# Order: first agent's `suffix` in <repo-root>/culture.yaml,
+# then basename of the git repo root.
+# Prints the nick to stdout. Always exits 0 — pr-reply.sh needs *some*
+# nick to sign with — but if a culture.yaml exists and we couldn't
+# extract a suffix from it, emits a stderr warning so a misconfigured
+# manifest doesn't silently mask itself behind the basename fallback.
+
+repo_root="$(git rev-parse --show-toplevel 2>/dev/null || true)"
+if [[ -z "$repo_root" ]]; then
+    repo_root="$PWD"
+fi
+
+manifest="$repo_root/culture.yaml"
+
+if [[ -f "$manifest" ]]; then
+    if ! command -v python3 >/dev/null 2>&1; then
+        echo "_resolve-nick: python3 not found; cannot parse $manifest, falling back to repo basename" >&2
+    else
+        nick="$(python3 - "$manifest" <<'PY' 2>/dev/null || true
+import re, sys
+path = sys.argv[1]
+with open(path, encoding="utf-8") as f:
+    for raw in f:
+        line = raw.rstrip("\n")
+        m = re.match(r"^[\s-]*\s*suffix:\s*(\S+)", line)
+        if m:
+            print(m.group(1).strip("'\""))
+            break
+PY
+)"
+        if [[ -n "$nick" ]]; then
+            printf '%s\n' "$nick"
+            exit 0
+        fi
+        echo "_resolve-nick: $manifest exists but no suffix could be parsed; falling back to repo basename" >&2
+    fi
+fi
+
+basename "$repo_root"

--- a/.claude/skills/cicd/scripts/create-pr-and-wait.sh
+++ b/.claude/skills/cicd/scripts/create-pr-and-wait.sh
@@ -1,0 +1,100 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Create a PR, wait for automated reviewers (qodo, copilot, sonarcloud) to
+# post comments, then dump the feedback. Wraps the manual `gh pr create →
+# sleep 300 → pr-comments.sh` sequence into one invocation.
+#
+# Usage:
+#   create-pr-and-wait.sh --title "Title" --body-file PATH [--wait SECS] [extra gh pr create flags...]
+#   create-pr-and-wait.sh --title "Title" [--wait SECS] [extra gh pr create flags...] < body-on-stdin
+#
+# Flags:
+#   --title TITLE     PR title (required)
+#   --body-file PATH  Read the body from a file. If omitted, reads stdin.
+#   --wait SECS       How long to sleep after `gh pr create` before fetching
+#                     comments. Default: 180 (3 min). qodo/copilot/sonarcloud
+#                     usually post within this window. Use `wait-and-check.sh`
+#                     to extend by another 3 min if reviewers haven't finished.
+#   Any other flags pass through to `gh pr create` (e.g. --base, --reviewer).
+#
+# Behavior:
+#   1. Stage the body to a tempfile and `gh pr create --body-file …` so
+#      large self-contained briefs don't hit the OS argv length limit.
+#   2. `sleep $WAIT_SECS` to give reviewers time to post.
+#   3. Run the sibling `pr-comments.sh <PR_NUMBER>` (vendored next to this
+#      script) to dump inline + issue + review comments.
+#
+# Exit codes:
+#   0  PR created and feedback fetched (no judgment about whether feedback
+#      is clean — caller decides what to do with it).
+#   2  Bad usage (missing --title, or no body source on a TTY).
+#   3  Could not parse PR number from `gh pr create` output.
+#   *  Whatever `gh pr create` or the comment-fetch step returns.
+
+usage() {
+    echo "Usage: create-pr-and-wait.sh --title TITLE [--body-file PATH | < stdin] [--wait SECS] [gh pr create flags...]" >&2
+    exit 2
+}
+
+require_value() {
+    if [[ $# -lt 2 ]]; then
+        echo "Missing value for $1" >&2
+        usage
+    fi
+}
+
+WAIT_SECS=180
+TITLE=""
+BODY_FILE=""
+PASSTHROUGH=()
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --title)      require_value "$@"; TITLE="$2"; shift 2 ;;
+        --body-file)  require_value "$@"; BODY_FILE="$2"; shift 2 ;;
+        --wait)       require_value "$@"; WAIT_SECS="$2"; shift 2 ;;
+        -h|--help)    usage ;;
+        *) PASSTHROUGH+=("$1"); shift ;;
+    esac
+done
+
+if [[ -z "$TITLE" ]]; then
+    usage
+fi
+
+# Stage the body to a tempfile and pass `--body-file` to gh. Large
+# self-contained briefs can otherwise hit the OS argv length limit
+# (~128 KB) when passed via `--body "$BODY"`.
+TMP_BODY=$(mktemp -t cicd-create-pr-body.XXXXXX)
+trap 'rm -f "$TMP_BODY"' EXIT
+
+if [[ -n "$BODY_FILE" ]]; then
+    cat "$BODY_FILE" > "$TMP_BODY"
+elif [[ ! -t 0 ]]; then
+    cat > "$TMP_BODY"
+else
+    echo "No --body-file given and stdin is a TTY — refusing to hang on cat." >&2
+    echo "Pass --body-file PATH or pipe the body in." >&2
+    exit 2
+fi
+
+# Step 1: create the PR
+PR_URL=$(gh pr create --title "$TITLE" --body-file "$TMP_BODY" "${PASSTHROUGH[@]}")
+echo "Created: $PR_URL"
+
+PR_NUM=$(echo "$PR_URL" | grep -oE '[0-9]+$' || true)
+if [[ -z "$PR_NUM" ]]; then
+    echo "Could not parse PR number from gh pr create output: $PR_URL" >&2
+    exit 3
+fi
+
+# Step 2: wait for reviewers
+echo "Waiting ${WAIT_SECS}s for automated reviewers (qodo, copilot, sonarcloud)..."
+sleep "$WAIT_SECS"
+
+# Step 3: dump feedback. The cicd skill always vendors pr-comments.sh
+# next to this script — no per-user $HOME fallback (would violate the
+# skills-portability rule).
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+bash "$SCRIPT_DIR/pr-comments.sh" "$PR_NUM"

--- a/.claude/skills/cicd/scripts/poll-readiness.sh
+++ b/.claude/skills/cicd/scripts/poll-readiness.sh
@@ -1,0 +1,222 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# poll-readiness.sh — wait until both automated PR reviewers (qodo + Copilot)
+# have posted their full reviews, OR the PR is merged/closed, OR an iteration
+# cap is hit.
+#
+# Designed to be invoked two ways:
+#   (a) Synchronously by `workflow.sh await` (stdin/stdout local to the
+#       caller — main session burns context during the wait).
+#   (b) Asynchronously by a background subagent (Agent tool with
+#       run_in_background:true). The subagent owns the wait so the main
+#       session pays the cache cost only once, at completion.
+#
+# Usage:
+#   poll-readiness.sh [--repo OWNER/REPO] [--max-iters N] [--interval SECS]
+#                     [--require LIST] PR_NUMBER
+#
+# Defaults: --max-iters 30, --interval 60, --require qodo  (≈30-minute hard cap)
+#
+# --require accepts a comma-separated subset of {qodo,copilot}; the loop
+# exits 0 only when every listed reviewer is "ready" (or PR state flips
+# to MERGED/CLOSED). Override the default via STEWARD_PR_REVIEWERS=...
+# Copilot is *not* required by default — its automated PR-review bot
+# stopped posting top-level reviews on agentculture repos in 2026, so
+# requiring it would cause every wait to TIMEOUT. Re-add `--require
+# qodo,copilot` if Copilot starts posting again.
+#
+# Exit codes:
+#   0  All required reviewers ready, OR PR state is MERGED / CLOSED.
+#   1  TIMEOUT after --max-iters with at least one required reviewer pending.
+#   2  Bad usage.
+#
+# Output:
+#   stdout — final headline (≤10 lines), suitable for capture.
+#   stderr — per-iteration diagnostics ("still waiting (qodo: …, copilot: …)").
+#
+# Detection heuristics (mirror cfafi's `poll` skill):
+#   qodo ready    = ISSUE COMMENTS section contains "Code Review by Qodo"
+#                   AND does NOT contain "Looking for bugs?" (qodo's
+#                   "still analysing" placeholder).
+#   Copilot ready = TOP-LEVEL REVIEWS header reports a count > 0.
+#
+# Dependencies: gh, jq, bash, curl  (same as the rest of the skill).
+
+usage() {
+    cat >&2 <<'EOF'
+Usage: poll-readiness.sh [--repo OWNER/REPO] [--max-iters N] [--interval SECS]
+                         [--require LIST] PR_NUMBER
+
+Defaults: --max-iters 30, --interval 60, --require qodo
+  (set STEWARD_PR_REVIEWERS to override the default --require list)
+
+--require LIST  comma-separated subset of {qodo,copilot}. Exit 0 only
+                when every listed reviewer is ready, or PR closes.
+                Copilot is not required by default — its bot stopped
+                posting top-level reviews on agentculture repos in 2026.
+
+Exit 0 when all required reviewers ready (or PR closed),
+exit 1 on TIMEOUT, exit 2 on bad usage.
+EOF
+    exit 2
+}
+
+require_value() {
+    if [[ $# -lt 2 ]]; then
+        echo "Missing value for $1" >&2
+        usage
+    fi
+}
+
+REPO=""
+MAX_ITERS=30
+INTERVAL=60
+PR_NUMBER=""
+REQUIRE="${STEWARD_PR_REVIEWERS:-qodo}"
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --repo)       require_value "$@"; REPO="$2"; shift 2 ;;
+        --max-iters)  require_value "$@"; MAX_ITERS="$2"; shift 2 ;;
+        --interval)   require_value "$@"; INTERVAL="$2"; shift 2 ;;
+        --require)    require_value "$@"; REQUIRE="$2"; shift 2 ;;
+        -h|--help)    usage ;;
+        --) shift; break ;;
+        -*) echo "Unknown flag: $1" >&2; usage ;;
+        *)  PR_NUMBER="$1"; shift ;;
+    esac
+done
+
+[[ -z "$PR_NUMBER" ]] && usage
+[[ "$PR_NUMBER" =~ ^[0-9]+$ ]] || { echo "PR_NUMBER must be a positive integer" >&2; exit 2; }
+[[ "$MAX_ITERS" =~ ^[0-9]+$ ]] || { echo "--max-iters must be a positive integer" >&2; exit 2; }
+[[ "$INTERVAL"  =~ ^[0-9]+$ ]] || { echo "--interval must be a positive integer"  >&2; exit 2; }
+
+# Parse --require into REQUIRE_QODO / REQUIRE_COPILOT booleans. Reject
+# unknown reviewers so a typo (e.g. "qoda") doesn't silently make the
+# loop exit on iteration 1.
+REQUIRE_QODO=0
+REQUIRE_COPILOT=0
+IFS=',' read -ra _REQ <<<"$REQUIRE"
+for r in "${_REQ[@]}"; do
+    r="${r// /}"
+    case "$r" in
+        ""|qodo)   REQUIRE_QODO=1 ;;
+        copilot)   REQUIRE_COPILOT=1 ;;
+        *) echo "--require: unknown reviewer '$r' (valid: qodo, copilot)" >&2; exit 2 ;;
+    esac
+done
+if [[ $REQUIRE_QODO -eq 0 && $REQUIRE_COPILOT -eq 0 ]]; then
+    echo "--require: at least one reviewer must be required" >&2
+    exit 2
+fi
+
+if [[ -z "$REPO" ]]; then
+    REPO=$(gh repo view --json nameWithOwner -q .nameWithOwner)
+fi
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PR_URL="https://github.com/${REPO}/pull/${PR_NUMBER}"
+
+emit_headline() {
+    # $1 final state, $2 qodo status, $3 copilot status, $4 iter count, $5 next-step hint
+    cat <<EOF
+PR URL:        ${PR_URL}
+Final state:   $1
+qodo:          $2
+Copilot:       $3
+Iterations:    $4 / ${MAX_ITERS}
+Next step:     $5
+EOF
+}
+
+iter=0
+qodo_status="not-posted"
+copilot_status="not-posted"
+
+while (( iter < MAX_ITERS )); do
+    iter=$((iter + 1))
+
+    # 1. Short-circuit on closed/merged.
+    pr_state=$(gh pr view "$PR_NUMBER" --repo "$REPO" --json state -q .state 2>/dev/null || echo "UNKNOWN")
+    if [[ "$pr_state" == "MERGED" || "$pr_state" == "CLOSED" ]]; then
+        emit_headline "$pr_state" "$qodo_status" "$copilot_status" "$iter" \
+            "PR was ${pr_state,,} before reviewers finished — no triage needed."
+        exit 0
+    fi
+
+    # 2. Fetch raw, untruncated bodies directly from the GitHub API.
+    #    Reasoning: pr-comments.sh truncates comment bodies for human display,
+    #    so its output isn't a reliable input for readiness logic — a long
+    #    qodo comment can have its "Code Review by Qodo" marker fall past the
+    #    truncation, and a stale "Looking for bugs?" placeholder elsewhere in
+    #    the dump can flip a real review back to "placeholder-only". Using
+    #    `gh api` here also avoids the SonarCloud round-trip pr-comments.sh
+    #    now does on every iteration (qodo PR #17 review, perf bug).
+    issue_json=$(gh api "repos/$REPO/issues/$PR_NUMBER/comments" --paginate 2>/dev/null) || {
+        echo "iter ${iter}: gh api issues/comments failed; will retry" >&2
+        sleep "$INTERVAL"
+        continue
+    }
+    reviews_json=$(gh api "repos/$REPO/pulls/$PR_NUMBER/reviews" --paginate 2>/dev/null) || {
+        echo "iter ${iter}: gh api pulls/reviews failed; will retry" >&2
+        sleep "$INTERVAL"
+        continue
+    }
+
+    # 3. qodo readiness — match the structural <h3>Code Review by Qodo</h3>
+    #    header, which appears only in the done-state body. Cfafi's bare-text
+    #    heuristic ("contains 'Code Review by Qodo' AND NOT 'Looking for
+    #    bugs?'") false-positives when qodo's done review *quotes* either
+    #    string while reporting bugs about polling code (PR #17 hit this).
+    #    The placeholder comment uses a different layout (no <h3> wrapper),
+    #    so the H3 marker alone is enough.
+    qodo_real=$(echo "$issue_json" | jq '[
+        .[] | select(.user.login == "qodo-code-review[bot]")
+            | select(.body | contains("<h3>Code Review by Qodo</h3>"))
+    ] | length')
+    qodo_any=$(echo "$issue_json" | jq '[
+        .[] | select(.user.login == "qodo-code-review[bot]")
+    ] | length')
+    if (( qodo_real > 0 )); then
+        qodo_status="ready"
+    elif (( qodo_any > 0 )); then
+        qodo_status="placeholder-only"
+    else
+        qodo_status="not-posted"
+    fi
+
+    # 4. Copilot readiness — at least one top-level review with a non-empty
+    #    body. Excludes "review whose only content is inline comments".
+    copilot_count=$(echo "$reviews_json" | jq '[
+        .[] | select((.user.login // "") | startswith("copilot"))
+            | select((.body // "") != "")
+    ] | length')
+    if (( copilot_count > 0 )); then
+        copilot_status="ready"
+    else
+        copilot_status="not-posted"
+    fi
+
+    # 5. Done?
+    qodo_ok=1
+    copilot_ok=1
+    [[ $REQUIRE_QODO    -eq 1 && "$qodo_status"    != "ready" ]] && qodo_ok=0
+    [[ $REQUIRE_COPILOT -eq 1 && "$copilot_status" != "ready" ]] && copilot_ok=0
+    if [[ $qodo_ok -eq 1 && $copilot_ok -eq 1 ]]; then
+        emit_headline "OPEN" "$qodo_status" "$copilot_status" "$iter" \
+            "Required reviewers ready (require=${REQUIRE}); run pr-status.sh and triage."
+        exit 0
+    fi
+
+    echo "iter ${iter}/${MAX_ITERS}: qodo=${qodo_status}, copilot=${copilot_status} (require=${REQUIRE}); sleeping ${INTERVAL}s" >&2
+    if (( iter < MAX_ITERS )); then
+        sleep "$INTERVAL"
+    fi
+done
+
+# Fell off the loop — TIMEOUT.
+emit_headline "TIMEOUT" "$qodo_status" "$copilot_status" "$MAX_ITERS" \
+    "Hit ${MAX_ITERS}-iteration cap; re-run poll-readiness.sh or check PR manually."
+exit 1

--- a/.claude/skills/cicd/scripts/portability-lint.sh
+++ b/.claude/skills/cicd/scripts/portability-lint.sh
@@ -1,0 +1,57 @@
+#!/usr/bin/env bash
+# Portability lint: catch path leaks and per-user config dependencies in
+# committed docs/configs before they ship in a PR. Steward's recurring bug
+# class.
+#
+# Usage: portability-lint.sh [--all]
+#   default: lint files modified vs HEAD (staged + unstaged)
+#   --all:   lint all tracked files
+#
+# Exits 0 if clean, 1 if any leak is found.
+
+set -euo pipefail
+
+mode="${1:-diff}"
+case "$mode" in
+    --all) files=$(git ls-files -- ':(exclude)*.lock') ;;
+    diff|--diff) files=$(git diff --diff-filter=AMR --name-only HEAD -- ':(exclude)*.lock') ;;
+    *) echo "Usage: $(basename "$0") [--all]" >&2; exit 2 ;;
+esac
+
+[ -z "$files" ] && { echo "(no files to check)"; exit 0; }
+
+# ----- Check 1: hard-coded /home/<user>/... paths -----
+hits1=$(echo "$files" | xargs -r grep -nE '/home/[a-z][a-z0-9_-]+/' 2>/dev/null || true)
+
+# ----- Check 2: per-user dotfile *config* refs in committed docs/configs -----
+# Carve-outs (allowed, NOT flagged):
+#   - ~/.claude/skills/<x>/scripts/   vendored tool calls
+#   - ~/.culture/                     Culture mesh data this skill is supposed to read
+md_yaml=$(echo "$files" | grep -E '\.(md|ya?ml|toml|json|jsonc)$' || true)
+if [ -n "$md_yaml" ]; then
+    hits2=$(echo "$md_yaml" | xargs -r grep -nE '~/\.[A-Za-z]' 2>/dev/null \
+        | grep -vE '~/\.claude/skills/[^[:space:]"]+/scripts/' \
+        | grep -vE '~/\.culture/' \
+        || true)
+else
+    hits2=""
+fi
+
+fail=0
+if [ -n "$hits1" ]; then
+    echo "❌ Hard-coded /home/<user>/ paths:"
+    echo "$hits1" | sed 's/^/    /'
+    echo "   Fix: use ../sibling, repo URL, or \$WORKSPACE/sibling instead."
+    fail=1
+fi
+if [ -n "$hits2" ]; then
+    [ "$fail" -eq 1 ] && echo
+    echo "❌ Per-user ~/.<dotfile> config refs in committed doc/config:"
+    echo "$hits2" | sed 's/^/    /'
+    echo "   Allowed carve-outs: ~/.claude/skills/.../scripts/ (tool calls), ~/.culture/ (mesh data)."
+    echo "   Otherwise: commit a repo-local config or document a portable lookup."
+    fail=1
+fi
+
+[ "$fail" -eq 0 ] && echo "✓ portability lint clean ($(echo "$files" | wc -l | tr -d ' ') files checked)"
+exit $fail

--- a/.claude/skills/cicd/scripts/pr-batch.sh
+++ b/.claude/skills/cicd/scripts/pr-batch.sh
@@ -1,0 +1,57 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Batch reply to PR review comments from JSONL on stdin.
+# Each line: {"comment_id": 123, "body": "reply text"}
+# Usage: pr-batch.sh [--repo OWNER/REPO] [--resolve] PR_NUMBER < input.jsonl
+
+REPO=""
+RESOLVE=false
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --repo) REPO="$2"; shift 2 ;;
+        --resolve) RESOLVE=true; shift ;;
+        *) break ;;
+    esac
+done
+
+PR_NUMBER="${1:?Usage: pr-batch.sh [--repo OWNER/REPO] [--resolve] PR_NUMBER < input.jsonl}"
+
+if [[ -z "$REPO" ]]; then
+    REPO=$(gh repo view --json nameWithOwner -q .nameWithOwner)
+fi
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+RESOLVE_FLAG=""
+if [[ "$RESOLVE" == true ]]; then
+    RESOLVE_FLAG="--resolve"
+fi
+
+SUCCESS=0
+FAIL=0
+
+while IFS= read -r line; do
+    # Skip empty lines
+    [[ -z "$line" ]] && continue
+
+    COMMENT_ID=$(echo "$line" | jq -r '.comment_id')
+    BODY=$(echo "$line" | jq -r '.body')
+
+    if [[ "$COMMENT_ID" == "null" || "$BODY" == "null" ]]; then
+        echo "SKIP: invalid line: $line"
+        ((FAIL++)) || true
+        continue
+    fi
+
+    echo "--- Comment $COMMENT_ID ---"
+    if bash "$SCRIPT_DIR/pr-reply.sh" --repo "$REPO" $RESOLVE_FLAG "$PR_NUMBER" "$COMMENT_ID" "$BODY"; then
+        ((SUCCESS++)) || true
+    else
+        echo "FAILED: comment $COMMENT_ID"
+        ((FAIL++)) || true
+    fi
+done
+
+echo ""
+echo "Done: $SUCCESS succeeded, $FAIL failed"

--- a/.claude/skills/cicd/scripts/pr-batch.sh
+++ b/.claude/skills/cicd/scripts/pr-batch.sh
@@ -35,8 +35,8 @@ while IFS= read -r line; do
     # Skip empty lines
     [[ -z "$line" ]] && continue
 
-    COMMENT_ID=$(echo "$line" | jq -r '.comment_id')
-    BODY=$(echo "$line" | jq -r '.body')
+    COMMENT_ID=$(echo "$line" | jq -r '.comment_id' 2>/dev/null || echo "null")
+    BODY=$(echo "$line" | jq -r '.body' 2>/dev/null || echo "null")
 
     if [[ "$COMMENT_ID" == "null" || "$BODY" == "null" ]]; then
         echo "SKIP: invalid line: $line"

--- a/.claude/skills/cicd/scripts/pr-comments.sh
+++ b/.claude/skills/cicd/scripts/pr-comments.sh
@@ -1,0 +1,128 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Fetch and display all PR feedback in one pass:
+#   1. Inline review comments (with thread resolve status)
+#   2. Issue comments (qodo summaries, sonarcloud, etc.)
+#   3. Top-level reviews with a non-empty body (copilot overview, etc.)
+#   4. SonarCloud new issues (silently skipped if project isn't on SonarCloud).
+#      Project key is derived as `<owner>_<repo>`; override with
+#      SONAR_PROJECT_KEY=<key> for non-standard naming.
+#
+# Usage: pr-comments.sh [--repo OWNER/REPO] PR_NUMBER
+
+REPO=""
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --repo) REPO="$2"; shift 2 ;;
+        *) break ;;
+    esac
+done
+
+PR_NUMBER="${1:?Usage: pr-comments.sh [--repo OWNER/REPO] PR_NUMBER}"
+
+if [[ -z "$REPO" ]]; then
+    REPO=$(gh repo view --json nameWithOwner -q .nameWithOwner)
+fi
+
+# ── Section 1: inline review comments ─────────────────────────────────────
+THREADS_JSON=$(gh api graphql -f query="
+{
+  repository(owner: \"${REPO%%/*}\", name: \"${REPO##*/}\") {
+    pullRequest(number: $PR_NUMBER) {
+      reviewThreads(first: 100) {
+        nodes {
+          id
+          isResolved
+          comments(first: 100) {
+            nodes { databaseId }
+          }
+        }
+      }
+    }
+  }
+}" --jq '.data.repository.pullRequest.reviewThreads.nodes')
+
+# Build a map from every comment ID in every thread → its thread metadata,
+# so replies in a thread also show resolved status (not just the first comment).
+THREAD_MAP=$(echo "$THREADS_JSON" | jq -r '
+  [.[] as $t | $t.comments.nodes[] | {
+    comment_id: .databaseId,
+    thread_id: $t.id,
+    resolved: $t.isResolved
+  }]
+')
+
+INLINE=$(gh api "repos/$REPO/pulls/$PR_NUMBER/comments" --paginate)
+INLINE_COUNT=$(echo "$INLINE" | jq 'length')
+
+echo "════════════════ INLINE REVIEW COMMENTS ($INLINE_COUNT) ════════════════"
+echo "$INLINE" | jq -r --argjson threads "$THREAD_MAP" '
+  .[] | . as $c |
+  ($threads | map(select(.comment_id == $c.id)) | first // {resolved: "unknown", thread_id: "?"}) as $t |
+  "──────────────────────────────────────────────────",
+  "ID: \($c.id)  |  Thread: \(if $t.resolved == true then "RESOLVED" elif $t.resolved == false then "UNRESOLVED" else "?" end)  |  Reply-to: \($c.in_reply_to_id // "none")",
+  "File: \($c.path):\($c.original_line // $c.line // "?")",
+  "Thread ID: \($t.thread_id)",
+  "Author: \($c.user.login)",
+  "",
+  ($c.body | split("\n") | if length > 10 then .[:10] + ["... (truncated)"] else . end | join("\n")),
+  ""
+'
+
+# ── Section 2: issue comments (general PR comments) ───────────────────────
+ISSUE=$(gh api "repos/$REPO/issues/$PR_NUMBER/comments" --paginate)
+ISSUE_COUNT=$(echo "$ISSUE" | jq 'length')
+
+echo ""
+echo "════════════════ ISSUE COMMENTS ($ISSUE_COUNT) ════════════════"
+echo "$ISSUE" | jq -r '
+  .[] |
+  "──────────────────────────────────────────────────",
+  "ID: \(.id)  |  Author: \(.user.login)  |  Created: \(.created_at)",
+  "",
+  (.body | split("\n") | if length > 10 then .[:10] + ["... (truncated)"] else . end | join("\n")),
+  ""
+'
+
+# ── Section 3: top-level reviews with a body ──────────────────────────────
+REVIEWS=$(gh api "repos/$REPO/pulls/$PR_NUMBER/reviews" --paginate)
+REVIEWS_WITH_BODY=$(echo "$REVIEWS" | jq '[.[] | select((.body // "") != "")]')
+REVIEW_COUNT=$(echo "$REVIEWS_WITH_BODY" | jq 'length')
+
+echo ""
+echo "════════════════ TOP-LEVEL REVIEWS ($REVIEW_COUNT) ════════════════"
+echo "$REVIEWS_WITH_BODY" | jq -r '
+  .[] |
+  "──────────────────────────────────────────────────",
+  "Review ID: \(.id)  |  Author: \(.user.login)  |  State: \(.state)  |  Submitted: \(.submitted_at)",
+  "",
+  (.body | split("\n") | if length > 10 then .[:10] + ["... (truncated)"] else . end | join("\n")),
+  ""
+'
+
+# ── Section 4: SonarCloud new issues ──────────────────────────────────────
+# Public API; no auth needed for public projects. Project key defaults to
+# the GitHub `<owner>_<repo>` convention; override with SONAR_PROJECT_KEY.
+SONAR_KEY="${SONAR_PROJECT_KEY:-${REPO%%/*}_${REPO##*/}}"
+SONAR_RAW=$(curl -fsS "https://sonarcloud.io/api/issues/search?componentKeys=${SONAR_KEY}&pullRequest=${PR_NUMBER}&ps=100" 2>/dev/null || echo '{}')
+
+if echo "$SONAR_RAW" | jq -e 'has("issues")' >/dev/null 2>&1; then
+    SONAR_COUNT=$(echo "$SONAR_RAW" | jq '.issues | length')
+    echo ""
+    echo "════════════════ SONARCLOUD NEW ISSUES ($SONAR_COUNT) ════════════════"
+    if [[ "$SONAR_COUNT" -gt 0 ]]; then
+        echo "$SONAR_RAW" | jq -r '
+          .issues[] |
+          "──────────────────────────────────────────────────",
+          "[\(.severity)] [\(.rule)] \(.component | sub("^[^:]+:"; "")):\(.line // "?")",
+          (.message | if length > 200 then .[:200] + "…" else . end),
+          ""
+        '
+    fi
+else
+    echo ""
+    echo "════════════════ SONARCLOUD NEW ISSUES ════════════════"
+    echo "(project key '${SONAR_KEY}' not registered on sonarcloud.io — section skipped)"
+fi

--- a/.claude/skills/cicd/scripts/pr-reply.sh
+++ b/.claude/skills/cicd/scripts/pr-reply.sh
@@ -1,0 +1,77 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Reply to a PR review comment, optionally resolve its thread.
+# Usage: pr-reply.sh [--repo OWNER/REPO] [--resolve] PR_NUMBER COMMENT_ID "body"
+
+REPO=""
+RESOLVE=false
+PRINT_BODY=false
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --repo) REPO="$2"; shift 2 ;;
+        --resolve) RESOLVE=true; shift ;;
+        --print-body) PRINT_BODY=true; shift ;;
+        *) break ;;
+    esac
+done
+
+PR_NUMBER="${1:?Usage: pr-reply.sh [--repo OWNER/REPO] [--resolve] [--print-body] PR_NUMBER COMMENT_ID \"body\"}"
+COMMENT_ID="${2:?Missing COMMENT_ID}"
+BODY="${3:?Missing reply body}"
+
+if [[ "$PRINT_BODY" != true && -z "$REPO" ]]; then
+    REPO=$(gh repo view --json nameWithOwner -q .nameWithOwner)
+fi
+
+# Sign with the agent's nick. Resolved per invocation so siblings that
+# vendor this skill pick up their own culture.yaml suffix automatically.
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+NICK="$("$SCRIPT_DIR/_resolve-nick.sh")"
+SIG="- ${NICK} (Claude)"
+if ! printf '%s' "$BODY" | grep -qFx -- "$SIG"; then
+    BODY="${BODY}
+
+${SIG}"
+fi
+
+if [[ "$PRINT_BODY" == true ]]; then
+    printf '%s\n' "$BODY"
+    exit 0
+fi
+
+# Post reply
+REPLY_URL=$(gh api "repos/$REPO/pulls/$PR_NUMBER/comments/$COMMENT_ID/replies" \
+    -f body="$BODY" \
+    --jq '.html_url')
+echo "Replied: $REPLY_URL"
+
+# Resolve thread if requested
+if [[ "$RESOLVE" == true ]]; then
+    # Find the thread ID for this comment
+    THREAD_ID=$(gh api graphql -f query="
+    {
+      repository(owner: \"${REPO%%/*}\", name: \"${REPO##*/}\") {
+        pullRequest(number: $PR_NUMBER) {
+          reviewThreads(first: 100) {
+            nodes {
+              id
+              comments(first: 100) {
+                nodes { databaseId }
+              }
+            }
+          }
+        }
+      }
+    }" --jq ".data.repository.pullRequest.reviewThreads.nodes[] | select(any(.comments.nodes[]; .databaseId == $COMMENT_ID)) | .id")
+
+    if [[ -n "$THREAD_ID" ]]; then
+        RESOLVED=$(gh api graphql -f query="
+          mutation { resolveReviewThread(input: {threadId: \"$THREAD_ID\"}) { thread { isResolved } } }
+        " --jq '.data.resolveReviewThread.thread.isResolved')
+        echo "Resolved: $RESOLVED (thread $THREAD_ID)"
+    else
+        echo "Warning: could not find thread for comment $COMMENT_ID"
+    fi
+fi

--- a/.claude/skills/cicd/scripts/pr-status.sh
+++ b/.claude/skills/cicd/scripts/pr-status.sh
@@ -1,0 +1,164 @@
+#!/usr/bin/env bash
+# pr-status.sh — one-shot status overview for a Steward PR.
+#
+# Combines five things review feedback usually scatters across:
+#   1. PR state (open / merged / closed) + branch + author
+#   2. CI checks (build / lint / unit / sonarcloud / cf-pages / etc.)
+#   3. Review-bot pipeline status (Copilot, qodo, SonarCloud, Cloudflare)
+#   4. SonarCloud quality gate + open-issue count
+#   5. Inline-thread resolved-vs-unresolved tally
+#
+# Usage: scripts/pr-status.sh [--repo OWNER/REPO] [--sonar-key KEY] PR_NUMBER
+#
+# Defaults:
+#   --repo           auto-detected via `gh repo view`
+#   --sonar-key      derived from repo as `<owner>_<name>` (SonarCloud convention)
+#
+# Requires: gh, jq, curl, python3.
+
+set -euo pipefail
+
+REPO=""
+SONAR_KEY=""
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --repo) REPO="$2"; shift 2 ;;
+        --sonar-key) SONAR_KEY="$2"; shift 2 ;;
+        *) break ;;
+    esac
+done
+
+PR_NUMBER="${1:?Usage: pr-status.sh [--repo OWNER/REPO] [--sonar-key KEY] PR_NUMBER}"
+
+if [[ -z "$REPO" ]]; then
+    REPO=$(gh repo view --json nameWithOwner -q .nameWithOwner)
+fi
+# Sonar key precedence: explicit --sonar-key flag > SONAR_PROJECT_KEY env >
+# `<owner>_<repo>` derivation. Mirrors pr-comments.sh so SKILL.md's claim
+# that the env var works for both scripts is true.
+if [[ -z "$SONAR_KEY" ]]; then
+    SONAR_KEY="${SONAR_PROJECT_KEY:-${REPO%%/*}_${REPO##*/}}"
+fi
+
+# ── 1. PR header ──────────────────────────────────────────────────────────
+PR_JSON=$(gh pr view "$PR_NUMBER" --json \
+    number,title,state,isDraft,mergedAt,mergedBy,baseRefName,headRefName,author,url)
+
+echo "════════════════════════════════════════════════════════════════════"
+echo "$PR_JSON" | jq -r '
+    "PR #\(.number) — \(.title)",
+    "  \(.url)",
+    "  Author:  \(.author.login)",
+    "  Branch:  \(.headRefName)  →  \(.baseRefName)",
+    "  State:   \(if .state == "MERGED" then "MERGED at \(.mergedAt) by \(.mergedBy.login)" elif .state == "OPEN" and .isDraft then "OPEN (draft)" else .state end)"
+'
+echo "════════════════════════════════════════════════════════════════════"
+
+# ── 2. CI checks ──────────────────────────────────────────────────────────
+echo
+echo "── CI checks ─────────────────────────────────────────────────────────"
+# `gh pr checks` exits non-zero when checks are still pending/failing.
+# We don't care about its exit code here; capture and pretty-print.
+CHECKS=$(gh pr checks "$PR_NUMBER" 2>/dev/null || true)
+if [[ -z "$CHECKS" ]]; then
+    echo "  (no checks reported)"
+else
+    echo "$CHECKS" | awk -F'\t' '
+        {
+            name  = $1
+            state = $2
+            dur   = $3
+            sym   = "?"
+            if (state == "pass")            sym = "✅"
+            else if (state == "fail")       sym = "❌"
+            else if (state == "skipping")   sym = "⏭"
+            else if (state == "pending"  || state == "queued"   || state == "in_progress") sym = "…"
+            printf "  %s %-22s %-10s %s\n", sym, name, state, dur
+        }
+    '
+fi
+
+# ── 3. Review bots & comment pipeline ────────────────────────────────────
+echo
+echo "── Review pipeline ───────────────────────────────────────────────────"
+
+# Inline-thread tally via GraphQL (resolved vs unresolved).
+THREADS_JSON=$(gh api graphql -f query="
+{
+  repository(owner: \"${REPO%%/*}\", name: \"${REPO##*/}\") {
+    pullRequest(number: $PR_NUMBER) {
+      reviewThreads(first: 100) {
+        nodes { id isResolved comments(first: 1) { nodes { author { login } } } }
+      }
+    }
+  }
+}" --jq '.data.repository.pullRequest.reviewThreads.nodes')
+
+INLINE_TOTAL=$(echo "$THREADS_JSON" | jq 'length')
+INLINE_RESOLVED=$(echo "$THREADS_JSON" | jq '[.[] | select(.isResolved)] | length')
+INLINE_PENDING=$((INLINE_TOTAL - INLINE_RESOLVED))
+
+# Per-bot inline counts.
+COPILOT_INLINE=$(echo "$THREADS_JSON" | jq '[.[] | select((.comments.nodes[0].author.login // "") | startswith("Copilot"))] | length')
+QODO_INLINE=$(echo "$THREADS_JSON" | jq '[.[] | select((.comments.nodes[0].author.login // "") | startswith("qodo"))] | length')
+
+# Issue-level comments (qodo summary, sonarcloud quality-gate body, cf-pages preview, etc.).
+# Skip --paginate to avoid array concatenation; per_page=100 covers typical PRs.
+ISSUE=$(gh api "repos/$REPO/issues/$PR_NUMBER/comments?per_page=100")
+QODO_ISSUE=$(echo "$ISSUE" | jq '[.[] | select((.user.login // "") | startswith("qodo"))] | length')
+SONARQUBE_ISSUE=$(echo "$ISSUE" | jq '[.[] | select((.user.login // "") | startswith("sonarqubecloud"))] | length')
+CFPAGES_ISSUE=$(echo "$ISSUE" | jq '[.[] | select((.user.login // "") | test("cloudflare"))] | length')
+COPILOT_TOPLEVEL=$(gh api "repos/$REPO/pulls/$PR_NUMBER/reviews?per_page=100" \
+    | jq '[.[] | select((.user.login // "") | startswith("copilot")) | select((.body // "") != "")] | length')
+
+# Cloudflare deploy URL hidden in issue-comment bodies (look for pages.dev).
+CF_URL=$(echo "$ISSUE" | jq -r '[.[].body // "" | scan("https?://[a-z0-9.-]+\\.pages\\.dev[^\\s)\"<]*")] | first // ""')
+
+printf "  %-12s %s\n"  "Copilot"     "$([[ "$COPILOT_TOPLEVEL" -gt 0 || "$COPILOT_INLINE" -gt 0 ]] && echo "✅ overview×$COPILOT_TOPLEVEL, inline×$COPILOT_INLINE" || echo "— no posts yet")"
+printf "  %-12s %s\n"  "qodo"        "$([[ "$QODO_ISSUE" -gt 0 || "$QODO_INLINE" -gt 0 ]] && echo "✅ summary×$QODO_ISSUE, inline×$QODO_INLINE" || echo "— no posts yet")"
+printf "  %-12s %s\n"  "Cloudflare"  "$([[ -n "$CF_URL" ]] && echo "✅ $CF_URL" || ([[ "$CFPAGES_ISSUE" -gt 0 ]] && echo "✅ ($CFPAGES_ISSUE comments)" || echo "— no deploy preview"))"
+
+# ── 4. SonarCloud quality gate + open issues ─────────────────────────────
+SONAR_QG=$(curl -s "https://sonarcloud.io/api/qualitygates/project_status?projectKey=${SONAR_KEY}&pullRequest=${PR_NUMBER}")
+SONAR_QG_STATUS=$(echo "$SONAR_QG" | jq -r '.projectStatus.status // "UNKNOWN"')
+SONAR_OPEN=$(curl -s "https://sonarcloud.io/api/issues/search?componentKeys=${SONAR_KEY}&pullRequest=${PR_NUMBER}&statuses=OPEN,CONFIRMED&ps=1" \
+    | jq -r '.total // 0')
+SONAR_HOTSPOTS=$(curl -s "https://sonarcloud.io/api/hotspots/search?projectKey=${SONAR_KEY}&pullRequest=${PR_NUMBER}&status=TO_REVIEW&ps=1" \
+    | jq -r '.paging.total // 0')
+
+case "$SONAR_QG_STATUS" in
+    OK)    SONAR_SYM="✅" ;;
+    ERROR) SONAR_SYM="❌" ;;
+    WARN)  SONAR_SYM="⚠ " ;;
+    *)     SONAR_SYM="?" ;;
+esac
+printf "  %-12s %s Quality Gate %s, %d OPEN issue(s), %d hotspot(s)\n" \
+    "SonarCloud" "$SONAR_SYM" "$SONAR_QG_STATUS" "$SONAR_OPEN" "$SONAR_HOTSPOTS"
+
+# When SonarCloud has OPEN issues, list them — saves a follow-up curl.
+if [[ "$SONAR_OPEN" != "0" ]]; then
+    echo
+    echo "  SonarCloud OPEN issues:"
+    curl -s "https://sonarcloud.io/api/issues/search?componentKeys=${SONAR_KEY}&pullRequest=${PR_NUMBER}&statuses=OPEN,CONFIRMED&ps=20" \
+        | jq -r '.issues[] | "    • [\(.rule)] \(.component | sub("^[^:]+:"; ""))(:\(.line // "?")) (\(.severity)) — \(.message)"'
+fi
+
+# ── 5. Tally + summary ────────────────────────────────────────────────────
+echo
+echo "── Inline threads ────────────────────────────────────────────────────"
+printf "  Total: %d   Resolved: %d   Unresolved: %d\n" \
+    "$INLINE_TOTAL" "$INLINE_RESOLVED" "$INLINE_PENDING"
+
+if [[ "$INLINE_PENDING" -gt 0 ]]; then
+    echo
+    echo "  Unresolved threads:"
+    echo "$THREADS_JSON" | jq -r '
+        .[] | select(.isResolved == false) |
+        "    • \(.comments.nodes[0].author.login): thread \(.id)"
+    '
+fi
+
+echo
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+echo "(For full comment bodies: bash \"$SCRIPT_DIR/pr-comments.sh\" $PR_NUMBER)"

--- a/.claude/skills/cicd/scripts/pr-status.sh
+++ b/.claude/skills/cicd/scripts/pr-status.sh
@@ -120,11 +120,11 @@ printf "  %-12s %s\n"  "qodo"        "$([[ "$QODO_ISSUE" -gt 0 || "$QODO_INLINE"
 printf "  %-12s %s\n"  "Cloudflare"  "$([[ -n "$CF_URL" ]] && echo "✅ $CF_URL" || ([[ "$CFPAGES_ISSUE" -gt 0 ]] && echo "✅ ($CFPAGES_ISSUE comments)" || echo "— no deploy preview"))"
 
 # ── 4. SonarCloud quality gate + open issues ─────────────────────────────
-SONAR_QG=$(curl -s "https://sonarcloud.io/api/qualitygates/project_status?projectKey=${SONAR_KEY}&pullRequest=${PR_NUMBER}")
+SONAR_QG=$(curl -s "https://sonarcloud.io/api/qualitygates/project_status?projectKey=${SONAR_KEY}&pullRequest=${PR_NUMBER}" || echo '{}')
 SONAR_QG_STATUS=$(echo "$SONAR_QG" | jq -r '.projectStatus.status // "UNKNOWN"')
-SONAR_OPEN=$(curl -s "https://sonarcloud.io/api/issues/search?componentKeys=${SONAR_KEY}&pullRequest=${PR_NUMBER}&statuses=OPEN,CONFIRMED&ps=1" \
+SONAR_OPEN=$( (curl -s "https://sonarcloud.io/api/issues/search?componentKeys=${SONAR_KEY}&pullRequest=${PR_NUMBER}&statuses=OPEN,CONFIRMED&ps=1" || echo '{}') \
     | jq -r '.total // 0')
-SONAR_HOTSPOTS=$(curl -s "https://sonarcloud.io/api/hotspots/search?projectKey=${SONAR_KEY}&pullRequest=${PR_NUMBER}&status=TO_REVIEW&ps=1" \
+SONAR_HOTSPOTS=$( (curl -s "https://sonarcloud.io/api/hotspots/search?projectKey=${SONAR_KEY}&pullRequest=${PR_NUMBER}&status=TO_REVIEW&ps=1" || echo '{}') \
     | jq -r '.paging.total // 0')
 
 case "$SONAR_QG_STATUS" in
@@ -140,7 +140,7 @@ printf "  %-12s %s Quality Gate %s, %d OPEN issue(s), %d hotspot(s)\n" \
 if [[ "$SONAR_OPEN" != "0" ]]; then
     echo
     echo "  SonarCloud OPEN issues:"
-    curl -s "https://sonarcloud.io/api/issues/search?componentKeys=${SONAR_KEY}&pullRequest=${PR_NUMBER}&statuses=OPEN,CONFIRMED&ps=20" \
+    (curl -s "https://sonarcloud.io/api/issues/search?componentKeys=${SONAR_KEY}&pullRequest=${PR_NUMBER}&statuses=OPEN,CONFIRMED&ps=20" || echo '{"issues":[]}') \
         | jq -r '.issues[] | "    • [\(.rule)] \(.component | sub("^[^:]+:"; ""))(:\(.line // "?")) (\(.severity)) — \(.message)"'
 fi
 

--- a/.claude/skills/cicd/scripts/wait-and-check.sh
+++ b/.claude/skills/cicd/scripts/wait-and-check.sh
@@ -1,0 +1,63 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Wait another N seconds (default 180 = 3 min) and re-check PR feedback.
+#
+# Use after `create-pr-and-wait.sh` if the first 3-minute window came back
+# empty or thin and you suspect a slow reviewer. Different from polling: this
+# script is "give it one more deliberate window," not "spam every minute."
+#
+# Usage:
+#   wait-and-check.sh <PR_NUMBER> [--wait SECS] [--repo OWNER/REPO]
+#
+# Flags:
+#   --wait SECS     How long to sleep before fetching comments. Default 180.
+#   --repo R        Override the repo (default: auto-detect from git remote).
+#
+# Exit codes:
+#   0   Wait completed and feedback fetched.
+#   2   Bad usage (missing PR number).
+#   *   Whatever the comment-fetch step returns.
+
+usage() {
+    echo "Usage: wait-and-check.sh <PR_NUMBER> [--wait SECS] [--repo OWNER/REPO]" >&2
+    exit 2
+}
+
+require_value() {
+    if [[ $# -lt 2 ]]; then
+        echo "Missing value for $1" >&2
+        usage
+    fi
+}
+
+WAIT_SECS=180
+REPO=""
+PR_NUM=""
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --wait)     require_value "$@"; WAIT_SECS="$2"; shift 2 ;;
+        --repo)     require_value "$@"; REPO="$2"; shift 2 ;;
+        -h|--help)  usage ;;
+        *) PR_NUM="$1"; shift ;;
+    esac
+done
+
+if [[ -z "$PR_NUM" ]]; then
+    usage
+fi
+
+echo "Waiting ${WAIT_SECS}s before re-checking PR #${PR_NUM}..."
+sleep "$WAIT_SECS"
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+REPO_ARG=()
+if [[ -n "$REPO" ]]; then
+    REPO_ARG=(--repo "$REPO")
+fi
+
+# pr-comments.sh is vendored next to this script — no per-user $HOME
+# fallback (would violate the skills-portability rule).
+bash "$SCRIPT_DIR/pr-comments.sh" "${REPO_ARG[@]}" "$PR_NUM"

--- a/.claude/skills/cicd/scripts/workflow.sh
+++ b/.claude/skills/cicd/scripts/workflow.sh
@@ -1,0 +1,211 @@
+#!/usr/bin/env bash
+# Steward cicd workflow entry point (renamed from pr-review in 0.7.0).
+#
+# Subcommands:
+#   lint                    run the portability lint on the current diff (staged + unstaged)
+#   open-pr [gh pr flags]   gh pr create + sleep 180s + fetch reviewer comments.
+#                           Use right after pushing the initial branch.
+#                           Override the wait with --wait <secs>.
+#   poll <PR>               fetch and display review comments
+#   poll-readiness <PR>     loop until required reviewers are ready (default:
+#                           qodo only; Copilot's bot stopped posting in 2026)
+#                           — or PR closes / cap hits. Forwards extra flags
+#                           to scripts/poll-readiness.sh (--max-iters N,
+#                           --interval SECS, --require qodo[,copilot],
+#                           --repo OWNER/REPO).
+#   wait-after-push <PR>    sleep 180s then re-fetch comments. Use after pushing fixes.
+#                           Override the wait with --wait <secs>.
+#   await <PR>              poll for reviewer readiness (default: up to 30 × 60s,
+#                           requires qodo only), then run pr-status + pr-comments.
+#                           Exits non-zero on SonarCloud ERROR or unresolved
+#                           threads. Tunables: STEWARD_PR_AWAIT_ITERS (default 30),
+#                           STEWARD_PR_AWAIT_INTERVAL (default 60),
+#                           STEWARD_PR_REVIEWERS (default "qodo").
+#                           Legacy fixed-sleep mode: set STEWARD_PR_AWAIT_SECONDS=<n>
+#                           (deprecated; emits a warning).
+#   reply <PR>              batch reply to review comments (JSONL on stdin), --resolve
+#   delta                   dump CLAUDE.md head + culture.yaml for each sibling project
+#                           listed in skills.local.yaml (alignment-delta check)
+#   help                    print this message
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SKILL_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+REPO_ROOT="$(cd "$SKILL_DIR/../../.." && pwd)"
+
+CFG="$REPO_ROOT/.claude/skills.local.yaml"
+[ -f "$CFG" ] || CFG="$REPO_ROOT/.claude/skills.local.yaml.example"
+
+# Read a top-level YAML list from CFG. Schema is intentionally tiny:
+#   <key>:
+#     - item
+#     - item
+# Stops at the next top-level key. No PyYAML dependency.
+read_list() {
+    awk -v key="$1" '
+        function trim(s) { sub(/^[[:space:]]+/, "", s); sub(/[[:space:]]+$/, "", s); return s }
+        {
+            line = $0
+            sub(/[[:space:]]+#.*$/, "", line)
+        }
+        in_list && line ~ /^[[:space:]]*-[[:space:]]*/ {
+            item = line
+            sub(/^[[:space:]]*-[[:space:]]*/, "", item)
+            item = trim(item)
+            sub(/^["\047]/, "", item); sub(/["\047]$/, "", item)
+            if (item != "") print item
+            next
+        }
+        in_list && line ~ /^[^[:space:]#]/ { exit }
+        line ~ ("^" key ":[[:space:]]*($|#)") { in_list = 1 }
+    ' "$CFG"
+}
+
+cmd="${1:-help}"
+shift || true
+
+case "$cmd" in
+    lint)
+        bash "$SCRIPT_DIR/portability-lint.sh"
+        ;;
+    open-pr)
+        bash "$SCRIPT_DIR/create-pr-and-wait.sh" "$@"
+        ;;
+    poll)
+        PR="${1:?Usage: workflow.sh poll <PR>}"
+        bash "$SCRIPT_DIR/pr-comments.sh" "$PR"
+        ;;
+    poll-readiness)
+        if [ $# -lt 1 ]; then
+            echo "Usage: workflow.sh poll-readiness <PR> [--max-iters N] [--interval SECS] [--repo OWNER/REPO]" >&2
+            exit 2
+        fi
+        bash "$SCRIPT_DIR/poll-readiness.sh" "$@"
+        ;;
+    wait-after-push)
+        # Forward all remaining args (PR number plus any --wait/--repo
+        # flags wait-and-check.sh accepts) so docs that promise
+        # `--wait <secs>` actually work.
+        if [ $# -lt 1 ]; then
+            echo "Usage: workflow.sh wait-after-push <PR> [--wait SECS] [--repo OWNER/REPO]" >&2
+            exit 2
+        fi
+        bash "$SCRIPT_DIR/wait-and-check.sh" "$@"
+        ;;
+    await)
+        PR="${1:?Usage: workflow.sh await <PR>}"
+        # Legacy fixed-sleep path — kept for back-compat. If
+        # STEWARD_PR_AWAIT_SECONDS is set we honor it but warn; the modern
+        # path is readiness-driven via poll-readiness.sh.
+        if [ -n "${STEWARD_PR_AWAIT_SECONDS:-}" ]; then
+            echo "warning: STEWARD_PR_AWAIT_SECONDS is deprecated; prefer STEWARD_PR_AWAIT_ITERS / _INTERVAL." >&2
+            echo "→ waiting ${STEWARD_PR_AWAIT_SECONDS}s (legacy fixed-sleep) …" >&2
+            sleep "$STEWARD_PR_AWAIT_SECONDS"
+        else
+            ITERS="${STEWARD_PR_AWAIT_ITERS:-30}"
+            INTERVAL="${STEWARD_PR_AWAIT_INTERVAL:-60}"
+            echo "── poll-readiness ────────────────────────────────────────────────────" >&2
+            # Don't bail if the looper TIMEOUTs — still want to dump pr-status
+            # and pr-comments so the user sees what *did* arrive.
+            set +e
+            bash "$SCRIPT_DIR/poll-readiness.sh" \
+                --max-iters "$ITERS" --interval "$INTERVAL" "$PR"
+            POLL_RC=$?
+            set -e
+            if [ "$POLL_RC" -ne 0 ]; then
+                echo "(poll-readiness exited $POLL_RC — falling through to status/comments anyway)" >&2
+            fi
+        fi
+        # pr-status.sh is the source of truth for the SonarCloud / unresolved
+        # markers we gate on, so its failure must propagate — otherwise we'd
+        # falsely claim "✓ no SonarCloud ERROR" when the check never ran.
+        # Use the if-form so `set -e` doesn't abort before we report the rc.
+        echo "── pr-status ─────────────────────────────────────────────────────────" >&2
+        if STATUS_OUT=$(bash "$SCRIPT_DIR/pr-status.sh" "$PR" 2>&1); then
+            STATUS_RC=0
+        else
+            STATUS_RC=$?
+        fi
+        printf '%s\n' "$STATUS_OUT"
+        if [ "$STATUS_RC" -ne 0 ]; then
+            echo >&2
+            echo "✗ pr-status.sh failed (exit $STATUS_RC) — cannot determine PR state" >&2
+            exit "$STATUS_RC"
+        fi
+        # pr-comments.sh is the user-visible thread dump — its failure is also
+        # a hard fail so reviewers don't go untriaged.
+        echo "── pr-comments ───────────────────────────────────────────────────────" >&2
+        if bash "$SCRIPT_DIR/pr-comments.sh" "$PR"; then
+            COMMENTS_RC=0
+        else
+            COMMENTS_RC=$?
+        fi
+        if [ "$COMMENTS_RC" -ne 0 ]; then
+            echo >&2
+            echo "✗ pr-comments.sh failed (exit $COMMENTS_RC) — review threads not fetched" >&2
+            exit "$COMMENTS_RC"
+        fi
+        # Decide pass/fail from the captured pr-status.sh output. Markers:
+        #   • "SonarCloud ❌ Quality Gate ERROR" → SonarCloud failed
+        #   • "Unresolved: N" with N>0 → unresolved review threads
+        SONAR_FAIL=0
+        UNRESOLVED=0
+        if printf '%s\n' "$STATUS_OUT" | grep -qE 'SonarCloud[[:space:]]+❌[[:space:]]+Quality Gate ERROR'; then
+            SONAR_FAIL=1
+        fi
+        if PENDING=$(printf '%s\n' "$STATUS_OUT" | grep -oE 'Unresolved:[[:space:]]+[0-9]+' | grep -oE '[0-9]+$' | head -1); then
+            [ -n "${PENDING:-}" ] && [ "$PENDING" -gt 0 ] && UNRESOLVED=1
+        fi
+        if [ "$SONAR_FAIL" -eq 1 ] || [ "$UNRESOLVED" -eq 1 ]; then
+            echo >&2
+            [ "$SONAR_FAIL" -eq 1 ] && echo "✗ SonarCloud quality gate ERROR" >&2
+            [ "$UNRESOLVED" -eq 1 ] && echo "✗ ${PENDING} unresolved review thread(s)" >&2
+            exit 1
+        fi
+        echo >&2
+        echo "✓ no SonarCloud ERROR, no unresolved threads" >&2
+        ;;
+    reply)
+        PR="${1:?Usage: workflow.sh reply <PR>  (JSONL on stdin)}"
+        bash "$SCRIPT_DIR/pr-batch.sh" --resolve "$PR"
+        ;;
+    delta)
+        any=0
+        while IFS= read -r sibling; do
+            [ -z "$sibling" ] && continue
+            any=1
+            sibling_abs="$REPO_ROOT/$sibling"
+            if [ ! -d "$sibling_abs" ] && [ ! -d "$sibling" ]; then
+                echo "=== $sibling ==="
+                echo "(not present on disk — skipped)"
+                continue
+            fi
+            target="$sibling_abs"
+            [ -d "$target" ] || target="$sibling"
+            echo "=== $target ==="
+            if [ -f "$target/CLAUDE.md" ]; then
+                head -40 "$target/CLAUDE.md"
+                echo "..."
+            else
+                echo "(no CLAUDE.md)"
+            fi
+            echo "--- culture.yaml ---"
+            if [ -f "$target/culture.yaml" ]; then
+                cat "$target/culture.yaml"
+            else
+                echo "(no culture.yaml)"
+            fi
+            echo
+        done < <(read_list sibling_projects)
+        [ "$any" -eq 0 ] && echo "(no sibling_projects configured in $CFG)"
+        ;;
+    help|--help|-h)
+        sed -n '2,29p' "${BASH_SOURCE[0]}" | sed 's/^# *//'
+        ;;
+    *)
+        echo "unknown subcommand: $cmd" >&2
+        echo "run '$(basename "$0") help' for usage." >&2
+        exit 2
+        ;;
+esac

--- a/.claude/skills/communicate/SKILL.md
+++ b/.claude/skills/communicate/SKILL.md
@@ -1,0 +1,168 @@
+---
+name: communicate
+description: >
+  Cross-repo + mesh communication from irc-lens: file tracked GitHub issues
+  on sibling repos, and send live messages to Culture mesh channels. Use
+  when the next step lives outside irc-lens (a brief for a sibling-repo
+  agent, a status ping for a Culture channel). Issue posts auto-sign with
+  `- irc-lens (Claude)`; mesh messages are unsigned (the IRC nick is the
+  speaker). Not for in-repo issues — use `gh issue create` or the `cicd`
+  skill for those. Vendored from steward's `communicate` skill.
+---
+
+# Communicate (Cross-Repo + Mesh)
+
+irc-lens lives inside the AgentCulture mesh. When a fix or follow-up
+belongs in a sibling repo, that hand-off goes through one of two channels:
+
+- **Tracked, async hand-offs** — a gap in another repo (a missing public
+  API, a divergent skill, a documentation ask) where an agent on the
+  other side needs to act, and the ask should outlive the conversation.
+  → `post-issue.sh` (GitHub).
+- **Ephemeral coordination** — a status ping, a question, a "PR ready
+  for merge" notice on a Culture mesh channel where the audience is
+  already listening.
+  → `mesh-message.sh` (Culture IRC).
+
+Both channels live under one skill because they share the same audience
+(sibling-repo agents) and the same red flag (don't double-post the same
+ask across both — pick one).
+
+## When to Use
+
+### Issue mode (`post-issue.sh`)
+
+- A gap surfaces in **another repo's surface** (missing public API,
+  wire-format compat fix, divergent skill, documentation ask).
+- You're handing off a self-contained brief to a sibling-repo agent.
+- You're asking a question that benefits from a tracked artifact rather
+  than ephemeral chat.
+
+### Mesh mode (`mesh-message.sh`)
+
+- You want to ping a Culture channel with a status update ("PR #N ready
+  for merge", "starting nightly corpus scan").
+- You're asking a question where you expect a fast reply from whoever
+  is listening on the channel right now.
+- You're announcing a decision that doesn't need a tracked artifact.
+
+## When NOT to Use
+
+- **In-repo issues on irc-lens itself** — open them with `gh issue create`
+  directly, or work them through the `cicd` skill.
+- **PR review comments** — that's the `cicd` skill (which already
+  auto-signs replies).
+- **Routine commits** — those don't get cross-repo signatures.
+- **Long-form asks on the mesh** — anything that needs acceptance
+  criteria belongs in an issue, not a channel message.
+
+## Conventions
+
+### 1. Briefs are self-contained
+
+The receiving agent must not need irc-lens-side context to act. Inline
+the relevant content; do not say "see irc-lens's plan."
+
+A brief that says "see irc-lens#NN" is a bug. The receiving agent will
+look at it, get lost in irc-lens-specific context that's irrelevant to
+them, and either ask for clarification (slow round-trip) or guess wrong
+(worse). Inline the ask, the rationale, and concrete acceptance
+criteria. Quote source-of-truth files (path + line numbers + small
+excerpts) when their shape matters to the ask.
+
+### 2. Per-channel signature rules
+
+| Channel | Signature | Why |
+|---------|-----------|-----|
+| GitHub issues | `- irc-lens (Claude)` (auto-appended by `post-issue.sh`) | Cross-repo audit trail — readers can tell at a glance which sibling and that it came from an AI. |
+| Culture mesh | none — unsigned | The IRC nick already identifies the speaker. A trailing `- irc-lens (Claude)` would be visual noise that the nick already supplies. |
+
+Each vendor of this skill hard-codes its own issue-signature literal —
+`communicate` deliberately does not depend on the `cicd` skill's
+`_resolve-nick.sh`, so it stays self-contained per the
+skills-portability rule. Mesh messages stay unsigned across all vendors.
+
+### 3. Issue title format
+
+`<verb> <thing> (unblocks <consumer>)` — e.g.,
+`Vendor portability-lint into <repo> (unblocks irc-lens AFI rubric pass)`.
+The parenthetical tells the receiving repo's maintainers what's waiting
+on them. Drop the parenthetical only when the ask isn't blocking
+anything.
+
+## How to Invoke
+
+### File a new issue
+
+```bash
+bash .claude/skills/communicate/scripts/post-issue.sh \
+    --repo agentculture/<sibling> \
+    --title "Vendor portability-lint into <sibling> (unblocks irc-lens)" \
+    --body-file /tmp/brief.md
+```
+
+Or pass the body on stdin:
+
+```bash
+bash .claude/skills/communicate/scripts/post-issue.sh \
+    --repo agentculture/<sibling> \
+    --title "..." <<'EOF'
+<brief body here, multi-paragraph, with all the inline context the receiving agent needs>
+EOF
+```
+
+The script prints the issue URL on success — capture it for
+cross-references in your spec / plan / PR description. The signature
+`- irc-lens (Claude)` is auto-appended at the end of the body.
+
+### Send a mesh channel message
+
+```bash
+bash .claude/skills/communicate/scripts/mesh-message.sh \
+    --channel "#general" \
+    --body "PR #42 — all review threads addressed. Ready for merge."
+```
+
+Body can also come from `--body-file PATH` or stdin. The script wraps
+`culture channel message <target> <text>` and forwards exit codes
+unchanged, so failures (no Culture server, agent not connected) surface
+verbatim. No signature is appended — the IRC nick is the speaker.
+
+irc-lens is **not** a registered mesh agent today. The script works
+once irc-lens has been registered and started via `culture agent
+register` + `culture start <suffix>`; until then, calling it will fail
+with whatever error the Culture CLI returns, which is the right
+behavior — fix the registration, don't paper over it.
+
+## Scripts
+
+| Script | Purpose |
+|--------|---------|
+| `scripts/post-issue.sh` | Create a new issue on a target repo. Auto-signs `- irc-lens (Claude)`. |
+| `scripts/mesh-message.sh` | Send a message to a Culture mesh channel. Unsigned (IRC nick is the speaker). |
+
+More scripts can land here as the communication footprint grows —
+`post-comment.sh` for issue follow-ups, `mesh-ask.sh` for
+question-shaped pings via `culture channel ask`, etc. Add them when
+there's a second concrete need; do not pre-build for hypotheticals.
+
+## Red Flags
+
+**Never:**
+
+- Post a brief that says "see irc-lens's plan" without inlining the
+  content. Briefs must be self-contained.
+- Skip the issue signature. The script enforces it; do not introduce a
+  `--no-signature` flag.
+- Sign mesh messages with `- irc-lens (Claude)`. The nick already says
+  who you are.
+- Use this skill for in-repo issues on irc-lens itself — use
+  `gh issue create` or the `cicd` skill instead.
+- Manually type `- irc-lens (Claude)` at the end of an issue body — the
+  script appends it. Manual typing creates double-signatures when the
+  script is later refactored.
+- Post the same ask twice across channels (issue + mesh). Pick one.
+  Tracked → issue. Ephemeral → mesh.
+- Use mesh mode for anything that needs acceptance criteria. If the
+  receiving agent has to decide "did I do this right?", you owe them
+  an issue.

--- a/.claude/skills/communicate/scripts/mesh-message.sh
+++ b/.claude/skills/communicate/scripts/mesh-message.sh
@@ -1,0 +1,74 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Send a message to a Culture mesh channel.
+# Thin wrapper around `culture channel message <target> <text>`.
+# No signature is appended — the IRC nick is the speaker.
+#
+# Usage:
+#   mesh-message.sh --channel '#general' --body "Hello"
+#   mesh-message.sh --channel '#general' --body-file PATH
+#   mesh-message.sh --channel '#general'  < body-on-stdin
+
+usage() {
+    echo "Usage: mesh-message.sh --channel '#NAME' [--body TEXT | --body-file PATH | < stdin]" >&2
+    exit 2
+}
+
+if ! command -v culture >/dev/null 2>&1; then
+    echo "mesh-message: 'culture' CLI not found on PATH" >&2
+    echo "  Install agentculture/culture and ensure 'culture --version' works." >&2
+    exit 127
+fi
+
+CHANNEL=""
+BODY=""
+BODY_FILE=""
+
+require_value() {
+    if [[ $# -lt 2 ]]; then
+        echo "Missing value for $1" >&2
+        usage
+    fi
+}
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --channel)    require_value "$@"; CHANNEL="$2"; shift 2 ;;
+        --body)       require_value "$@"; BODY="$2"; shift 2 ;;
+        --body-file)  require_value "$@"; BODY_FILE="$2"; shift 2 ;;
+        -h|--help)    usage ;;
+        *) echo "Unknown flag: $1" >&2; usage ;;
+    esac
+done
+
+if [[ -z "$CHANNEL" ]]; then
+    echo "Missing --channel" >&2
+    usage
+fi
+
+if [[ -n "$BODY" && -n "$BODY_FILE" ]]; then
+    echo "Pass at most one of --body / --body-file (stdin is the third option)" >&2
+    usage
+fi
+
+if [[ -z "$BODY" ]]; then
+    if [[ -n "$BODY_FILE" ]]; then
+        BODY="$(cat "$BODY_FILE")"
+    elif [[ ! -t 0 ]]; then
+        BODY="$(cat)"
+    else
+        echo "No --body / --body-file given and stdin is a TTY — refusing to hang on cat." >&2
+        echo "Pass --body 'text', --body-file PATH, or pipe the body in." >&2
+        exit 2
+    fi
+fi
+
+if [[ -z "$BODY" ]]; then
+    echo "Empty message body" >&2
+    exit 2
+fi
+
+# Forward exit code from culture; if the agent isn't running or the
+# server is unreachable, the operator should see that error verbatim.
+exec culture channel message "$CHANNEL" "$BODY"

--- a/.claude/skills/communicate/scripts/post-issue.sh
+++ b/.claude/skills/communicate/scripts/post-issue.sh
@@ -1,0 +1,61 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Post a cross-repo issue with auto-signature `- irc-lens (Claude)`.
+#
+# Usage:
+#   post-issue.sh --repo OWNER/REPO --title "Title" --body-file PATH
+#   post-issue.sh --repo OWNER/REPO --title "Title"  < body-on-stdin
+
+usage() {
+    echo "Usage: post-issue.sh --repo OWNER/REPO --title TITLE [--body-file PATH | < stdin]" >&2
+    exit 2
+}
+
+# `gh issue create --body "$LONG_STRING"` can hit the OS argv length limit
+# (typically ~128 KB) for the long self-contained briefs this skill is meant
+# to post. Stage the body to a tempfile and pass `--body-file` instead.
+TMP_BODY=$(mktemp -t coordinate-post-issue-body.XXXXXX)
+trap 'rm -f "$TMP_BODY"' EXIT
+
+REPO=""
+TITLE=""
+BODY_FILE=""
+
+# Require a value to follow each flag (otherwise `--repo` with no argument
+# would crash on `$2` under `set -u` instead of printing usage).
+require_value() {
+    if [[ $# -lt 2 ]]; then
+        echo "Missing value for $1" >&2
+        usage
+    fi
+}
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --repo)       require_value "$@"; REPO="$2"; shift 2 ;;
+        --title)      require_value "$@"; TITLE="$2"; shift 2 ;;
+        --body-file)  require_value "$@"; BODY_FILE="$2"; shift 2 ;;
+        -h|--help)    usage ;;
+        *) echo "Unknown flag: $1" >&2; usage ;;
+    esac
+done
+
+if [[ -z "$REPO" || -z "$TITLE" ]]; then
+    usage
+fi
+
+if [[ -n "$BODY_FILE" ]]; then
+    cat "$BODY_FILE" > "$TMP_BODY"
+elif [[ ! -t 0 ]]; then
+    cat > "$TMP_BODY"
+else
+    echo "No --body-file given and stdin is a TTY — refusing to hang on cat." >&2
+    echo "Pass --body-file PATH or pipe the body in." >&2
+    exit 2
+fi
+
+# Append the signature.
+printf '\n\n- irc-lens (Claude)\n' >> "$TMP_BODY"
+
+gh issue create --repo "$REPO" --title "$TITLE" --body-file "$TMP_BODY"

--- a/.gitignore
+++ b/.gitignore
@@ -220,9 +220,14 @@ __marimo__/
 # Cited references from afi cli cite (regenerate locally; never committed)
 .afi/
 
-# Per-user Claude Code config (settings, scheduled tasks, project-local
-# skills, etc. — none of these belong in the repo).
-.claude/
+# Per-user Claude Code state (settings, scheduled tasks, per-machine
+# overrides). Tracked skills under `.claude/skills/<name>/` are committed
+# so the team shares the workflow surface; this matches steward's pattern.
+.claude/settings.local.json
+.claude/scheduled_tasks.lock
+.claude/skills.local.yaml
+.claude/skills/*/local.yaml
+.claude/skills/*/scripts/*.local.sh
 
 # CF round-trip service-token secret (written by scripts/cf-roundtrip/setup.sh)
 .cf-roundtrip.env

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,3 +35,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - `.claude/skills/pr-review/` — superseded by `.claude/skills/cicd/`
   (steward 0.7.0 rename).
+
+### Fixed
+
+- `cicd/scripts/pr-batch.sh` — guarded `jq -r` parses with
+  `2>/dev/null || echo "null"` so a malformed JSONL line yields the
+  sentinel that the existing null-check catches and skips, instead of
+  aborting the entire batch under `set -e`. (Divergence from upstream
+  steward; will reconcile when steward picks up the same patch.)
+- `cicd/scripts/pr-status.sh` — wrapped each `curl -s` call in command
+  substitution with `|| echo '{}'` so transient SonarCloud / network
+  failures yield empty JSON instead of empty stdout, preventing
+  `workflow.sh await` from crashing on a flaky API call. (Divergence
+  from upstream steward; will reconcile.)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,37 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [0.5.1] - 2026-05-08
+
+### Added
+
+- `.claude/skills/cicd/` — CI/CD workflow skill vendored from
+  `agentculture/steward` (replaces `pr-review`). Adds `workflow.sh`
+  entry point with portability lint, reviewer-readiness polling, batch
+  reply, alignment-delta check, and SonarCloud quality-gate
+  integration. Includes an `irc-lens notes` section preserving
+  AFI-rubric guardrails (recurring bug classes, PUSHBACK rules for
+  `.afi/reference/` and stable-contract files).
+- `.claude/skills/communicate/` — cross-repo + Culture-mesh
+  communication skill vendored from `agentculture/steward`. Files
+  GitHub issues on sibling repos with auto-signature
+  `- irc-lens (Claude)` and sends Culture mesh channel messages.
+
+### Changed
+
+- `.gitignore` narrowed from `.claude/` (entire directory) to steward's
+  selective pattern: per-user state (`settings.local.json`,
+  `scheduled_tasks.lock`, `skills.local.yaml`, `*/local.yaml`,
+  `*/scripts/*.local.sh`) stays ignored; tracked skills become
+  visible. Closes #30.
+
+### Removed
+
+- `.claude/skills/pr-review/` — superseded by `.claude/skills/cicd/`
+  (steward 0.7.0 rename).

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "irc-lens"
-version = "0.5.0"
+version = "0.5.1"
 description = "Reactive web console for AgentIRC — Playwright-driveable lens for the Culture mesh."
 readme = "README.md"
 requires-python = ">=3.11"


### PR DESCRIPTION
Closes #30.

Vendors steward's canonical `cicd` (replaces `pr-review`) and `communicate` skills, adapted to irc-lens voice and signature conventions.

## Acceptance criteria from #30

- [x] `.claude/skills/cicd/` exists with `SKILL.md` + `scripts/` (entry point: `workflow.sh`).
- [x] `.claude/skills/pr-review/` removed.
- [x] `.claude/skills/communicate/` exists with `SKILL.md`, `scripts/post-issue.sh`, and `scripts/mesh-message.sh`.
- [x] `scripts/post-issue.sh` hardcodes `- irc-lens (Claude)` (lines 4 and 59).
- [x] No `/home/<user>/` paths or per-user dotfile references in committed skill files (`portability-lint.sh` clean — 17 files checked).
- [x] Version bumped 0.5.0 → 0.5.1 in `pyproject.toml`; `CHANGELOG.md` bootstrapped per Keep-a-Changelog.

## Notes

- `cicd/SKILL.md` includes an `irc-lens notes` trailing section preserving the AFI-rubric guardrails that lived in the old `pr-review` skill (recurring bug classes, PUSHBACK rules for `.afi/reference/` and stable-contract CLI files).
- Scripts vendored verbatim from steward — historical `STEWARD_PR_*` env-var names retained for clean upstream tracking. Some script internals (e.g. `workflow.sh help` header, `mktemp` template `coordinate-post-issue-body.XXXXXX`) still mention steward; this is intentional vendoring drift, not a defect.
- `.gitignore` narrowed from `.claude/` to steward's selective pattern. Per-user state (`settings.local.json`, `scheduled_tasks.lock`, `*.local.yaml`, `*/scripts/*.local.sh`) stays ignored.
- The `(Optional)` ask in #30 to add `docs/skill-sources.md` is deferred — irc-lens does not yet have a skills-vendoring overview doc, and that work warrants its own PR if it lands.

## Verification (local on `skill/cicd-and-communicate`)

- `bash .claude/skills/cicd/scripts/workflow.sh help` → exit 0, full subcommand listing.
- `bash .claude/skills/cicd/scripts/portability-lint.sh` → `✓ portability lint clean (17 files checked)`.
- `bash .claude/skills/cicd/scripts/_resolve-nick.sh` → prints `irc-lens` (basename fallback; irc-lens has no `culture.yaml`).
- `grep 'irc-lens (Claude)' .claude/skills/communicate/scripts/post-issue.sh` matches lines 4 and 59. `grep steward` on the same file is empty.
- `python3 -c "import tomllib; tomllib.load(open('pyproject.toml','rb'))"` succeeds; version reads `0.5.1`.

## Wait for review

Per the new `cicd` skill: after pushing, `bash .claude/skills/cicd/scripts/workflow.sh await <PR>` polls for Qodo readiness, fetches CI + SonarCloud + all comments, then triages FIX/PUSHBACK per the rubric. Wait for a human merge.

- Claude