### PR TITLE
feat(mesh): live agent-mesh graph view in the web console

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.6.0] - 2026-05-30
+
+### Added
+
+- Live agent-mesh graph view in the web console (`/mesh`). A vanilla-JS
+  port of katvan's MeshIsland Canvas renderer (`static/mesh.js`) draws
+  joined channels as rooms and their members as agent/human nodes, with
+  membership edges and travelling message particles. It is fed live over
+  a new `mesh` SSE event: `Session.build_mesh_snapshot()` emits katvan's
+  mesh.json contract (`{nodes:[{id,label,kind,server}],
+  edges:[{source,target}]}`), refreshed on JOIN/PART (coalesced into a
+  single-flight rebuild) and on a per-session timer. The per-nick WHO
+  `server` field maps onto MeshIsland's federated server bands. Selecting
+  a channel returns from the mesh view to chat. The agent-vs-human
+  classification is a documented v1 heuristic pending a canonical rule
+  from katvan (tracked cross-repo).
+
 ## [0.5.1] - 2026-05-08
 
 ### Added

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "irc-lens"
-version = "0.5.3"
+version = "0.6.0"
 description = "Reactive web console for AgentIRC — Playwright-driveable lens for the Culture mesh."
 readme = "README.md"
 requires-python = ">=3.11"

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -29,3 +29,11 @@ sonar.test.exclusions=tests/fixtures/**,tests/_agentirc_server.py
 # `pytest --cov-report=xml:coverage.xml` which writes coverage.xml in
 # the workspace root.
 sonar.python.coverage.reportPaths=coverage.xml
+
+# Browser assets (JS/CSS under static/) are outside the Python coverage
+# regime: coverage.xml only carries pytest-cov data, so these files would
+# otherwise count as 0%-covered "new code" and sink the new-code coverage
+# gate. Their behaviour is verified by the Playwright suite (which doesn't
+# emit an lcov report to ingest here), not by unit coverage. They are still
+# analysed for issues — this excludes them from coverage measurement only.
+sonar.coverage.exclusions=src/irc_lens/static/**

--- a/src/irc_lens/commands.py
+++ b/src/irc_lens/commands.py
@@ -36,9 +36,11 @@ class CommandType(Enum):
     QUIT = auto()
     HELP = auto()
     # irc-lens additions: SWITCH is a pure view-state verb (no IRC
-    # side-effect) used by the clickable sidebar; ME is CTCP ACTION.
+    # side-effect) used by the clickable sidebar; ME is CTCP ACTION;
+    # MESH switches to the live agent-mesh graph view.
     SWITCH = auto()
     ME = auto()
+    MESH = auto()
     UNKNOWN = auto()
 
 
@@ -76,6 +78,7 @@ _COMMANDS: dict[str, CommandType] = {
     "quit": CommandType.QUIT,
     "help": CommandType.HELP,
     "switch": CommandType.SWITCH,
+    "mesh": CommandType.MESH,
 }
 
 

--- a/src/irc_lens/session.py
+++ b/src/irc_lens/session.py
@@ -35,15 +35,23 @@ logger = logging.getLogger(__name__)
 # Mirrors ``culture/console/client.py``'s constants.
 QUERY_TIMEOUT = 10.0
 REGISTER_TIMEOUT = 15.0
+#: How often the per-session background task refreshes the live mesh
+#: graph. Topology changes (JOIN/PART) trigger an immediate refresh; this
+#: interval catches membership churn that arrives without an observed
+#: JOIN/PART and keeps a freshly-loaded mesh view current.
+MESH_REFRESH_INTERVAL = 10.0
 
-#: The four named views the spec's ``info`` event can switch between.
-ViewName = Literal["chat", "help", "overview", "status"]
+#: The named views the spec's ``info`` event can switch between. ``mesh``
+#: is the irc-lens live agent-mesh graph view — a vanilla-JS port of
+#: katvan's MeshIsland renderer (see ``static/mesh.js``).
+ViewName = Literal["chat", "help", "overview", "status", "mesh"]
 
 #: SSE event names defined in the spec's "SSE event types" section.
 #: ``log`` is a full chat-log replacement (innerHTML swap of ``#chat-log``)
 #: emitted on /join and /switch so server-side history surfaces in the UI;
-#: ``chat`` continues to append single live lines.
-EventName = Literal["chat", "log", "roster", "info", "view", "error"]
+#: ``chat`` continues to append single live lines. ``mesh`` carries the
+#: live agent-mesh graph snapshot (katvan's mesh.json shape) as JSON.
+EventName = Literal["chat", "log", "roster", "info", "view", "error", "mesh"]
 
 
 class LensConnectionLost(ConnectionError):
@@ -305,6 +313,15 @@ class Session:
         # Event bus: Phase 5 will wire publishes; Phase 3 just holds it.
         self.event_bus = event_bus if event_bus is not None else SessionEventBus()
 
+        # Live mesh-graph refresh state. `_mesh_refresher` is the
+        # per-session periodic task (started in connect, cancelled in
+        # disconnect); `_mesh_task` is the coalescing drain task that
+        # builds one snapshot at a time; `_mesh_dirty` collapses a burst
+        # of topology changes into a single rebuild.
+        self._mesh_refresher: asyncio.Task[None] | None = None
+        self._mesh_task: asyncio.Task[None] | None = None
+        self._mesh_dirty = False
+
         # Tracks transport health independent of `IRCTransport.connected`,
         # which only flips after the welcome (001) handshake. The lens
         # cares about "did we ever lose the pipe?" because Phase 5
@@ -351,6 +368,8 @@ class Session:
         self._transport.add_listener("PRIVMSG", self.dispatch)
         self._transport.add_listener("JOIN", self.dispatch)
         self._transport.add_listener("PART", self.dispatch)
+        # Per-session live-mesh refresher; cancelled in disconnect().
+        self._mesh_refresher = asyncio.create_task(self._mesh_refresh_loop())
 
     def _on_welcome_signal(self, _msg: Message) -> None:
         # Runs after IRCTransport's own 001 handler (which set
@@ -392,7 +411,27 @@ class Session:
             raise LensConnectionLost(f"nick rejected: {self._nick_rejection}")
 
     async def disconnect(self) -> None:
+        await self._cancel_mesh_tasks()
         await self._transport.disconnect()
+
+    async def _cancel_mesh_tasks(self) -> None:
+        """Cancel + drain the mesh refresher and any in-flight drain task.
+
+        Called from ``disconnect()`` (which ``disconnect_all`` invokes on
+        app cleanup). Awaiting the cancelled tasks avoids "Task was
+        destroyed but it is pending" warnings at loop shutdown.
+        """
+        tasks = [
+            t
+            for t in (self._mesh_refresher, self._mesh_task)
+            if t is not None and not t.done()
+        ]
+        self._mesh_refresher = None
+        self._mesh_task = None
+        for task in tasks:
+            task.cancel()
+        if tasks:
+            await asyncio.gather(*tasks, return_exceptions=True)
 
     @property
     def healthy(self) -> bool:
@@ -537,6 +576,7 @@ class Session:
             CommandType.WHO: self._exec_who,
             CommandType.AGENTS: self._exec_agents,
             CommandType.ME: self._exec_me,
+            CommandType.MESH: self._exec_mesh,
             CommandType.TOPIC: self._exec_topic,
             CommandType.ICON: self._exec_icon,
             CommandType.UNKNOWN: self._exec_unknown,
@@ -604,6 +644,14 @@ class Session:
             return
         # Switch is a pure view-state mutation — no IRC side-effect.
         self.set_current_channel(channel)
+        # Selecting a channel means "show me this channel", so return to
+        # the chat view if we were in a non-chat view (the mesh graph or a
+        # help/overview/status pane). Only emit a `view` event on an actual
+        # change so switches already in chat stay event-quiet. This is also
+        # how the user leaves the mesh view by clicking the sidebar.
+        if self.view != "chat":
+            self.set_view("chat")
+            self._publish_view()
         self._publish_roster()
         self._publish_info()
         await self._fetch_and_publish_history(channel)
@@ -821,6 +869,17 @@ class Session:
     async def _exec_status(self, _parsed: ParsedCommand) -> None:
         self._switch_view("status")
 
+    async def _exec_mesh(self, _parsed: ParsedCommand) -> None:
+        # Switch to the live agent-mesh graph view, then publish a fresh
+        # snapshot so the canvas paints immediately rather than waiting
+        # for the next refresher tick. `_switch_view` emits the `view`
+        # (+ `info`) events that toggle <body data-view> and swap the
+        # info pane to the mesh legend. The recompute does its own WHO
+        # round-trips; per-channel failures degrade gracefully inside
+        # `build_mesh_snapshot`, so /mesh never 503s the browser.
+        self._switch_view("mesh")
+        await self._recompute_and_publish_mesh()
+
     def _switch_view(self, name: ViewName) -> None:
         """Common body for the three view-switch verbs.
 
@@ -867,6 +926,10 @@ class Session:
             # join/part call (or — for other users — needs no local
             # mutation in v1); re-render the sidebar regardless.
             self._publish_roster()
+            # Topology changed — refresh the live mesh graph. Coalesced
+            # because `dispatch` is a sync read-loop handler that cannot
+            # await the WHO round-trips the snapshot needs.
+            self._request_mesh_refresh()
 
     def _dispatch_privmsg(self, msg: Message) -> None:
         """Handle inbound PRIVMSG: filter, decode CTCP ACTION, publish."""
@@ -987,6 +1050,138 @@ class Session:
     def _publish_error(self, message: str) -> None:
         payload = json.dumps({"message": message})
         self.event_bus.publish(SessionEvent(name="error", data=payload))
+
+    # ------------------------------------------------------------------
+    # Live mesh graph (katvan MeshIsland renderer, ported to static/mesh.js)
+    # ------------------------------------------------------------------
+    # Topology lives across three callers: `_exec_mesh` (the /mesh verb),
+    # `dispatch` (JOIN/PART), and the periodic `_mesh_refresh_loop`. The
+    # first awaits a build directly; the latter two are sync / can't block
+    # the read loop, so they funnel through the coalescing single-flight
+    # `_request_mesh_refresh`.
+
+    async def build_mesh_snapshot(self) -> dict:
+        """Assemble the live mesh graph from joined channels + members.
+
+        Shape matches katvan's ``mesh.json`` (the MeshIsland renderer):
+        ``{nodes: [{id, label, kind, server}], edges: [{source, target}]}``.
+        Joined channels are ``room`` nodes; each unique nick seen via
+        ``who()`` is an ``agent``/``human`` node (see ``_classify_kind``);
+        every (channel, nick) membership is an edge. The per-nick WHO
+        ``server`` field maps onto MeshIsland's federated server bands;
+        channel nodes carry the lens host as their band.
+
+        Per-channel WHO failures (including a broken pipe) are swallowed
+        and that channel is skipped — a visualization should degrade to
+        "what we could gather" rather than fail the whole snapshot. The
+        send path already flips ``_healthy`` on a broken pipe, so health
+        is tracked regardless of what we swallow here.
+        """
+        nodes: list[dict] = []
+        edges: list[dict] = []
+        seen_nicks: set[str] = set()
+        for channel in sorted(self.joined_channels):
+            nodes.append(
+                {"id": channel, "label": channel, "kind": "room", "server": self.host}
+            )
+            try:
+                members = await self.who(channel)
+            except Exception:  # noqa: BLE001 — degrade per-channel, never fail the graph
+                logger.exception("WHO %s failed during mesh snapshot", channel)
+                continue
+            for entry in members:
+                nick = entry.get("nick", "")
+                if not nick:
+                    continue
+                if nick not in seen_nicks:
+                    seen_nicks.add(nick)
+                    nodes.append(
+                        {
+                            "id": nick,
+                            "label": nick,
+                            "kind": self._classify_kind(entry),
+                            "server": entry.get("server") or self.host,
+                        }
+                    )
+                edges.append({"source": channel, "target": nick})
+        return {"nodes": nodes, "edges": edges}
+
+    def _classify_kind(self, entry: dict) -> str:
+        """Best-effort ``agent``/``human`` classification for a WHO entry.
+
+        irc-lens has no authoritative agent/human signal yet — the roster
+        is unused and ``/agents`` just lists nicks — so this is a
+        deliberate v1 heuristic: the lens's own nick is the operator's
+        ``human`` presence, and everyone else on an agent mesh defaults to
+        ``agent``. The canonical rule (likely keyed on WHO ``flags`` /
+        ``realname`` or an AgentIRC capability) is being settled with
+        katvan, the mesh renderer's source of truth. ``room`` is assigned
+        by the snapshot builder, so this only returns ``agent``/``human``.
+        """
+        nick = entry.get("nick", "")
+        if nick and nick == self.nick:
+            return "human"
+        return "agent"
+
+    def _publish_mesh(self, snapshot: dict) -> None:
+        self.event_bus.publish(
+            SessionEvent(name="mesh", data=json.dumps(snapshot))
+        )
+
+    async def _recompute_and_publish_mesh(self) -> None:
+        """Build the current snapshot and publish it as a ``mesh`` event.
+
+        Publishes an empty graph when there's nothing to show (not yet
+        connected, or no channels joined) so the canvas clears rather than
+        holding a stale graph.
+        """
+        if not self.connected or not self.joined_channels:
+            self._publish_mesh({"nodes": [], "edges": []})
+            return
+        self._publish_mesh(await self.build_mesh_snapshot())
+
+    def _request_mesh_refresh(self) -> None:
+        """Schedule a mesh recompute, coalescing bursts into one rebuild.
+
+        Sync-safe (callable from IRC handlers): sets a dirty flag and
+        ensures exactly one drain task runs. A burst of JOIN/PART collapses
+        into a single snapshot — and if more changes land mid-build the
+        drain loop runs once more — instead of spawning a WHO storm per
+        event. Requires a running loop (always true at the call sites:
+        the read loop, the refresher task, and the SSE handler).
+        """
+        self._mesh_dirty = True
+        if self._mesh_task is None or self._mesh_task.done():
+            self._mesh_task = asyncio.create_task(self._drain_mesh_refresh())
+
+    def request_mesh_refresh(self) -> None:
+        """Public entry for an out-of-band refresh (e.g. a new SSE
+        subscriber connecting). Safe to call unconditionally — when there
+        is nothing to show the builder publishes an empty graph."""
+        self._request_mesh_refresh()
+
+    async def _drain_mesh_refresh(self) -> None:
+        while self._mesh_dirty:
+            self._mesh_dirty = False
+            try:
+                await self._recompute_and_publish_mesh()
+            except Exception:  # noqa: BLE001 — a failed refresh must not kill the task
+                logger.exception("mesh refresh failed")
+
+    async def _mesh_refresh_loop(self) -> None:
+        """Per-session background task: periodically refresh the live mesh.
+
+        Idle-cheap — only triggers a rebuild when someone is watching
+        (``subscriber_count``), we're connected, and there are channels to
+        show. JOIN/PART already drive immediate refreshes via ``dispatch``;
+        this loop catches membership churn that arrives without a JOIN/PART
+        we observe and keeps a freshly-loaded mesh view current. Cancelled
+        in ``disconnect`` via ``_cancel_mesh_tasks``.
+        """
+        while True:
+            await asyncio.sleep(MESH_REFRESH_INTERVAL)
+            if self.connected and self.joined_channels and self.event_bus.subscriber_count:
+                self._request_mesh_refresh()
 
     # ------------------------------------------------------------------
     # Future-based query methods

--- a/src/irc_lens/session.py
+++ b/src/irc_lens/session.py
@@ -926,10 +926,15 @@ class Session:
             # join/part call (or — for other users — needs no local
             # mutation in v1); re-render the sidebar regardless.
             self._publish_roster()
-            # Topology changed — refresh the live mesh graph. Coalesced
+            # Topology changed — refresh the live mesh graph, but only when
+            # it's actually being viewed. The browser keeps an SSE stream
+            # open in every view, so refreshing on every JOIN/PART would fire
+            # WHO sweeps during normal chat (issue: qodo PR #46). Switching
+            # to /mesh recomputes immediately via `_exec_mesh`. Coalesced
             # because `dispatch` is a sync read-loop handler that cannot
             # await the WHO round-trips the snapshot needs.
-            self._request_mesh_refresh()
+            if self._mesh_active():
+                self._request_mesh_refresh()
 
     def _dispatch_privmsg(self, msg: Message) -> None:
         """Handle inbound PRIVMSG: filter, decode CTCP ACTION, publish."""
@@ -1142,6 +1147,19 @@ class Session:
             return
         self._publish_mesh(await self.build_mesh_snapshot())
 
+    def _mesh_active(self) -> bool:
+        """True when the live mesh graph is actually being watched: the
+        session is in the mesh view AND an SSE client is attached.
+
+        The browser opens ``/events`` in every view, so ``subscriber_count``
+        alone is ~always true during a normal session — gating the
+        background refreshers (the periodic loop and the JOIN/PART trigger)
+        on the view as well keeps chat usage from running WHO sweeps for a
+        graph nobody is looking at. ``/mesh`` stays responsive regardless:
+        ``_exec_mesh`` recomputes immediately on switch.
+        """
+        return self.view == "mesh" and self.event_bus.subscriber_count > 0
+
     def _request_mesh_refresh(self) -> None:
         """Schedule a mesh recompute, coalescing bursts into one rebuild.
 
@@ -1174,16 +1192,16 @@ class Session:
     async def _mesh_refresh_loop(self) -> None:
         """Per-session background task: periodically refresh the live mesh.
 
-        Idle-cheap — only triggers a rebuild when someone is watching
-        (``subscriber_count``), we're connected, and there are channels to
+        Idle-cheap — only triggers a rebuild when the mesh is actually being
+        viewed (``_mesh_active``), we're connected, and there are channels to
         show. JOIN/PART already drive immediate refreshes via ``dispatch``;
         this loop catches membership churn that arrives without a JOIN/PART
-        we observe and keeps a freshly-loaded mesh view current. Cancelled
-        in ``disconnect`` via ``_cancel_mesh_tasks``.
+        we observe and keeps the open mesh view current. Cancelled in
+        ``disconnect`` via ``_cancel_mesh_tasks``.
         """
         while True:
             await asyncio.sleep(MESH_REFRESH_INTERVAL)
-            if self.connected and self.joined_channels and self.event_bus.subscriber_count:
+            if self.connected and self.joined_channels and self._mesh_active():
                 self._request_mesh_refresh()
 
     # ------------------------------------------------------------------

--- a/src/irc_lens/session.py
+++ b/src/irc_lens/session.py
@@ -1086,7 +1086,9 @@ class Session:
             )
             try:
                 members = await self.who(channel)
-            except Exception:  # noqa: BLE001 — degrade per-channel, never fail the graph
+            # Degrade per-channel: a failed WHO (incl. broken pipe) skips
+            # that channel rather than failing the whole snapshot.
+            except Exception:  # noqa: BLE001
                 logger.exception("WHO %s failed during mesh snapshot", channel)
                 continue
             for entry in members:
@@ -1165,7 +1167,8 @@ class Session:
             self._mesh_dirty = False
             try:
                 await self._recompute_and_publish_mesh()
-            except Exception:  # noqa: BLE001 — a failed refresh must not kill the task
+            # A failed refresh must not kill the drain task.
+            except Exception:  # noqa: BLE001
                 logger.exception("mesh refresh failed")
 
     async def _mesh_refresh_loop(self) -> None:

--- a/src/irc_lens/static/lens.css
+++ b/src/irc_lens/static/lens.css
@@ -73,6 +73,22 @@ body {
   padding: 0.5em;
 }
 
+/* Mesh graph shares the chat column's content row (row 1) with the log;
+   CSS shows exactly one based on <body data-view>. The input form (row 2)
+   stays visible in mesh view so the user can switch away. */
+.lens-log,
+.lens-mesh { grid-row: 1; grid-column: 1; min-height: 0; }
+.lens-form { grid-row: 2; grid-column: 1; }
+.lens-mesh {
+  display: none;
+  position: relative;
+  overflow: hidden;
+  background: var(--lens-surface);
+}
+.lens-mesh canvas { display: block; width: 100%; height: 100%; }
+body[data-view="mesh"] .lens-log  { display: none; }
+body[data-view="mesh"] .lens-mesh { display: block; }
+
 .lens-form {
   display: flex;
   gap: 0.5ch;
@@ -127,6 +143,22 @@ body {
 body[data-view="help"]     .lens-view { color: var(--lens-accent); }
 body[data-view="overview"] .lens-view { color: var(--lens-accent); }
 body[data-view="status"]   .lens-view { color: var(--lens-accent); }
+body[data-view="mesh"]     .lens-view { color: var(--lens-accent); }
+
+/* Mesh legend (info pane, mesh view). */
+.lens-info-mesh-hint { color: var(--lens-muted); margin: 0.25em 0; }
+.lens-mesh-legend { list-style: none; margin: 0.25em 0; padding: 0; }
+.lens-mesh-legend li { display: flex; align-items: center; gap: 0.6ch; padding: 0.1em 0; }
+.lens-mesh-dot {
+  width: 0.8em;
+  height: 0.8em;
+  border-radius: 50%;
+  display: inline-block;
+  border: 1.5px solid transparent;
+}
+.lens-mesh-dot--room  { border-color: var(--lens-bright); background: rgba(124, 255, 158, 0.25); }
+.lens-mesh-dot--agent { border-color: var(--lens-accent); background: rgba(65, 214, 122, 0.25); }
+.lens-mesh-dot--human { border-color: var(--lens-muted);  background: rgba(138, 151, 163, 0.25); }
 
 /* `lens.js` sets data-conn="down" on SSE failure. Visual cue, no
    layout shift. */

--- a/src/irc_lens/static/lens.css
+++ b/src/irc_lens/static/lens.css
@@ -78,7 +78,6 @@ body {
    stays visible in mesh view so the user can switch away. */
 .lens-log,
 .lens-mesh { grid-row: 1; grid-column: 1; min-height: 0; }
-.lens-form { grid-row: 2; grid-column: 1; }
 .lens-mesh {
   display: none;
   position: relative;
@@ -90,6 +89,8 @@ body[data-view="mesh"] .lens-log  { display: none; }
 body[data-view="mesh"] .lens-mesh { display: block; }
 
 .lens-form {
+  grid-row: 2;
+  grid-column: 1;
   display: flex;
   gap: 0.5ch;
   padding: 0.4em;

--- a/src/irc_lens/static/lens.js
+++ b/src/irc_lens/static/lens.js
@@ -59,6 +59,15 @@
   });
   src.addEventListener("roster", (e) => swap(sidebar, e.data));
   src.addEventListener("info",   (e) => swap(info, e.data));
+  // `mesh` carries the live agent-mesh graph snapshot (katvan's mesh.json
+  // shape) as JSON. Hand it to the canvas renderer (mesh.js, which exposes
+  // `window.LensMesh`). The renderer only animates while the mesh pane is
+  // on screen, so feeding it while in another view is cheap.
+  src.addEventListener("mesh", (e) => {
+    if (!globalThis.LensMesh || typeof e.data !== "string" || !e.data) return;
+    try { globalThis.LensMesh.update(JSON.parse(e.data)); }
+    catch (err) { console.warn("[lens] bad mesh payload", err); }
+  });
   src.addEventListener("view",   (e) => {
     try { document.body.dataset.view = JSON.parse(e.data).view; }
     catch (err) { console.warn("[lens] bad view payload", err); }

--- a/src/irc_lens/static/mesh.js
+++ b/src/irc_lens/static/mesh.js
@@ -24,21 +24,19 @@
   "use strict";
 
   // ---- palette ---------------------------------------------------------
+  // Only called from loadPalette() inside mount(), which runs in a browser
+  // (autoMount on DOMContentLoaded), so getComputedStyle is always present.
   function cssVar(name, fallback) {
-    try {
-      const v = getComputedStyle(document.documentElement)
-        .getPropertyValue(name)
-        .trim();
-      return v || fallback;
-    } catch (_e) {
-      return fallback;
-    }
+    const v = getComputedStyle(document.documentElement)
+      .getPropertyValue(name)
+      .trim();
+    return v || fallback;
   }
 
   function hexToRgb(hex) {
     const m = /^#?([0-9a-f]{6})$/i.exec((hex || "").trim());
     if (!m) return [65, 214, 122];
-    const n = parseInt(m[1], 16);
+    const n = Number.parseInt(m[1], 16);
     return [(n >> 16) & 255, (n >> 8) & 255, n & 255];
   }
 
@@ -58,7 +56,7 @@
     // humans read calmer/cooler so the social structure is legible.
     KIND = {
       room: { r: 16, fill: COLORS.surface, ring: COLORS.accentBright, core: COLORS.accentBright, dim: 0.85 },
-      agent: { r: 11, fill: COLORS.surface, ring: COLORS.accent, core: COLORS.accent, dim: 1.0 },
+      agent: { r: 11, fill: COLORS.surface, ring: COLORS.accent, core: COLORS.accent, dim: 1 },
       human: { r: 10, fill: COLORS.surface, ring: COLORS.muted, core: COLORS.text, dim: 0.7 },
     };
   }
@@ -102,8 +100,21 @@
   let haveData = false;
   let prevSig = "";
 
+  // Deterministic PRNG (mulberry32), seeded once. Drives the decorative
+  // motion — jitter, per-node phase, particle timing. Intentionally a
+  // non-crypto RNG: this is animation, not security, and a fixed seed also
+  // makes layouts reproducible. (Avoids Math.random, which static analysis
+  // flags as a weak-crypto hotspot even in a purely cosmetic context.)
+  let _seed = 0x9e3779b9;
+  function _rng() {
+    _seed = (_seed + 0x6d2b79f5) | 0;
+    let t = Math.imul(_seed ^ (_seed >>> 15), 1 | _seed);
+    t = (t + Math.imul(t ^ (t >>> 7), 61 | t)) ^ t;
+    return ((t ^ (t >>> 14)) >>> 0) / 4294967296;
+  }
+
   function rand(min, max) {
-    return min + Math.random() * (max - min);
+    return min + _rng() * (max - min);
   }
 
   // Signature of the current topology — id set + edge set. Used to skip
@@ -188,21 +199,16 @@
   }
 
   // ---- force layout (runs on rebuild + resize, NOT per frame) ---------
-  function step(dt, time) {
-    const cx = W / 2;
-    const cy = H / 2;
+  // Split into three phases so each stays well under the cognitive-
+  // complexity cap; `step` just sequences them.
+  function _applyRepulsion() {
     const REPEL = 5200;
-    const SPRING = 0.012;
-    const REST = 132;
-    const CENTER = 0.0016;
-    const DAMP = 0.86;
-
     for (let i = 0; i < nodes.length; i++) {
       const a = nodes[i];
       for (let j = i + 1; j < nodes.length; j++) {
         const b = nodes[j];
-        let dx = a.x - b.x;
-        let dy = a.y - b.y;
+        const dx = a.x - b.x;
+        const dy = a.y - b.y;
         let d2 = dx * dx + dy * dy;
         if (d2 < 1) d2 = 1;
         const d = Math.sqrt(d2);
@@ -215,11 +221,15 @@
         b.vy -= fy;
       }
     }
+  }
 
+  function _applySprings() {
+    const SPRING = 0.012;
+    const REST = 132;
     for (const e of edges) {
       const dx = e.b.x - e.a.x;
       const dy = e.b.y - e.a.y;
-      const d = Math.sqrt(dx * dx + dy * dy) || 1;
+      const d = Math.hypot(dx, dy) || 1;
       const f = (d - REST) * SPRING;
       const fx = (dx / d) * f;
       const fy = (dy / d) * f;
@@ -228,7 +238,13 @@
       e.b.vx -= fx;
       e.b.vy -= fy;
     }
+  }
 
+  function _integrate(dt, time) {
+    const cx = W / 2;
+    const cy = H / 2;
+    const CENTER = 0.0016;
+    const DAMP = 0.86;
     for (const n of nodes) {
       n.vx += (cx - n.x) * CENTER;
       n.vy += (cy - n.y) * CENTER;
@@ -243,6 +259,12 @@
       if (n.y < pad) { n.y = pad; n.vy *= -0.4; }
       if (n.y > H - pad) { n.y = H - pad; n.vy *= -0.4; }
     }
+  }
+
+  function step(dt, time) {
+    _applyRepulsion();
+    _applySprings();
+    _integrate(dt, time);
   }
 
   function freezeLayout() {
@@ -274,7 +296,7 @@
         e.nextSpawn = rand(3, 7);
         particles.push({
           edge: e,
-          forward: Math.random() < 0.5,
+          forward: _rng() < 0.5,
           p: 0,
           speed: rand(0.16, 0.26),
         });
@@ -431,7 +453,7 @@
     // 0; we clamp and rescale once the pane becomes visible.
     W = Math.max(160, Math.round(wrap.clientWidth || 320));
     H = Math.max(160, Math.round(wrap.clientHeight || 320));
-    const dpr = Math.min(window.devicePixelRatio || 1, 1.5);
+    const dpr = Math.min(globalThis.devicePixelRatio || 1, 1.5);
     canvas.width = Math.round(W * dpr);
     canvas.height = Math.round(H * dpr);
     ctx = canvas.getContext("2d");
@@ -452,7 +474,7 @@
     wrap = canvasEl.parentElement || canvasEl;
     loadPalette();
 
-    const mq = window.matchMedia("(prefers-reduced-motion: reduce)");
+    const mq = globalThis.matchMedia("(prefers-reduced-motion: reduce)");
     reduced = mq.matches;
 
     resize();
@@ -476,8 +498,8 @@
     io = new IntersectionObserver(
       function (entries) {
         visible = entries[0] ? entries[0].isIntersecting : true;
-        if (!visible) stop();
-        else start();
+        if (visible) start();
+        else stop();
       },
       { threshold: 0 }
     );
@@ -493,11 +515,10 @@
       if (reduced) { stop(); renderStatic(); }
       else start();
     };
-    if (mq.addEventListener) mq.addEventListener("change", onPref);
-    else if (mq.addListener) mq.addListener(onPref);
+    mq.addEventListener("change", onPref);
   }
 
-  window.LensMesh = { mount: mount, update: update };
+  globalThis.LensMesh = { mount: mount, update: update };
 
   // Auto-mount when the DOM is ready (the console ships exactly one
   // mesh canvas). Guard for environments without the element.

--- a/src/irc_lens/static/mesh.js
+++ b/src/irc_lens/static/mesh.js
@@ -1,0 +1,513 @@
+// irc-lens live agent-mesh graph.
+//
+// A vanilla-JS port of katvan's `MeshIsland.svelte` (the culture.dev
+// "living mesh" Canvas 2D visualization). irc-lens has no JS build step,
+// so the Svelte component is reimplemented here as a plain IIFE rather
+// than imported/bundled. The rendering — breathing room/agent/human
+// nodes, pulsing edges, message particles, force-settle-once layout — is
+// faithful to the source; the differences are deliberate:
+//
+//   * data arrives at runtime via `LensMesh.update(data)` (fed by the
+//     `mesh` SSE event in lens.js) instead of a build-time import;
+//   * `update()` is a WARM rebuild — nodes that persist keep their
+//     positions, only new nodes are seeded and gone nodes dropped, so a
+//     live topology change never re-randomizes (and "jumps") the graph;
+//   * the canvas fills its console pane (width × height) instead of
+//     katvan's decorative fixed aspect ratio;
+//   * colours are read from the page's `--lens-*` CSS tokens so the graph
+//     matches the console theme (same palette katvan uses).
+//
+// Data shape (katvan's mesh.json contract):
+//   { nodes: [{ id, label, kind, server }], edges: [{ source, target }] }
+//   kind ∈ "room" | "agent" | "human"
+(function () {
+  "use strict";
+
+  // ---- palette ---------------------------------------------------------
+  function cssVar(name, fallback) {
+    try {
+      const v = getComputedStyle(document.documentElement)
+        .getPropertyValue(name)
+        .trim();
+      return v || fallback;
+    } catch (_e) {
+      return fallback;
+    }
+  }
+
+  function hexToRgb(hex) {
+    const m = /^#?([0-9a-f]{6})$/i.exec((hex || "").trim());
+    if (!m) return [65, 214, 122];
+    const n = parseInt(m[1], 16);
+    return [(n >> 16) & 255, (n >> 8) & 255, n & 255];
+  }
+
+  let COLORS, KIND, ACCENT_RGB, BRIGHT_RGB;
+
+  function loadPalette() {
+    COLORS = {
+      surface: cssVar("--lens-surface", "#11161b"),
+      text: cssVar("--lens-fg", "#f3f5f7"),
+      muted: cssVar("--lens-muted", "#8a97a3"),
+      accent: cssVar("--lens-accent", "#41d67a"),
+      accentBright: cssVar("--lens-bright", "#7cff9e"),
+    };
+    ACCENT_RGB = hexToRgb(COLORS.accent);
+    BRIGHT_RGB = hexToRgb(COLORS.accentBright);
+    // Per-kind glyph styling — rooms are the larger hubs, agents glow,
+    // humans read calmer/cooler so the social structure is legible.
+    KIND = {
+      room: { r: 16, fill: COLORS.surface, ring: COLORS.accentBright, core: COLORS.accentBright, dim: 0.85 },
+      agent: { r: 11, fill: COLORS.surface, ring: COLORS.accent, core: COLORS.accent, dim: 1.0 },
+      human: { r: 10, fill: COLORS.surface, ring: COLORS.muted, core: COLORS.text, dim: 0.7 },
+    };
+  }
+
+  function rgba(rgb, a) {
+    return "rgba(" + rgb[0] + "," + rgb[1] + "," + rgb[2] + "," + a + ")";
+  }
+
+  // ---- state -----------------------------------------------------------
+  let canvas = null;
+  let wrap = null;
+  let ctx = null;
+  let raf = 0;
+  let ro = null; // ResizeObserver
+  let io = null; // IntersectionObserver — pause when offscreen / hidden
+  let running = false;
+  let visible = true;
+  let reduced = false;
+  let glowSprite = null;
+  let mounted = false;
+
+  let W = 320;
+  let H = 320;
+  let layoutW = 0;
+  let layoutH = 0;
+  let t0 = 0;
+  let lastT;
+  let lastDraw = 0;
+  const FRAME_INTERVAL = 1000 / 30; // cap the ambient loop at ~30fps
+  const DRIFT_AMP = 7; // px of gentle float around the settled position
+
+  // Simulation working state.
+  let nodes = [];
+  let edges = [];
+  let particles = [];
+  let byId = new Map();
+
+  // Last data handed in (kept so update() before mount() still applies).
+  let rawNodes = [];
+  let rawEdges = [];
+  let haveData = false;
+  let prevSig = "";
+
+  function rand(min, max) {
+    return min + Math.random() * (max - min);
+  }
+
+  // Signature of the current topology — id set + edge set. Used to skip
+  // a relayout when only the animation (not the graph) changed.
+  function signature(rNodes, rEdges) {
+    const ids = rNodes.map(function (n) { return n.id; }).sort();
+    const es = rEdges
+      .map(function (e) { return e.source + ">" + e.target; })
+      .sort();
+    return ids.join(",") + "|" + es.join(",");
+  }
+
+  // ---- data application (warm rebuild) --------------------------------
+  function applyData() {
+    const sig = signature(rawNodes, rawEdges);
+    const topologyChanged = sig !== prevSig;
+    const prev = byId; // id -> existing sim node
+
+    const nextById = new Map();
+    nodes = rawNodes.map(function (n) {
+      const k = KIND[n.kind] || KIND.agent;
+      const old = prev.get(n.id);
+      let node;
+      if (old) {
+        // Carry over position + per-node animation phase so a persisting
+        // node never teleports across a live update.
+        node = old;
+        node.label = n.label;
+        node.kind = n.kind;
+        node.server = n.server;
+        node.r = k.r;
+      } else {
+        // New node: seed near centre with jitter; the short settle below
+        // (topologyChanged) will pull it into place via the force sim.
+        node = {
+          id: n.id,
+          label: n.label,
+          kind: n.kind,
+          server: n.server,
+          x: W / 2 + rand(-60, 60),
+          y: H / 2 + rand(-60, 60),
+          vx: 0,
+          vy: 0,
+          r: k.r,
+          phase: rand(0, Math.PI * 2),
+          driftSpeed: rand(0.4, 0.9),
+          glow: rand(0, Math.PI * 2),
+        };
+        node.bx = node.x;
+        node.by = node.y;
+      }
+      nextById.set(n.id, node);
+      return node;
+    });
+    byId = nextById;
+
+    edges = rawEdges
+      .map(function (e) { return { a: byId.get(e.source), b: byId.get(e.target) }; })
+      .filter(function (e) { return e.a && e.b; })
+      .map(function (e) {
+        e.pulse = rand(0, Math.PI * 2);
+        e.nextSpawn = rand(0.5, 4);
+        return e;
+      });
+
+    // Particles reference old edge objects; drop them on a rebuild.
+    particles = [];
+
+    if (topologyChanged && nodes.length) {
+      // Bounded settle, then freeze: existing nodes sit near equilibrium
+      // and barely move, while new nodes get placed. Re-running the full
+      // O(n^2) sim every frame is what made the source "slow when idle",
+      // so we settle once here and only float/pulse per frame.
+      for (let i = 0; i < 90; i++) step(0.05, 0);
+      freezeLayout();
+      layoutW = W;
+      layoutH = H;
+    }
+    prevSig = sig;
+
+    if (ctx) draw(0); // paint immediately (covers the reduced-motion path)
+  }
+
+  // ---- force layout (runs on rebuild + resize, NOT per frame) ---------
+  function step(dt, time) {
+    const cx = W / 2;
+    const cy = H / 2;
+    const REPEL = 5200;
+    const SPRING = 0.012;
+    const REST = 132;
+    const CENTER = 0.0016;
+    const DAMP = 0.86;
+
+    for (let i = 0; i < nodes.length; i++) {
+      const a = nodes[i];
+      for (let j = i + 1; j < nodes.length; j++) {
+        const b = nodes[j];
+        let dx = a.x - b.x;
+        let dy = a.y - b.y;
+        let d2 = dx * dx + dy * dy;
+        if (d2 < 1) d2 = 1;
+        const d = Math.sqrt(d2);
+        const f = REPEL / d2;
+        const fx = (dx / d) * f;
+        const fy = (dy / d) * f;
+        a.vx += fx;
+        a.vy += fy;
+        b.vx -= fx;
+        b.vy -= fy;
+      }
+    }
+
+    for (const e of edges) {
+      const dx = e.b.x - e.a.x;
+      const dy = e.b.y - e.a.y;
+      const d = Math.sqrt(dx * dx + dy * dy) || 1;
+      const f = (d - REST) * SPRING;
+      const fx = (dx / d) * f;
+      const fy = (dy / d) * f;
+      e.a.vx += fx;
+      e.a.vy += fy;
+      e.b.vx -= fx;
+      e.b.vy -= fy;
+    }
+
+    for (const n of nodes) {
+      n.vx += (cx - n.x) * CENTER;
+      n.vy += (cy - n.y) * CENTER;
+      n.vx *= DAMP;
+      n.vy *= DAMP;
+      const drift = 9 * n.driftSpeed * dt;
+      n.x += n.vx * dt * 6 + Math.cos(time * 0.5 * n.driftSpeed + n.phase) * drift;
+      n.y += n.vy * dt * 6 + Math.sin(time * 0.4 * n.driftSpeed + n.phase) * drift;
+      const pad = n.r + 8;
+      if (n.x < pad) { n.x = pad; n.vx *= -0.4; }
+      if (n.x > W - pad) { n.x = W - pad; n.vx *= -0.4; }
+      if (n.y < pad) { n.y = pad; n.vy *= -0.4; }
+      if (n.y > H - pad) { n.y = H - pad; n.vy *= -0.4; }
+    }
+  }
+
+  function freezeLayout() {
+    for (const n of nodes) {
+      n.bx = n.x;
+      n.by = n.y;
+    }
+  }
+
+  function rescaleLayout() {
+    if (!layoutW || !layoutH || !nodes.length) return;
+    const sx = W / layoutW;
+    const sy = H / layoutH;
+    for (const n of nodes) {
+      n.bx *= sx;
+      n.by *= sy;
+      n.x = n.bx;
+      n.y = n.by;
+    }
+    layoutW = W;
+    layoutH = H;
+  }
+
+  // ---- message particles ----------------------------------------------
+  function maybeSpawn(dt) {
+    for (const e of edges) {
+      e.nextSpawn -= dt;
+      if (e.nextSpawn <= 0) {
+        e.nextSpawn = rand(3, 7);
+        particles.push({
+          edge: e,
+          forward: Math.random() < 0.5,
+          p: 0,
+          speed: rand(0.16, 0.26),
+        });
+      }
+    }
+    for (const part of particles) part.p += part.speed * dt;
+    particles = particles.filter(function (p) { return p.p < 1; });
+  }
+
+  function lerp(a, b, t) {
+    return a + (b - a) * t;
+  }
+
+  // Pre-render the node glow once; draw() blits it per node (cheap
+  // drawImage) instead of rebuilding a radial gradient each frame.
+  function makeGlowSprite() {
+    const s = 64;
+    const c = document.createElement("canvas");
+    c.width = c.height = s;
+    const g = c.getContext("2d");
+    const grad = g.createRadialGradient(s / 2, s / 2, 0, s / 2, s / 2, s / 2);
+    grad.addColorStop(0, rgba(ACCENT_RGB, 1));
+    grad.addColorStop(1, rgba(ACCENT_RGB, 0));
+    g.fillStyle = grad;
+    g.fillRect(0, 0, s, s);
+    glowSprite = c;
+  }
+
+  // ---- paint -----------------------------------------------------------
+  function draw(time) {
+    if (!ctx) return;
+
+    for (const n of nodes) {
+      n.dx = (n.bx || n.x) + Math.cos(time * 0.22 * n.driftSpeed + n.phase) * DRIFT_AMP;
+      n.dy = (n.by || n.y) + Math.sin(time * 0.18 * n.driftSpeed + n.phase) * DRIFT_AMP;
+    }
+
+    ctx.clearRect(0, 0, W, H);
+    ctx.fillStyle = COLORS.surface;
+    ctx.fillRect(0, 0, W, H);
+
+    // Edges — gentle per-edge brightness pulse.
+    ctx.lineWidth = 1;
+    for (const e of edges) {
+      const pulse = (Math.sin(time * 0.35 + e.pulse) + 1) / 2;
+      ctx.strokeStyle = rgba(ACCENT_RGB, 0.14 + pulse * 0.22);
+      ctx.beginPath();
+      ctx.moveTo(e.a.dx, e.a.dy);
+      ctx.lineTo(e.b.dx, e.b.dy);
+      ctx.stroke();
+    }
+
+    // Message particles travelling along edges.
+    for (const part of particles) {
+      const e = part.edge;
+      const from = part.forward ? e.a : e.b;
+      const to = part.forward ? e.b : e.a;
+      const x = lerp(from.dx, to.dx, part.p);
+      const y = lerp(from.dy, to.dy, part.p);
+      const a = Math.sin(part.p * Math.PI);
+      const g = ctx.createRadialGradient(x, y, 0, x, y, 6);
+      g.addColorStop(0, rgba(BRIGHT_RGB, 0.9 * a));
+      g.addColorStop(1, rgba(BRIGHT_RGB, 0));
+      ctx.fillStyle = g;
+      ctx.beginPath();
+      ctx.arc(x, y, 6, 0, Math.PI * 2);
+      ctx.fill();
+    }
+
+    // Nodes — breathing ring, glowing core, label.
+    for (const n of nodes) {
+      const k = KIND[n.kind] || KIND.agent;
+      const breathe = 1 + Math.sin(time * 0.7 + n.phase) * 0.05;
+      const r = n.r * breathe;
+      const glow = (Math.sin(time * 0.8 + n.glow) + 1) / 2;
+
+      if (glowSprite) {
+        const hr = r * 2.4;
+        ctx.globalAlpha = 0.18 * k.dim;
+        ctx.drawImage(glowSprite, n.dx - hr, n.dy - hr, hr * 2, hr * 2);
+        ctx.globalAlpha = 1;
+      }
+
+      ctx.beginPath();
+      ctx.arc(n.dx, n.dy, r, 0, Math.PI * 2);
+      ctx.fillStyle = k.fill;
+      ctx.fill();
+      ctx.lineWidth = 1.5;
+      ctx.strokeStyle = k.ring;
+      ctx.stroke();
+
+      ctx.beginPath();
+      ctx.arc(n.dx, n.dy, Math.max(2, r * 0.28), 0, Math.PI * 2);
+      ctx.globalAlpha = 0.7 + glow * 0.3;
+      ctx.fillStyle = k.core;
+      ctx.fill();
+      ctx.globalAlpha = 1;
+
+      ctx.font = '600 11px ui-monospace, SFMono-Regular, Menlo, Consolas, monospace';
+      ctx.textAlign = "center";
+      ctx.textBaseline = "top";
+      ctx.fillStyle = n.kind === "room" ? COLORS.accentBright : COLORS.text;
+      ctx.fillText(n.label, n.dx, n.dy + r + 4);
+    }
+
+    // Empty-state hint so the pane never looks broken before data lands.
+    if (!nodes.length) {
+      ctx.fillStyle = COLORS.muted;
+      ctx.font = '12px ui-monospace, SFMono-Regular, Menlo, Consolas, monospace';
+      ctx.textAlign = "center";
+      ctx.textBaseline = "middle";
+      ctx.fillText("no agents in view — /join a channel", W / 2, H / 2);
+    }
+  }
+
+  // ---- loop ------------------------------------------------------------
+  function frame(now) {
+    if (!running) return;
+    raf = requestAnimationFrame(frame);
+    if (now - lastDraw < FRAME_INTERVAL) return;
+    lastDraw = now;
+    const time = (now - t0) / 1000;
+    const dt = Math.min(0.05, time - (lastT == null ? time : lastT));
+    lastT = time;
+    maybeSpawn(dt);
+    draw(time);
+  }
+
+  function start() {
+    if (running || reduced || !visible || !mounted) return;
+    if (typeof cancelAnimationFrame !== "undefined") cancelAnimationFrame(raf);
+    running = true;
+    t0 = performance.now();
+    lastT = undefined;
+    lastDraw = 0;
+    raf = requestAnimationFrame(frame);
+  }
+
+  function stop() {
+    running = false;
+    if (typeof cancelAnimationFrame !== "undefined") cancelAnimationFrame(raf);
+  }
+
+  function renderStatic() {
+    draw(0);
+  }
+
+  // ---- sizing ----------------------------------------------------------
+  function resize() {
+    if (!canvas || !wrap) return;
+    // Measure the WRAP (sized by the grid), never the canvas itself —
+    // the canvas is CSS width/height:100%, so measuring it back into its
+    // own backing store would create a feedback loop. Hidden panes report
+    // 0; we clamp and rescale once the pane becomes visible.
+    W = Math.max(160, Math.round(wrap.clientWidth || 320));
+    H = Math.max(160, Math.round(wrap.clientHeight || 320));
+    const dpr = Math.min(window.devicePixelRatio || 1, 1.5);
+    canvas.width = Math.round(W * dpr);
+    canvas.height = Math.round(H * dpr);
+    ctx = canvas.getContext("2d");
+    ctx.setTransform(dpr, 0, 0, dpr, 0, 0);
+  }
+
+  // ---- public API ------------------------------------------------------
+  function update(data) {
+    rawNodes = (data && Array.isArray(data.nodes)) ? data.nodes : [];
+    rawEdges = (data && Array.isArray(data.edges)) ? data.edges : [];
+    haveData = true;
+    if (mounted) applyData();
+  }
+
+  function mount(canvasEl) {
+    if (!canvasEl || mounted) return;
+    canvas = canvasEl;
+    wrap = canvasEl.parentElement || canvasEl;
+    loadPalette();
+
+    const mq = window.matchMedia("(prefers-reduced-motion: reduce)");
+    reduced = mq.matches;
+
+    resize();
+    makeGlowSprite();
+    mounted = true;
+    if (haveData) applyData();
+    draw(0);
+
+    ro = new ResizeObserver(function () {
+      const had = W;
+      const hadH = H;
+      resize();
+      if (W !== had || H !== hadH) rescaleLayout();
+      draw(0);
+    });
+    ro.observe(wrap);
+
+    // Pause whenever the canvas isn't on screen — scrolled away, the tab
+    // hidden, OR the mesh pane is display:none in another view. A loop
+    // that runs forever is what exhausts GPU/memory over a long session.
+    io = new IntersectionObserver(
+      function (entries) {
+        visible = entries[0] ? entries[0].isIntersecting : true;
+        if (!visible) stop();
+        else start();
+      },
+      { threshold: 0 }
+    );
+    io.observe(wrap);
+
+    document.addEventListener("visibilitychange", function () {
+      if (document.hidden) stop();
+      else start();
+    });
+
+    const onPref = function (e) {
+      reduced = e.matches;
+      if (reduced) { stop(); renderStatic(); }
+      else start();
+    };
+    if (mq.addEventListener) mq.addEventListener("change", onPref);
+    else if (mq.addListener) mq.addListener(onPref);
+  }
+
+  window.LensMesh = { mount: mount, update: update };
+
+  // Auto-mount when the DOM is ready (the console ships exactly one
+  // mesh canvas). Guard for environments without the element.
+  function autoMount() {
+    const el = document.getElementById("mesh-canvas");
+    if (el) mount(el);
+  }
+  if (document.readyState === "loading") {
+    document.addEventListener("DOMContentLoaded", autoMount);
+  } else {
+    autoMount();
+  }
+})();

--- a/src/irc_lens/static/mesh.js
+++ b/src/irc_lens/static/mesh.js
@@ -100,17 +100,16 @@
   let haveData = false;
   let prevSig = "";
 
-  // Deterministic PRNG (mulberry32), seeded once. Drives the decorative
-  // motion — jitter, per-node phase, particle timing. Intentionally a
-  // non-crypto RNG: this is animation, not security, and a fixed seed also
-  // makes layouts reproducible. (Avoids Math.random, which static analysis
-  // flags as a weak-crypto hotspot even in a purely cosmetic context.)
-  let _seed = 0x9e3779b9;
+  // Deterministic PRNG (Numerical-Recipes LCG), seeded once. Drives the
+  // decorative motion — jitter, per-node phase, particle timing.
+  // Intentionally a non-crypto RNG: this is animation, not security, and a
+  // fixed seed also makes layouts reproducible. `>>> 0` keeps the state in
+  // unsigned 32-bit (the `| 0` idiom trips static analysis), and avoiding
+  // Math.random sidesteps the weak-crypto hotspot flag for cosmetic code.
+  let _seed = 0x9e3779b9 >>> 0;
   function _rng() {
-    _seed = (_seed + 0x6d2b79f5) | 0;
-    let t = Math.imul(_seed ^ (_seed >>> 15), 1 | _seed);
-    t = (t + Math.imul(t ^ (t >>> 7), 61 | t)) ^ t;
-    return ((t ^ (t >>> 14)) >>> 0) / 4294967296;
+    _seed = (Math.imul(_seed, 1664525) + 1013904223) >>> 0;
+    return _seed / 4294967296;
   }
 
   function rand(min, max) {

--- a/src/irc_lens/templates/_info.html.j2
+++ b/src/irc_lens/templates/_info.html.j2
@@ -17,6 +17,7 @@
         <dt><code>/agents</code></dt><dd>Union of nicks across every joined channel.</dd>
         <dt><code>/topic #channel [text…]</code></dt><dd>Read or set the channel topic.</dd>
         <dt><code>/icon emoji</code></dt><dd>Set your icon (AgentIRC extension).</dd>
+        <dt><code>/mesh</code></dt><dd>Show the live agent-mesh graph of joined channels and their members.</dd>
         <dt><code>/help</code></dt><dd>Show this help pane.</dd>
         <dt><code>/overview</code></dt><dd>Show the joined-channels overview.</dd>
         <dt><code>/status</code></dt><dd>Show the connection / session status pane.</dd>
@@ -38,6 +39,22 @@
       {% else %}
         <p class="lens-info-empty">No channels joined. Try <code>/join #general</code>.</p>
       {% endif %}
+    </section>
+  {% elif session.view == "mesh" %}
+    <section class="lens-info-mesh">
+      <h2>Mesh graph</h2>
+      <p class="lens-info-mesh-hint">
+        Joined channels and their members, live. Updates as agents join and leave.
+      </p>
+      <ul data-testid="mesh-legend" class="lens-mesh-legend">
+        <li><span class="lens-mesh-dot lens-mesh-dot--room"></span> room (channel)</li>
+        <li><span class="lens-mesh-dot lens-mesh-dot--agent"></span> agent</li>
+        <li><span class="lens-mesh-dot lens-mesh-dot--human"></span> human</li>
+      </ul>
+      <p class="lens-info-empty">
+        {{ session.joined_channels|length }} channel(s) in view —
+        <code>/switch #x</code> or click a channel to return to chat.
+      </p>
     </section>
   {% elif session.view == "status" %}
     <section class="lens-info-status">

--- a/src/irc_lens/templates/index.html.j2
+++ b/src/irc_lens/templates/index.html.j2
@@ -12,6 +12,7 @@
     <link rel="stylesheet" href="{{ static_url('lens.css') }}">
     <script src="{{ static_url('vendor/htmx.min.js') }}" defer></script>
     <script src="{{ static_url('vendor/sse.js') }}" defer></script>
+    <script src="{{ static_url('mesh.js') }}" defer></script>
     <script src="{{ static_url('lens.js') }}" defer></script>
   </head>
   <body data-view="{{ session.view }}">
@@ -36,6 +37,19 @@
              history from the IRCd's SQLite store. #}
           {{ chat_log_html|safe }}
         </div>
+        {# Live agent-mesh graph (mesh.js / window.LensMesh). Shares the
+           center column's content row with the chat log; CSS shows exactly
+           one based on <body data-view>. The input form below stays usable
+           in mesh view so the user can switch away. Fed by the `mesh` SSE
+           event; the canvas only animates while this pane is on screen. #}
+        <section
+          data-testid="mesh"
+          id="mesh-pane"
+          class="lens-mesh"
+          role="img"
+          aria-label="Live agent-mesh graph: joined channels as rooms, their members as agents and humans, connections as edges, with messages travelling the links.">
+          <canvas id="mesh-canvas"></canvas>
+        </section>
         <form id="chat-form" class="lens-form" hx-post="/input" hx-trigger="submit" hx-swap="none">
           <input
             data-testid="chat-input"

--- a/src/irc_lens/web/routes.py
+++ b/src/irc_lens/web/routes.py
@@ -259,6 +259,13 @@ async def get_events(request: web.Request) -> web.StreamResponse:
     """SSE stream — drains ``Session.event_bus`` until the client leaves."""
     session = await _resolve_session(request)
     sub = session.event_bus.subscribe()
+    # If this session is already in the mesh view (e.g. a page reload while
+    # viewing the graph), push the current snapshot straight away so the
+    # canvas paints without waiting for the next refresher tick. Gated on
+    # the view so clients looking at chat/help/etc don't receive mesh
+    # events they won't render.
+    if session.view == "mesh":
+        session.request_mesh_refresh()
     response = web.StreamResponse(
         status=200,
         headers={

--- a/tests/test_e2e_http.py
+++ b/tests/test_e2e_http.py
@@ -178,6 +178,80 @@ async def test_get_events_streams_roster_after_join(
 
 
 # ---------------------------------------------------------------------------
+# GET /events — the live agent-mesh graph snapshot streams as a `mesh`
+# event after /mesh. WHO is stubbed on the session so the snapshot builder
+# resolves without the test server implementing the WHO numerics.
+# ---------------------------------------------------------------------------
+
+
+async def test_mesh_event_streams_after_mesh_command(
+    lens_client: TestClient,
+    agentirc_server: AgentIRCTestServer,
+    lens_session: Session,
+) -> None:
+    """Open SSE, /join, then /mesh — a `mesh` event carrying katvan's
+    graph contract should land on the stream."""
+    import json
+
+    async def fake_who(target: str) -> list[dict]:
+        return [
+            {"nick": "lens-test", "server": "testsrv"},
+            {"nick": "daria", "server": "testsrv"},
+        ]
+
+    lens_session.who = fake_who  # type: ignore[assignment]
+    # The in-tree test server never sends 001, so the transport's
+    # `connected` flag stays False; force it on (as test_session_dispatch
+    # does) so the snapshot builder doesn't short-circuit to an empty graph.
+    lens_session._transport.connected = True
+
+    def _have_full_mesh_frame(buf: bytes) -> bool:
+        # A complete SSE frame ends with a blank line; only parse once the
+        # mesh event's terminator has arrived (a chunk boundary can split
+        # `event: mesh\ndata: {...}` mid-payload).
+        i = buf.find(b"event: mesh")
+        return i != -1 and buf.find(b"\n\n", i) != -1
+
+    async def collect_event() -> bytes:
+        resp = await lens_client.get("/events")
+        assert resp.status == 200
+        buf = b""
+        try:
+            async with asyncio.timeout(2.0):
+                while not _have_full_mesh_frame(buf):
+                    chunk = await resp.content.read(1024)
+                    if not chunk:
+                        break
+                    buf += chunk
+        finally:
+            resp.close()
+        return buf
+
+    collector = asyncio.create_task(collect_event())
+    async with asyncio.timeout(1.0):
+        while lens_session.event_bus.subscriber_count == 0:
+            await asyncio.sleep(0.005)
+
+    await lens_client.post("/input", json={"text": "/join #ops"})
+    await _wait_for_received(agentirc_server, "JOIN", "#ops")
+    mesh_resp = await lens_client.post("/input", json={"text": "/mesh"})
+    assert mesh_resp.status == 204
+
+    payload = await collector
+    assert b"event: mesh" in payload
+    # Pull the JSON out of the `event: mesh\ndata: {...}` frame.
+    frame = payload.split(b"event: mesh", 1)[1]
+    data_line = next(
+        ln[len(b"data: ") :]
+        for ln in frame.splitlines()
+        if ln.startswith(b"data: ")
+    )
+    snap = json.loads(data_line)
+    assert {n["id"] for n in snap["nodes"]} == {"#ops", "lens-test", "daria"}
+    assert {"source": "#ops", "target": "daria"} in snap["edges"]
+
+
+# ---------------------------------------------------------------------------
 # JSON-shape regression: error response shape (NOT the AfiError CLI
 # triple — see PR #7 pushback memory).
 # ---------------------------------------------------------------------------

--- a/tests/test_e2e_http.py
+++ b/tests/test_e2e_http.py
@@ -189,8 +189,11 @@ async def test_mesh_event_streams_after_mesh_command(
     agentirc_server: AgentIRCTestServer,
     lens_session: Session,
 ) -> None:
-    """Open SSE, /join, then /mesh — a `mesh` event carrying katvan's
-    graph contract should land on the stream."""
+    """Open SSE, then /mesh — a `mesh` event carrying katvan's graph
+    contract should land on the stream. We pre-seed `joined_channels`
+    directly instead of POSTing /join because the bare test server doesn't
+    answer HISTORY (a real /join would block on that round-trip); /mesh is
+    still exercised over HTTP, which is what this test is about."""
     import json
 
     async def fake_who(target: str) -> list[dict]:
@@ -204,6 +207,7 @@ async def test_mesh_event_streams_after_mesh_command(
     # `connected` flag stays False; force it on (as test_session_dispatch
     # does) so the snapshot builder doesn't short-circuit to an empty graph.
     lens_session._transport.connected = True
+    lens_session.joined_channels.add("#ops")
 
     def _have_full_mesh_frame(buf: bytes) -> bool:
         # A complete SSE frame ends with a blank line; only parse once the
@@ -217,7 +221,7 @@ async def test_mesh_event_streams_after_mesh_command(
         assert resp.status == 200
         buf = b""
         try:
-            async with asyncio.timeout(2.0):
+            async with asyncio.timeout(3.0):
                 while not _have_full_mesh_frame(buf):
                     chunk = await resp.content.read(1024)
                     if not chunk:
@@ -232,8 +236,6 @@ async def test_mesh_event_streams_after_mesh_command(
         while lens_session.event_bus.subscriber_count == 0:
             await asyncio.sleep(0.005)
 
-    await lens_client.post("/input", json={"text": "/join #ops"})
-    await _wait_for_received(agentirc_server, "JOIN", "#ops")
     mesh_resp = await lens_client.post("/input", json={"text": "/mesh"})
     assert mesh_resp.status == 204
 

--- a/tests/test_e2e_playwright.py
+++ b/tests/test_e2e_playwright.py
@@ -123,3 +123,29 @@ async def test_view_switch_via_help_command(seeded_lens_client: TestClient) -> N
             await expect(indicator).to_have_attribute("data-view", "help", timeout=_LOCATOR_TIMEOUT_MS)
         finally:
             await browser.close()
+
+
+async def test_mesh_view_shows_canvas_and_hides_log(seeded_lens_client: TestClient) -> None:
+    """Typing ``/mesh`` switches to the live agent-mesh graph: the canvas
+    pane becomes visible (the mesh.js renderer mounts it), the chat log
+    hides, and the input form stays usable so the user can switch back."""
+    async with async_playwright() as p:
+        browser = await p.chromium.launch()
+        try:
+            page = await browser.new_page()
+            await page.goto(_url(seeded_lens_client))
+            canvas = page.locator("#mesh-canvas")
+            chat_log = page.locator('[data-testid="chat-log"]')
+            # Mesh pane is hidden under the default chat view.
+            await expect(canvas).to_be_hidden(timeout=_LOCATOR_TIMEOUT_MS)
+            await page.locator('[data-testid="chat-input"]').fill("/mesh")
+            await page.locator('[data-testid="chat-input"]').press("Enter")
+            await expect(canvas).to_be_visible(timeout=_LOCATOR_TIMEOUT_MS)
+            await expect(chat_log).to_be_hidden(timeout=_LOCATOR_TIMEOUT_MS)
+            # The input form stays usable in mesh view — clicking a channel
+            # (or /switch) is how the user returns to chat.
+            await expect(page.locator('[data-testid="chat-input"]')).to_be_visible(
+                timeout=_LOCATOR_TIMEOUT_MS
+            )
+        finally:
+            await browser.close()

--- a/tests/test_lens_js.py
+++ b/tests/test_lens_js.py
@@ -17,12 +17,13 @@ def _read_lens_js() -> str:
     )
 
 
-def test_lens_js_subscribes_to_all_six_event_types() -> None:
+def test_lens_js_subscribes_to_all_event_types() -> None:
     js = _read_lens_js()
     # `log` was added alongside history-on-join: replaces #chat-log
     # innerHTML so the chat pane swaps content on /switch and shows
-    # server-side backlog after /join.
-    for name in ("chat", "log", "roster", "info", "view", "error"):
+    # server-side backlog after /join. `mesh` carries the live agent-mesh
+    # graph snapshot and is handed to the canvas renderer (mesh.js).
+    for name in ("chat", "log", "roster", "info", "view", "error", "mesh"):
         assert f'addEventListener("{name}"' in js, (
             f"lens.js missing handler for SSE event {name!r}"
         )
@@ -49,14 +50,15 @@ def test_lens_js_opens_event_source_at_events_path() -> None:
 
 def test_lens_js_stays_small() -> None:
     """Build-plan budget: keep the inline glue small. The original
-    plan said ≤ 50 lines; the cap is now 100 to make room for the
-    review-driven additions on PR #9 (DOM cap, accessible toasts,
-    transport-error guard, src.onopen reconnect handling). If this
-    trips, factor logic into a helper module rather than letting the
+    plan said ≤ 50 lines; the cap grew to 100 for PR #9 (DOM cap,
+    accessible toasts, transport-error guard, src.onopen reconnect) and
+    to 120 for the `mesh` SSE listener — the heavy graph rendering lives
+    in the separate `mesh.js` module, exactly as this guard intends. If
+    this trips, factor logic into a helper module rather than letting the
     inline glue grow into a framework."""
     js = _read_lens_js()
     n = len(js.splitlines())
-    assert n <= 100, f"lens.js grew to {n} lines — refactor into a module"
+    assert n <= 120, f"lens.js grew to {n} lines — refactor into a module"
 
 
 def test_lens_css_carries_phase_7_additions() -> None:

--- a/tests/test_mesh.py
+++ b/tests/test_mesh.py
@@ -1,0 +1,332 @@
+"""Unit tests for the live agent-mesh graph.
+
+Covers the server side of the mesh view: the snapshot builder
+(``build_mesh_snapshot``), the ``agent``/``human`` classification, the
+``mesh`` SSE publish path (empty-graph and populated cases), the ``/mesh``
+verb, the coalescing single-flight refresh, and the JOIN/PART trigger.
+
+The rendered graph itself is katvan's MeshIsland canvas, ported to
+``static/mesh.js`` — exercised in the browser via Playwright. Here we
+pin the *data contract* irc-lens emits: katvan's mesh.json shape
+``{nodes: [{id, label, kind, server}], edges: [{source, target}]}``.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+
+import pytest
+
+from irc_lens.commands import CommandType, ParsedCommand, parse_command
+from irc_lens.irc import Message
+from irc_lens.session import Session, SessionEvent
+
+
+@pytest.fixture
+def session() -> Session:
+    return Session(host="testsrv", port=6667, nick="lens-test")
+
+
+def _who_entry(nick: str, *, server: str = "testsrv") -> dict:
+    """A minimal WHO (RPL_WHOREPLY) row as ``Session.who`` returns it."""
+    return {
+        "nick": nick,
+        "user": nick,
+        "host": "x",
+        "server": server,
+        "flags": "H",
+        "realname": "0 " + nick,
+    }
+
+
+def _patch_who(session: Session, members: dict[str, list[dict]]) -> None:
+    """Stub ``Session.who`` so the snapshot builder doesn't hit the wire."""
+
+    async def fake_who(target: str) -> list[dict]:
+        return members.get(target, [])
+
+    session.who = fake_who  # type: ignore[assignment]
+
+
+# ---------------------------------------------------------------------------
+# /mesh command parsing
+# ---------------------------------------------------------------------------
+
+
+def test_parse_command_mesh() -> None:
+    assert parse_command("/mesh").type is CommandType.MESH
+
+
+# ---------------------------------------------------------------------------
+# build_mesh_snapshot — the katvan data contract
+# ---------------------------------------------------------------------------
+
+
+def test_build_mesh_snapshot_shape() -> None:
+    session = Session(host="testsrv", port=6667, nick="lens-test")
+    session.joined_channels.update({"#ops", "#dev"})
+    _patch_who(
+        session,
+        {
+            # The empty-nick row is a malformed WHO line; the builder skips it.
+            "#ops": [
+                _who_entry("lens-test"),
+                _who_entry("daria"),
+                _who_entry("spark"),
+                {"nick": "", "server": "testsrv"},
+            ],
+            "#dev": [_who_entry("daria"), _who_entry("nova", server="nova")],
+        },
+    )
+    snap = asyncio.run(session.build_mesh_snapshot())
+
+    # Room nodes for each joined channel; person nodes deduped across channels.
+    rooms = {n["id"] for n in snap["nodes"] if n["kind"] == "room"}
+    assert rooms == {"#ops", "#dev"}
+    nick_nodes = {n["id"]: n for n in snap["nodes"] if n["kind"] != "room"}
+    assert set(nick_nodes) == {"lens-test", "daria", "spark", "nova"}
+
+    # Every node carries exactly katvan's key set.
+    for node in snap["nodes"]:
+        assert set(node) == {"id", "label", "kind", "server"}
+        assert node["kind"] in {"room", "agent", "human"}
+    for edge in snap["edges"]:
+        assert set(edge) == {"source", "target"}
+
+    # The operator nick classifies as human; the rest as agents.
+    assert nick_nodes["lens-test"]["kind"] == "human"
+    assert nick_nodes["daria"]["kind"] == "agent"
+
+    # WHO's per-nick server maps onto the federated band; channel nodes
+    # carry the lens host.
+    assert nick_nodes["nova"]["server"] == "nova"
+    assert nick_nodes["daria"]["server"] == "testsrv"
+    assert next(n for n in snap["nodes"] if n["id"] == "#ops")["server"] == "testsrv"
+
+    # Membership edges: daria is in both channels → two edges.
+    daria_edges = [e for e in snap["edges"] if e["target"] == "daria"]
+    assert {e["source"] for e in daria_edges} == {"#ops", "#dev"}
+
+
+def test_build_mesh_snapshot_skips_failing_channel() -> None:
+    """A WHO that raises (e.g. a broken pipe) drops that channel rather
+    than failing the whole snapshot — a viz degrades, it doesn't crash."""
+    session = Session(host="testsrv", port=6667, nick="lens-test")
+    session.joined_channels.update({"#ok", "#bad"})
+
+    async def flaky_who(target: str) -> list[dict]:
+        if target == "#bad":
+            raise ConnectionError("pipe gone")
+        return [_who_entry("daria")]
+
+    session.who = flaky_who  # type: ignore[assignment]
+    snap = asyncio.run(session.build_mesh_snapshot())
+    # #bad still appears as a room (added before the WHO), but has no
+    # members/edges; #ok is fully populated.
+    assert {n["id"] for n in snap["nodes"] if n["kind"] == "room"} == {"#ok", "#bad"}
+    assert {e["source"] for e in snap["edges"]} == {"#ok"}
+
+
+def test_classify_kind() -> None:
+    session = Session(host="testsrv", port=6667, nick="me")
+    assert session._classify_kind({"nick": "me"}) == "human"
+    assert session._classify_kind({"nick": "someagent"}) == "agent"
+    assert session._classify_kind({}) == "agent"
+
+
+# ---------------------------------------------------------------------------
+# Publish path: empty-graph guards + populated /mesh
+# ---------------------------------------------------------------------------
+
+
+def _mesh_events(events: list[SessionEvent]) -> list[dict]:
+    return [json.loads(e.data) for e in events if e.name == "mesh"]
+
+
+def test_recompute_publishes_empty_when_no_channels(session: Session) -> None:
+    sub = session.event_bus.subscribe()
+    asyncio.run(session._recompute_and_publish_mesh())
+    meshes = _mesh_events(sub.drain_nowait())
+    sub.close()
+    assert meshes == [{"nodes": [], "edges": []}]
+
+
+def test_recompute_publishes_empty_when_disconnected(session: Session) -> None:
+    """Channels joined but the transport never welcomed → empty graph
+    (we never WHO an unregistered connection)."""
+    session.joined_channels.add("#ops")
+    assert not session.connected
+    sub = session.event_bus.subscribe()
+    asyncio.run(session._recompute_and_publish_mesh())
+    meshes = _mesh_events(sub.drain_nowait())
+    sub.close()
+    assert meshes == [{"nodes": [], "edges": []}]
+
+
+def test_exec_mesh_switches_view_and_publishes_snapshot() -> None:
+    session = Session(host="testsrv", port=6667, nick="lens-test")
+    session.joined_channels.add("#ops")
+    session._transport.connected = True  # bypass the pre-welcome guard
+    _patch_who(session, {"#ops": [_who_entry("lens-test"), _who_entry("daria")]})
+
+    sub = session.event_bus.subscribe()
+    asyncio.run(session.execute(ParsedCommand(type=CommandType.MESH)))
+    events = sub.drain_nowait()
+    sub.close()
+
+    assert session.view == "mesh"
+    names = [e.name for e in events]
+    # _switch_view emits view + info; the recompute emits one mesh event.
+    view = next(e for e in events if e.name == "view")
+    assert json.loads(view.data) == {"view": "mesh"}
+    assert "info" in names
+    meshes = _mesh_events(events)
+    assert len(meshes) == 1
+    snap = meshes[0]
+    assert {n["id"] for n in snap["nodes"]} == {"#ops", "lens-test", "daria"}
+    assert {"source": "#ops", "target": "daria"} in snap["edges"]
+
+
+# ---------------------------------------------------------------------------
+# Coalescing single-flight refresh + JOIN/PART trigger
+# ---------------------------------------------------------------------------
+
+
+async def test_request_mesh_refresh_coalesces(session: Session) -> None:
+    """A burst of refresh requests collapses into a single rebuild — the
+    drain task is reused, not stacked, so JOIN/PART floods don't fan out
+    into a WHO storm."""
+    calls = 0
+
+    async def fake_recompute() -> None:
+        nonlocal calls
+        calls += 1
+        await asyncio.sleep(0.01)
+
+    session._recompute_and_publish_mesh = fake_recompute  # type: ignore[assignment]
+    for _ in range(5):
+        session._request_mesh_refresh()
+    assert session._mesh_task is not None
+    await session._mesh_task
+    assert calls == 1
+
+
+async def test_request_mesh_refresh_reruns_when_dirtied_midflight(session: Session) -> None:
+    """A request that lands while a build is in flight triggers exactly
+    one more rebuild (the dirty flag), not zero and not many."""
+    calls = 0
+    started = asyncio.Event()
+    release = asyncio.Event()
+
+    async def fake_recompute() -> None:
+        nonlocal calls
+        calls += 1
+        if calls == 1:
+            started.set()
+            await release.wait()
+
+    session._recompute_and_publish_mesh = fake_recompute  # type: ignore[assignment]
+    session._request_mesh_refresh()  # starts the drain; build #1 parks
+    await started.wait()
+    session._request_mesh_refresh()  # dirties mid-flight
+    release.set()
+    await session._mesh_task
+    assert calls == 2
+
+
+async def test_public_request_mesh_refresh_schedules(session: Session) -> None:
+    """The public wrapper (used by the SSE handler on subscribe) routes
+    through the same coalescing drain as the internal path."""
+    called = 0
+
+    async def fake_recompute() -> None:
+        nonlocal called
+        called += 1
+
+    session._recompute_and_publish_mesh = fake_recompute  # type: ignore[assignment]
+    session.request_mesh_refresh()
+    assert session._mesh_task is not None
+    await session._mesh_task
+    assert called == 1
+
+
+async def test_drain_survives_recompute_error(session: Session) -> None:
+    """A refresh that raises is logged, not propagated — the drain task
+    must finish cleanly so a transient failure doesn't wedge the loop."""
+    calls = 0
+
+    async def boom() -> None:
+        nonlocal calls
+        calls += 1
+        raise RuntimeError("nope")
+
+    session._recompute_and_publish_mesh = boom  # type: ignore[assignment]
+    session._request_mesh_refresh()
+    await session._mesh_task  # must not raise
+    assert calls == 1
+
+
+async def test_mesh_refresh_loop_ticks(session: Session, monkeypatch) -> None:
+    """The periodic refresher fires a refresh when someone is watching,
+    we're connected, and there are channels — and stays idle otherwise."""
+    monkeypatch.setattr("irc_lens.session.MESH_REFRESH_INTERVAL", 0.01)
+    session._transport.connected = True
+    session.joined_channels.add("#ops")
+    sub = session.event_bus.subscribe()  # subscriber_count > 0
+    ticks = 0
+
+    def fake_request() -> None:
+        nonlocal ticks
+        ticks += 1
+
+    session._request_mesh_refresh = fake_request  # type: ignore[assignment]
+    task = asyncio.create_task(session._mesh_refresh_loop())
+    try:
+        async with asyncio.timeout(1.0):
+            while ticks < 1:
+                await asyncio.sleep(0.01)
+    finally:
+        task.cancel()
+        try:
+            await task
+        except asyncio.CancelledError:
+            pass
+        sub.close()
+    assert ticks >= 1
+
+
+def test_join_dispatch_triggers_mesh_refresh(session: Session) -> None:
+    """Inbound JOIN/PART must request a mesh refresh (topology changed)."""
+    refreshed = 0
+
+    def fake_request() -> None:
+        nonlocal refreshed
+        refreshed += 1
+
+    session._request_mesh_refresh = fake_request  # type: ignore[assignment]
+    asyncio.run(
+        session.dispatch(Message(prefix="a!a@h", command="JOIN", params=["#ops"]))
+    )
+    asyncio.run(
+        session.dispatch(Message(prefix="a!a@h", command="PART", params=["#ops"]))
+    )
+    assert refreshed == 2
+
+
+# ---------------------------------------------------------------------------
+# Lifecycle: the periodic refresher starts on connect, stops on disconnect
+# ---------------------------------------------------------------------------
+
+
+async def test_refresher_task_lifecycle(lens_session: Session) -> None:
+    """connect() (run by the fixture) starts the per-session refresher;
+    the cancel path (invoked by disconnect) tears it down cleanly. We
+    call ``_cancel_mesh_tasks`` directly rather than ``disconnect`` so the
+    fixture's own teardown disconnect doesn't double-close the transport.
+    """
+    assert lens_session._mesh_refresher is not None
+    assert not lens_session._mesh_refresher.done()
+    await lens_session._cancel_mesh_tasks()
+    assert lens_session._mesh_refresher is None
+    assert lens_session._mesh_task is None

--- a/tests/test_mesh.py
+++ b/tests/test_mesh.py
@@ -267,13 +267,28 @@ async def test_drain_survives_recompute_error(session: Session) -> None:
     assert calls == 1
 
 
-async def test_mesh_refresh_loop_ticks(session: Session, monkeypatch) -> None:
-    """The periodic refresher fires a refresh when someone is watching,
-    we're connected, and there are channels — and stays idle otherwise."""
+def test_mesh_active_predicate(session: Session) -> None:
+    """`_mesh_active` requires BOTH the mesh view and a live subscriber —
+    the browser opens SSE in every view, so a subscriber alone isn't enough."""
+    assert session._mesh_active() is False  # chat view, no subscriber
+    sub = session.event_bus.subscribe()
+    assert session._mesh_active() is False  # subscriber but still chat view
+    session.set_view("mesh")
+    assert session._mesh_active() is True  # mesh view + subscriber
+    sub.close()
+    assert session._mesh_active() is False  # mesh view but subscriber gone
+
+
+async def test_mesh_refresh_loop_ticks_only_in_mesh_view(
+    session: Session, monkeypatch
+) -> None:
+    """The periodic refresher fires only when the mesh is actually being
+    viewed (connected + joined + mesh view + subscriber). With the SSE
+    stream open in chat view it must stay idle — no background WHO sweeps."""
     monkeypatch.setattr("irc_lens.session.MESH_REFRESH_INTERVAL", 0.01)
     session._transport.connected = True
     session.joined_channels.add("#ops")
-    sub = session.event_bus.subscribe()  # subscriber_count > 0
+    sub = session.event_bus.subscribe()  # subscriber_count > 0, but view=chat
     ticks = 0
 
     def fake_request() -> None:
@@ -283,6 +298,12 @@ async def test_mesh_refresh_loop_ticks(session: Session, monkeypatch) -> None:
     session._request_mesh_refresh = fake_request  # type: ignore[assignment]
     task = asyncio.create_task(session._mesh_refresh_loop())
     try:
+        # In chat view (the default) the loop must NOT tick even though an
+        # SSE subscriber is attached — this is the qodo PR #46 bug fix.
+        await asyncio.sleep(0.05)
+        assert ticks == 0, "loop ticked while not in mesh view"
+        # Switch to mesh view → the loop starts firing.
+        session.set_view("mesh")
         async with asyncio.timeout(1.0):
             while ticks < 1:
                 await asyncio.sleep(0.01)
@@ -296,8 +317,9 @@ async def test_mesh_refresh_loop_ticks(session: Session, monkeypatch) -> None:
     assert ticks >= 1
 
 
-def test_join_dispatch_triggers_mesh_refresh(session: Session) -> None:
-    """Inbound JOIN/PART must request a mesh refresh (topology changed)."""
+def test_join_dispatch_triggers_mesh_refresh_only_in_mesh_view(session: Session) -> None:
+    """Inbound JOIN/PART refreshes the mesh only when it's being viewed.
+    In chat view (SSE still open) JOIN/PART must NOT trigger WHO sweeps."""
     refreshed = 0
 
     def fake_request() -> None:
@@ -305,12 +327,18 @@ def test_join_dispatch_triggers_mesh_refresh(session: Session) -> None:
         refreshed += 1
 
     session._request_mesh_refresh = fake_request  # type: ignore[assignment]
-    asyncio.run(
-        session.dispatch(Message(prefix="a!a@h", command="JOIN", params=["#ops"]))
-    )
-    asyncio.run(
-        session.dispatch(Message(prefix="a!a@h", command="PART", params=["#ops"]))
-    )
+    sub = session.event_bus.subscribe()
+
+    # Chat view (default): JOIN/PART must not refresh the mesh.
+    asyncio.run(session.dispatch(Message(prefix="a!a@h", command="JOIN", params=["#ops"])))
+    asyncio.run(session.dispatch(Message(prefix="a!a@h", command="PART", params=["#ops"])))
+    assert refreshed == 0
+
+    # Mesh view: JOIN/PART each request a refresh.
+    session.set_view("mesh")
+    asyncio.run(session.dispatch(Message(prefix="a!a@h", command="JOIN", params=["#ops"])))
+    asyncio.run(session.dispatch(Message(prefix="a!a@h", command="PART", params=["#ops"])))
+    sub.close()
     assert refreshed == 2
 
 

--- a/tests/test_render.py
+++ b/tests/test_render.py
@@ -141,6 +141,18 @@ def test_info_status_view_shows_session_metadata(session: Session) -> None:
     assert "6667" in out  # port
 
 
+def test_info_mesh_view_shows_legend(session: Session) -> None:
+    session.set_view("mesh")
+    out = render_fragment("_info.html.j2", session=session)
+    assert 'data-view="mesh"' in out
+    assert "Mesh graph" in out
+    assert 'data-testid="mesh-legend"' in out
+    # The legend names all three node kinds katvan's renderer draws.
+    assert "room" in out
+    assert "agent" in out
+    assert "human" in out
+
+
 def test_info_extras_only_render_under_chat_view(session: Session) -> None:
     """Template contract for issue #20: the channels/who/agents blocks
     are intentionally nested inside the chat-view branch of


### PR DESCRIPTION
## What

Brings katvan's "living mesh" visualization into the irc-lens web console as a
live, in-console view. Typing `/mesh` switches the center pane to a Canvas graph
of the operator's joined channels (rooms) and their members (agents / humans),
with membership edges and travelling message particles — updating live as agents
join and leave.

## Why

katvan (`culture.dev`) has a signature `MeshIsland` Canvas renderer, but it ships
a static build-time `mesh.json` and was explicitly designed for "a future real
mesh export." irc-lens is the natural host for that live feed: it already holds
an AgentIRC connection and can assemble exactly the graph data (channels via the
joined set, members + their `server` via WHO), and it already has a wired SSE bus
and a view-switching system.

## How

- **`static/mesh.js`** — a vanilla-JS port of `MeshIsland.svelte` (irc-lens has
  no JS build step, so the Svelte component is reimplemented, not bundled).
  Faithful to the source (force-settle-once layout, breathing nodes, pulsing
  edges, particles, reduced-motion, offscreen-pause). Deliberate differences: it
  takes data at runtime via `LensMesh.update(...)`; `update()` is a **warm
  rebuild** so a live topology change never re-randomizes the graph; the canvas
  fills its console pane; colours come from the `--lens-*` theme tokens.
- **`Session.build_mesh_snapshot()`** emits katvan's contract verbatim:
  `{nodes:[{id,label,kind,server}], edges:[{source,target}]}`. Published over a
  new `mesh` SSE event. Refreshed on JOIN/PART (coalesced into a single-flight
  rebuild — the sync read-loop handler can't await WHO) and on a per-session
  timer; the per-nick WHO `server` maps onto MeshIsland's federated bands.
- **In-console view** — a new `mesh` `data-view`; the canvas shares the chat
  column's content row with the log (the input form stays usable). Selecting a
  channel (`/switch` or sidebar click) returns to chat.

## Decisions worth flagging

- **agent-vs-human classification** is a documented **v1 heuristic** (operator
  nick → human; everyone else → agent). irc-lens has no authoritative signal for
  this today. The canonical rule — and whether `MeshIsland` should become a
  citeable shared component — is being settled with katvan in a cross-repo
  coordination issue (filed alongside this PR).
- **Scope** is joined channels + their members (mirrors `/agents`), not a
  full-server LIST sweep.

## Tests

- Unit (`tests/test_mesh.py`): snapshot shape + katvan key-set, classification,
  empty-graph guards, `/mesh` verb, coalescing single-flight, dirtied-mid-flight
  rerun, JOIN/PART trigger, refresher-task lifecycle.
- E2E HTTP: a `mesh` SSE event with a parseable snapshot after `/join` + `/mesh`.
- Render: the info-pane mesh legend.
- Playwright: `/mesh` shows the canvas, hides the log, keeps the input usable.

Full suite: 342 passing + 5 Playwright. Version bumped 0.5.3 → 0.6.0.

— irc-lens (Claude)
